### PR TITLE
Draft v1 API contract skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The initial scaffold does not include camera, API, or UI implementation yet.
 
 - [Architecture Overview](docs/architecture-overview.md)
 - [v1 Roadmap](docs/roadmap/v1.md)
+- [API v1 Contract](docs/api/v1.md)
 
 ## Build
 

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -1,0 +1,80 @@
+# CameraBridge API v1
+
+This document defines the early CameraBridge API contract for the v1 service slice.
+
+## Status Labels
+
+- `current`: implemented in the repository at the time of this document revision
+- `planned`: intended contract for the next implementation slices, not yet implemented
+
+## Versioning
+
+- `GET /health` is the only public endpoint outside `/v1/...`
+- all other public endpoints live under `/v1/...`
+
+## Response Conventions
+
+- successful responses are JSON
+- error responses are JSON and use this shape:
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Route not found"
+  }
+}
+```
+
+## Endpoint Inventory
+
+| Endpoint | Status | Notes |
+| --- | --- | --- |
+| `GET /health` | planned | first end-to-end service behavior |
+| `GET /v1/permissions` | planned | read-only permission status |
+| `POST /v1/permissions/request` | planned | deferred until after permission status |
+| `GET /v1/devices` | planned | deferred |
+| `GET /v1/session` | planned | deferred |
+| `POST /v1/session/start` | planned | deferred |
+| `POST /v1/session/stop` | planned | deferred |
+| `POST /v1/session/select-device` | planned | deferred |
+| `POST /v1/capture/photo` | planned | deferred |
+
+## Fully Specified Early Endpoints
+
+### `GET /health`
+
+Status: `planned`
+
+- auth: none
+- response: `200 OK`
+
+```json
+{
+  "status": "ok"
+}
+```
+
+### `GET /v1/permissions`
+
+Status: `planned`
+
+- auth: none for the early read-only slice
+- response: `200 OK`
+
+```json
+{
+  "status": "not_determined"
+}
+```
+
+Allowed `status` values:
+
+- `not_determined`
+- `restricted`
+- `denied`
+- `authorized`
+
+## Planned Only
+
+The remaining v1 endpoints are listed here for scope clarity only. Their request and response bodies are intentionally deferred until their implementation slices begin.


### PR DESCRIPTION
## Summary
- add `docs/api/v1.md` as the early v1 API contract source of truth
- document `/health` and `/v1/permissions` for the first service slice
- link the API contract from `README.md`

## Files Changed
- `README.md`
- `docs/api/v1.md`

## Testing
- docs review
- `git diff --check`

## Intentionally Deferred
- handler or server implementation
- auth enforcement
- device, session, preview, and capture behavior