### PR TITLE
Implement read-only permission status

### DIFF
--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -1,4 +1,5 @@
 import CameraBridgeAPI
+import CameraBridgeCore
 import Foundation
 
 struct ServerConfiguration: Sendable, Equatable {
@@ -28,18 +29,32 @@ struct CameraBridgeDaemon {
         self.logger = logger
     }
 
-    func makeServer(router: CameraBridgeRouter = CameraBridgeRouter(routes: CameraBridgeRoutes.current())) -> LocalHTTPServer {
-        LocalHTTPServer(
+    func makeRouter(
+        permissionStatusProvider: any CameraPermissionStatusProviding = AVFoundationCameraPermissionStatusProvider()
+    ) -> CameraBridgeRouter {
+        CameraBridgeRouter(routes: CameraBridgeRoutes.current(permissionStatusProvider: permissionStatusProvider))
+    }
+
+    func makeServer(
+        router: CameraBridgeRouter? = nil,
+        permissionStatusProvider: any CameraPermissionStatusProviding = AVFoundationCameraPermissionStatusProvider()
+    ) -> LocalHTTPServer {
+        let resolvedRouter = router ?? makeRouter(permissionStatusProvider: permissionStatusProvider)
+
+        return LocalHTTPServer(
             configuration: .init(host: configuration.host, port: configuration.port),
-            router: router,
+            router: resolvedRouter,
             logger: logger
         )
     }
 
     @discardableResult
-    func start(router: CameraBridgeRouter = CameraBridgeRouter(routes: CameraBridgeRoutes.current())) throws -> LocalHTTPServer {
+    func start(
+        router: CameraBridgeRouter? = nil,
+        permissionStatusProvider: any CameraPermissionStatusProviding = AVFoundationCameraPermissionStatusProvider()
+    ) throws -> LocalHTTPServer {
         logger("starting camd on \(configuration.host):\(configuration.port)")
-        let server = makeServer(router: router)
+        let server = makeServer(router: router, permissionStatusProvider: permissionStatusProvider)
         let port = try server.start()
         logger("camd ready on \(configuration.host):\(port)")
         return server

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -31,7 +31,7 @@ This document defines the early CameraBridge API contract for the v1 service sli
 | Endpoint | Status | Notes |
 | --- | --- | --- |
 | `GET /health` | current | implemented and unauthenticated |
-| `GET /v1/permissions` | planned | read-only permission status |
+| `GET /v1/permissions` | current | implemented as public read-only status |
 | `POST /v1/permissions/request` | planned | deferred until after permission status |
 | `GET /v1/devices` | planned | deferred |
 | `GET /v1/session` | planned | deferred |
@@ -57,7 +57,7 @@ Status: `current`
 
 ### `GET /v1/permissions`
 
-Status: `planned`
+Status: `current`
 
 - auth: none for the early read-only slice
 - response: `200 OK`

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -92,13 +92,25 @@ public struct CameraBridgeRouter: Sendable {
 }
 
 public enum CameraBridgeRoutes {
-    public static func current() -> [HTTPRoute] {
-        [health()]
+    public static func current(permissionStatusProvider: any CameraPermissionStatusProviding) -> [HTTPRoute] {
+        [
+            health(),
+            permissionStatus(provider: permissionStatusProvider),
+        ]
     }
 
     public static func health() -> HTTPRoute {
         HTTPRoute(method: .get, path: "/health") { _ in
             .json(statusCode: 200, body: #"{ "status": "ok" }"#)
+        }
+    }
+
+    public static func permissionStatus(provider: any CameraPermissionStatusProviding) -> HTTPRoute {
+        HTTPRoute(method: .get, path: "/v1/permissions") { _ in
+            .json(
+                statusCode: 200,
+                body: #"{ "status": "\#(provider.currentPermissionState().rawValue)" }"#
+            )
         }
     }
 }

--- a/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
+++ b/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
@@ -1,3 +1,5 @@
+import AVFoundation
+
 public enum CameraBridgeCoreModule {
     public static let name = "CameraBridgeCore"
 }
@@ -46,5 +48,36 @@ public struct CameraState: Sendable, Equatable {
         self.previewState = previewState
         self.activeDeviceID = activeDeviceID
         self.lastError = lastError
+    }
+}
+
+public protocol CameraPermissionStatusProviding: Sendable {
+    func currentPermissionState() -> PermissionState
+}
+
+public struct AVFoundationCameraPermissionStatusProvider: CameraPermissionStatusProviding {
+    public init() {}
+
+    public func currentPermissionState() -> PermissionState {
+        PermissionState(
+            authorizationStatus: AVCaptureDevice.authorizationStatus(for: .video)
+        )
+    }
+}
+
+extension PermissionState {
+    init(authorizationStatus: AVAuthorizationStatus) {
+        switch authorizationStatus {
+        case .notDetermined:
+            self = .notDetermined
+        case .restricted:
+            self = .restricted
+        case .denied:
+            self = .denied
+        case .authorized:
+            self = .authorized
+        @unknown default:
+            self = .denied
+        }
     }
 }

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 @testable import CameraBridgeAPI
+import CameraBridgeCore
 
 @Test
 func apiModuleNameMatchesTarget() {
@@ -18,7 +19,9 @@ func routerReturnsNotFoundForUnknownRoute() {
 
 @Test
 func routerReturnsHealthResponseForHealthRoute() {
-    let router = CameraBridgeRouter(routes: CameraBridgeRoutes.current())
+    let router = CameraBridgeRouter(
+        routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized))
+    )
     let response = router.response(for: HTTPRequest(method: .get, path: "/health"))
 
     #expect(response.statusCode == 200)
@@ -30,7 +33,9 @@ func localHTTPServerReturnsHealthResponse() async throws {
     let port = try reserveEphemeralPort()
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: CameraBridgeRouter(routes: CameraBridgeRoutes.current())
+        router: CameraBridgeRouter(
+            routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized))
+        )
     )
 
     defer { server.stop() }
@@ -49,7 +54,9 @@ func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
     let port = try reserveEphemeralPort()
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: CameraBridgeRouter(routes: CameraBridgeRoutes.current())
+        router: CameraBridgeRouter(
+            routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized))
+        )
     )
 
     defer { server.stop() }
@@ -62,6 +69,46 @@ func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
 
     #expect(httpResponse.statusCode == 404)
     #expect(String(decoding: data, as: UTF8.self) == #"{ "error": { "code": "not_found", "message": "Route not found" } }"#)
+}
+
+@Test(arguments: PermissionState.allCases)
+func routerReturnsPermissionStatusForProviderState(_ state: PermissionState) {
+    let router = CameraBridgeRouter(
+        routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: state))
+    )
+    let response = router.response(for: HTTPRequest(method: .get, path: "/v1/permissions"))
+
+    #expect(response.statusCode == 200)
+    #expect(String(decoding: response.body, as: UTF8.self) == #"{ "status": "\#(state.rawValue)" }"#)
+}
+
+@Test
+func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
+    let port = try reserveEphemeralPort()
+    let server = LocalHTTPServer(
+        configuration: .init(host: "127.0.0.1", port: port),
+        router: CameraBridgeRouter(
+            routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted))
+        )
+    )
+
+    defer { server.stop() }
+
+    let boundPort = try server.start()
+    let url = try #require(URL(string: "http://127.0.0.1:\(boundPort)/v1/permissions"))
+    let (data, response) = try await URLSession.shared.data(from: url)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+
+    #expect(httpResponse.statusCode == 200)
+    #expect(String(decoding: data, as: UTF8.self) == #"{ "status": "restricted" }"#)
+}
+
+private struct FixedPermissionStatusProvider: CameraPermissionStatusProviding {
+    let state: PermissionState
+
+    func currentPermissionState() -> PermissionState {
+        state
+    }
 }
 
 private func reserveEphemeralPort() throws -> UInt16 {

--- a/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
+++ b/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
@@ -1,5 +1,6 @@
 import Testing
 @testable import CameraBridgeCore
+import AVFoundation
 
 @Test
 func coreModuleNameMatchesTarget() {
@@ -41,4 +42,12 @@ func cameraStateRetainsExplicitValues() {
     #expect(state.previewState == .running)
     #expect(state.activeDeviceID == "camera-1")
     #expect(state.lastError == error)
+}
+
+@Test
+func permissionStateMapsAVFoundationStatusValues() {
+    #expect(PermissionState(authorizationStatus: .notDetermined) == .notDetermined)
+    #expect(PermissionState(authorizationStatus: .restricted) == .restricted)
+    #expect(PermissionState(authorizationStatus: .denied) == .denied)
+    #expect(PermissionState(authorizationStatus: .authorized) == .authorized)
 }


### PR DESCRIPTION
## Summary
- add the Core permission-status protocol and AVFoundation-backed mapper
- expose `GET /v1/permissions` as a public read-only endpoint
- update docs and tests to cover the live status endpoint without hardware-dependent test setup

## Issue
Closes #5

## Files Changed
- `apps/camd/Sources/camd/CameraBridgeDaemon.swift`
- `docs/api/v1.md`
- `packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift`
- `packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift`
- `tests/CameraBridgeAPITests/CameraBridgeAPITests.swift`
- `tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift`

## Testing
- `swift test`
- `git diff --check`

## Intentionally Deferred
- permission request prompting
- auth enforcement
- remaining device, session, preview, and capture endpoints
