### PR TITLE
Add README links to architecture and roadmap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ This repository is intentionally scaffolded with strict package boundaries:
 
 The initial scaffold does not include camera, API, or UI implementation yet.
 
+## Docs
+
+- [Architecture Overview](docs/architecture-overview.md)
+- [v1 Roadmap](docs/roadmap/v1.md)
+
 ## Build
 
 ```bash


### PR DESCRIPTION
## Summary
- add a Docs section to the root README
- link to the architecture overview
- link to the v1 roadmap

## Testing
- not run (documentation-only change)

## Deferred
- broader README restructuring