### PR TITLE
Add app URL scheme support to v1 roadmap

### DIFF
--- a/docs/roadmap/v1.md
+++ b/docs/roadmap/v1.md
@@ -93,6 +93,9 @@ If this flow works reliably, v1 is successful.
 - first-run onboarding
 - permission status visibility
 - basic service status (running / stopped)
+- custom URL scheme for app activation and onboarding only:
+  - `camerabridge://open` launches or focuses the CameraBridge app
+  - `camerabridge://request-permissions` opens the app and surfaces the permission flow
 
 ---
 


### PR DESCRIPTION
## Summary
- add a narrow app-shell URL scheme capability to the v1 roadmap
- document camerabridge://open for launching or focusing the app
- document camerabridge://request-permissions for onboarding and permission flow

## Testing
- not run (documentation-only change)

## Deferred
- any URL scheme actions that control camera behavior or expand the core API contract