### PR TITLE
Define minimal core state and domain scaffolding

### DIFF
--- a/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
+++ b/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
@@ -1,3 +1,50 @@
 public enum CameraBridgeCoreModule {
     public static let name = "CameraBridgeCore"
 }
+
+public enum PermissionState: String, Sendable, CaseIterable, Equatable {
+    case notDetermined = "not_determined"
+    case restricted
+    case denied
+    case authorized
+}
+
+public enum SessionState: Sendable, Equatable {
+    case stopped
+    case running
+}
+
+public enum PreviewState: Sendable, Equatable {
+    case stopped
+    case running
+}
+
+public struct CameraStateError: Error, Sendable, Equatable {
+    public let message: String
+
+    public init(message: String) {
+        self.message = message
+    }
+}
+
+public struct CameraState: Sendable, Equatable {
+    public var permissionState: PermissionState
+    public var sessionState: SessionState
+    public var previewState: PreviewState
+    public var activeDeviceID: String?
+    public var lastError: CameraStateError?
+
+    public init(
+        permissionState: PermissionState = .notDetermined,
+        sessionState: SessionState = .stopped,
+        previewState: PreviewState = .stopped,
+        activeDeviceID: String? = nil,
+        lastError: CameraStateError? = nil
+    ) {
+        self.permissionState = permissionState
+        self.sessionState = sessionState
+        self.previewState = previewState
+        self.activeDeviceID = activeDeviceID
+        self.lastError = lastError
+    }
+}

--- a/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
+++ b/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
@@ -5,3 +5,40 @@ import Testing
 func coreModuleNameMatchesTarget() {
     #expect(CameraBridgeCoreModule.name == "CameraBridgeCore")
 }
+
+@Test
+func cameraStateDefaultsMatchEarlySlice() {
+    let state = CameraState()
+
+    #expect(state.permissionState == .notDetermined)
+    #expect(state.sessionState == .stopped)
+    #expect(state.previewState == .stopped)
+    #expect(state.activeDeviceID == nil)
+    #expect(state.lastError == nil)
+}
+
+@Test
+func permissionStateRawValuesMatchAPIVocabulary() {
+    #expect(PermissionState.notDetermined.rawValue == "not_determined")
+    #expect(PermissionState.restricted.rawValue == "restricted")
+    #expect(PermissionState.denied.rawValue == "denied")
+    #expect(PermissionState.authorized.rawValue == "authorized")
+}
+
+@Test
+func cameraStateRetainsExplicitValues() {
+    let error = CameraStateError(message: "permission unavailable")
+    let state = CameraState(
+        permissionState: .authorized,
+        sessionState: .running,
+        previewState: .running,
+        activeDeviceID: "camera-1",
+        lastError: error
+    )
+
+    #expect(state.permissionState == .authorized)
+    #expect(state.sessionState == .running)
+    #expect(state.previewState == .running)
+    #expect(state.activeDeviceID == "camera-1")
+    #expect(state.lastError == error)
+}


### PR DESCRIPTION
## Summary
- replace the Core placeholder surface with minimal early-slice camera state models
- align permission vocabulary with the API contract
- add unit coverage for default and explicit state values

## Files Changed
- `packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift`
- `tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift`

## Testing
- `swift test`
- `git diff --check`

## Intentionally Deferred
- AVFoundation integration
- device models beyond `activeDeviceID`
- ownership, artifact, and recording models