### PR TITLE
Add daemon bootstrap and API wiring scaffolding

### DIFF
--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -1,0 +1,47 @@
+import CameraBridgeAPI
+import Foundation
+
+struct ServerConfiguration: Sendable, Equatable {
+    static let defaultHost = "127.0.0.1"
+    static let defaultPort: UInt16 = 8731
+
+    var host: String
+    var port: UInt16
+
+    init(host: String = ServerConfiguration.defaultHost, port: UInt16 = ServerConfiguration.defaultPort) {
+        self.host = host
+        self.port = port
+    }
+}
+
+struct CameraBridgeDaemon {
+    typealias Logger = @Sendable (String) -> Void
+
+    var configuration: ServerConfiguration
+    var logger: Logger
+
+    init(
+        configuration: ServerConfiguration = ServerConfiguration(),
+        logger: @escaping Logger = { print($0) }
+    ) {
+        self.configuration = configuration
+        self.logger = logger
+    }
+
+    func makeServer(router: CameraBridgeRouter = CameraBridgeRouter()) -> LocalHTTPServer {
+        LocalHTTPServer(
+            configuration: .init(host: configuration.host, port: configuration.port),
+            router: router,
+            logger: logger
+        )
+    }
+
+    @discardableResult
+    func start(router: CameraBridgeRouter = CameraBridgeRouter()) throws -> LocalHTTPServer {
+        logger("starting camd on \(configuration.host):\(configuration.port)")
+        let server = makeServer(router: router)
+        let port = try server.start()
+        logger("camd ready on \(configuration.host):\(port)")
+        return server
+    }
+}

--- a/apps/camd/Sources/camd/main.swift
+++ b/apps/camd/Sources/camd/main.swift
@@ -1,9 +1,17 @@
 import CameraBridgeAPI
 import CameraBridgeCore
+import Dispatch
 
-@main
-struct CameraBridgeDaemonMain {
-    static func main() {
-        print("camd scaffold: \(CameraBridgeAPIModule.name) -> \(CameraBridgeCoreModule.name)")
+_ = CameraBridgeAPIModule.name
+_ = CameraBridgeCoreModule.name
+
+let daemon = CameraBridgeDaemon()
+
+do {
+    let server = try daemon.start()
+    withExtendedLifetime(server) {
+        dispatchMain()
     }
+} catch {
+    fputs("camd failed to start: \(error)\n", stderr)
 }

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -1,6 +1,337 @@
 import CameraBridgeCore
+import Dispatch
+import Foundation
+import Network
 
 public enum CameraBridgeAPIModule {
     public static let name = "CameraBridgeAPI"
     public static let coreModuleName = CameraBridgeCoreModule.name
+}
+
+public enum HTTPMethod: String, Sendable, Equatable {
+    case get = "GET"
+    case post = "POST"
+}
+
+public struct HTTPRequest: Sendable, Equatable {
+    public var method: HTTPMethod
+    public var path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: HTTPMethod, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public struct HTTPResponse: Sendable, Equatable {
+    public var statusCode: Int
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(statusCode: Int, headers: [String: String] = [:], body: Data = Data()) {
+        self.statusCode = statusCode
+        self.headers = headers
+        self.body = body
+    }
+
+    public static func json(statusCode: Int, body: String) -> HTTPResponse {
+        HTTPResponse(
+            statusCode: statusCode,
+            headers: ["Content-Type": "application/json"],
+            body: Data(body.utf8)
+        )
+    }
+
+    public static func notFound() -> HTTPResponse {
+        .json(
+            statusCode: 404,
+            body: #"{ "error": { "code": "not_found", "message": "Route not found" } }"#
+        )
+    }
+}
+
+public struct HTTPRoute: Sendable {
+    public typealias Handler = @Sendable (HTTPRequest) -> HTTPResponse
+
+    public var method: HTTPMethod
+    public var path: String
+    private let handler: Handler
+
+    public init(method: HTTPMethod, path: String, handler: @escaping Handler) {
+        self.method = method
+        self.path = path
+        self.handler = handler
+    }
+
+    fileprivate func respond(to request: HTTPRequest) -> HTTPResponse {
+        handler(request)
+    }
+}
+
+public struct CameraBridgeRouter: Sendable {
+    private var routes: [RouteKey: HTTPRoute]
+
+    public init(routes: [HTTPRoute] = []) {
+        self.routes = Dictionary(
+            uniqueKeysWithValues: routes.map { (RouteKey(method: $0.method, path: $0.path), $0) }
+        )
+    }
+
+    public func response(for request: HTTPRequest) -> HTTPResponse {
+        let key = RouteKey(method: request.method, path: request.path)
+        guard let route = routes[key] else {
+            return .notFound()
+        }
+
+        return route.respond(to: request)
+    }
+}
+
+public final class LocalHTTPServer: @unchecked Sendable {
+    public struct Configuration: Sendable, Equatable {
+        public var host: String
+        public var port: UInt16
+
+        public init(host: String, port: UInt16) {
+            self.host = host
+            self.port = port
+        }
+    }
+
+    public typealias Logger = @Sendable (String) -> Void
+
+    public let configuration: Configuration
+
+    private let router: CameraBridgeRouter
+    private let logger: Logger
+    private let queue: DispatchQueue
+    private let stateLock = NSLock()
+    private var listener: NWListener?
+    private var started = false
+    private(set) public var boundPort: UInt16?
+
+    public init(
+        configuration: Configuration,
+        router: CameraBridgeRouter,
+        logger: @escaping Logger = { _ in }
+    ) {
+        self.configuration = configuration
+        self.router = router
+        self.logger = logger
+        self.queue = DispatchQueue(label: "CameraBridgeAPI.LocalHTTPServer")
+    }
+
+    @discardableResult
+    public func start() throws -> UInt16 {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        guard !started else {
+            return boundPort ?? configuration.port
+        }
+
+        guard let port = NWEndpoint.Port(rawValue: configuration.port) else {
+            throw HTTPServerError.invalidPort(configuration.port)
+        }
+
+        let listener = try NWListener(using: .tcp, on: port)
+        let readySemaphore = DispatchSemaphore(value: 0)
+        var startError: Error?
+
+        listener.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .ready:
+                self?.boundPort = listener.port?.rawValue ?? self?.configuration.port
+                readySemaphore.signal()
+            case .failed(let error):
+                startError = error
+                readySemaphore.signal()
+            default:
+                break
+            }
+        }
+
+        listener.newConnectionHandler = { [weak self] connection in
+            self?.handle(connection: connection)
+        }
+
+        listener.start(queue: queue)
+        readySemaphore.wait()
+
+        if let startError {
+            listener.cancel()
+            throw startError
+        }
+
+        self.listener = listener
+        self.started = true
+        let activePort = boundPort ?? configuration.port
+        logger("listening on http://\(configuration.host):\(activePort)")
+        return activePort
+    }
+
+    public func stop() {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        listener?.cancel()
+        listener = nil
+        started = false
+    }
+
+    private func handle(connection: NWConnection) {
+        connection.stateUpdateHandler = { state in
+            if case .failed = state {
+                connection.cancel()
+            }
+        }
+
+        connection.start(queue: queue)
+        receive(on: connection, accumulated: Data())
+    }
+
+    private func receive(on connection: NWConnection, accumulated: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) { [weak self] data, _, isComplete, error in
+            guard let self else {
+                connection.cancel()
+                return
+            }
+
+            if error != nil {
+                connection.cancel()
+                return
+            }
+
+            var buffer = accumulated
+            if let data {
+                buffer.append(data)
+            }
+
+            switch HTTPRequestParser.parse(buffer) {
+            case .success(let request):
+                let response = router.response(for: request)
+                send(response: response, on: connection)
+            case .incomplete:
+                if isComplete {
+                    send(response: .notFound(), on: connection)
+                } else {
+                    receive(on: connection, accumulated: buffer)
+                }
+            case .failure:
+                send(response: .notFound(), on: connection)
+            }
+        }
+    }
+
+    private func send(response: HTTPResponse, on connection: NWConnection) {
+        connection.send(content: HTTPResponseSerializer.serialize(response), completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+}
+
+public enum HTTPServerError: Error, Sendable, Equatable {
+    case invalidPort(UInt16)
+}
+
+private struct RouteKey: Hashable, Sendable {
+    var method: HTTPMethod
+    var path: String
+}
+
+private enum HTTPRequestParseResult {
+    case success(HTTPRequest)
+    case incomplete
+    case failure
+}
+
+private enum HTTPRequestParser {
+    static func parse(_ data: Data) -> HTTPRequestParseResult {
+        guard let headersRange = data.range(of: Data("\r\n\r\n".utf8)) else {
+            return .incomplete
+        }
+
+        let headerData = data[..<headersRange.lowerBound]
+        guard let headerString = String(data: headerData, encoding: .utf8) else {
+            return .failure
+        }
+
+        let lines = headerString.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else {
+            return .failure
+        }
+
+        let requestParts = requestLine.split(separator: " ")
+        guard requestParts.count == 3,
+              let method = HTTPMethod(rawValue: String(requestParts[0])) else {
+            return .failure
+        }
+
+        let path = String(requestParts[1])
+        let headers = parseHeaders(lines.dropFirst())
+        let expectedBodyLength = Int(headers["content-length"] ?? "") ?? 0
+        let bodyStart = headersRange.upperBound
+        let availableBodyLength = data.count - bodyStart
+
+        guard availableBodyLength >= expectedBodyLength else {
+            return .incomplete
+        }
+
+        let body = Data(data[bodyStart..<(bodyStart + expectedBodyLength)])
+        return .success(
+            HTTPRequest(method: method, path: path, headers: headers, body: body)
+        )
+    }
+
+    private static func parseHeaders<S: Sequence>(_ lines: S) -> [String: String] where S.Element == String {
+        var headers: [String: String] = [:]
+
+        for line in lines where !line.isEmpty {
+            let parts = line.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else {
+                continue
+            }
+
+            headers[String(parts[0]).lowercased()] = String(parts[1]).trimmingCharacters(in: .whitespaces)
+        }
+
+        return headers
+    }
+}
+
+private enum HTTPResponseSerializer {
+    static func serialize(_ response: HTTPResponse) -> Data {
+        var headers = response.headers
+        headers["Connection"] = "close"
+        headers["Content-Length"] = String(response.body.count)
+
+        let statusText = reasonPhrase(for: response.statusCode)
+        let headerLines = headers
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key): \($0.value)" }
+            .joined(separator: "\r\n")
+
+        var message = "HTTP/1.1 \(response.statusCode) \(statusText)\r\n"
+        message += headerLines
+        message += "\r\n\r\n"
+
+        var data = Data(message.utf8)
+        data.append(response.body)
+        return data
+    }
+
+    private static func reasonPhrase(for statusCode: Int) -> String {
+        switch statusCode {
+        case 200:
+            return "OK"
+        case 404:
+            return "Not Found"
+        default:
+            return "Error"
+        }
+    }
 }

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -1,7 +1,76 @@
+import Foundation
 import Testing
 @testable import CameraBridgeAPI
 
 @Test
 func apiModuleNameMatchesTarget() {
     #expect(CameraBridgeAPIModule.name == "CameraBridgeAPI")
+}
+
+@Test
+func routerReturnsNotFoundForUnknownRoute() {
+    let router = CameraBridgeRouter()
+    let response = router.response(for: HTTPRequest(method: .get, path: "/missing"))
+
+    #expect(response.statusCode == 404)
+    #expect(String(decoding: response.body, as: UTF8.self) == #"{ "error": { "code": "not_found", "message": "Route not found" } }"#)
+}
+
+@Test
+func localHTTPServerReturnsNotFoundForUnknownRoute() async throws {
+    let port = try reserveEphemeralPort()
+    let server = LocalHTTPServer(
+        configuration: .init(host: "127.0.0.1", port: port),
+        router: CameraBridgeRouter()
+    )
+
+    defer { server.stop() }
+
+    let boundPort = try server.start()
+    let url = try #require(URL(string: "http://127.0.0.1:\(boundPort)/missing"))
+    let (data, response) = try await URLSession.shared.data(from: url)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+
+    #expect(httpResponse.statusCode == 404)
+    #expect(String(decoding: data, as: UTF8.self) == #"{ "error": { "code": "not_found", "message": "Route not found" } }"#)
+}
+
+private func reserveEphemeralPort() throws -> UInt16 {
+    let socketDescriptor = socket(AF_INET, SOCK_STREAM, 0)
+    guard socketDescriptor >= 0 else {
+        throw POSIXError(.EIO)
+    }
+
+    defer { close(socketDescriptor) }
+
+    var address = sockaddr_in()
+    address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+    address.sin_family = sa_family_t(AF_INET)
+    address.sin_port = in_port_t(0).bigEndian
+    address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+    let bindResult = withUnsafePointer(to: &address) {
+        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            bind(socketDescriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+        }
+    }
+
+    guard bindResult == 0 else {
+        throw POSIXError(.EADDRNOTAVAIL)
+    }
+
+    var assignedAddress = sockaddr_in()
+    var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+
+    let nameResult = withUnsafeMutablePointer(to: &assignedAddress) {
+        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            getsockname(socketDescriptor, $0, &length)
+        }
+    }
+
+    guard nameResult == 0 else {
+        throw POSIXError(.EIO)
+    }
+
+    return UInt16(bigEndian: assignedAddress.sin_port)
 }


### PR DESCRIPTION
## Summary
- add the minimal localhost HTTP server, request/response models, and route dispatch infrastructure
- add `camd` bootstrap, default loopback binding, and startup logging
- keep runtime behavior limited to infrastructure and exact JSON 404 handling

## Files Changed
- `apps/camd/Sources/camd/CameraBridgeDaemon.swift`
- `apps/camd/Sources/camd/main.swift`
- `packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift`
- `tests/CameraBridgeAPITests/CameraBridgeAPITests.swift`

## Testing
- `swift test`
- `git diff --check`

## Intentionally Deferred
- successful endpoint behavior beyond infrastructure
- auth enforcement
- camera and AVFoundation business logic