### PR TITLE
Add GitHub workflow docs and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,54 @@
+name: Bug Report
+description: Track a focused bug fix slice.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the observed behavior and why it is a bug.
+      placeholder: The daemon reports healthy even when...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: Describe the correct behavior.
+      placeholder: Health should return an error state when...
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Define the narrow slice to fix now.
+      placeholder: Fix the status mapping in CameraBridgeAPI only. Do not change capture behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: List concrete conditions that must be true when this issue is done.
+      placeholder: |
+        - Returns the correct HTTP status code
+        - Includes a handler test covering the failure case
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: Explain how the change should be tested.
+      placeholder: Add/update handler tests and include any manual verification notes.
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out Of Scope
+      description: Record adjacent work that should not be included in this issue.
+      placeholder: Do not refactor session ownership or change unrelated endpoints.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Engineering Workflow
+    url: https://github.com/rschroed/CameraBridge/blob/main/docs/workflow.md
+    about: Review the repository workflow before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,55 @@
+name: Feature Slice
+description: Define one focused implementation slice.
+title: "[Feature]: "
+labels:
+  - feature
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem To Solve
+      description: Explain the user or system need behind this slice.
+      placeholder: Local apps need a stable way to request permission status over the localhost API.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Describe the smallest complete slice that should land in one PR.
+      placeholder: Add a read-only permission status endpoint under /v1 and the supporting core abstraction.
+    validations:
+      required: true
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Capture architecture, product boundary, or v1 scope guardrails that matter here.
+      placeholder: Keep AVFoundation logic in CameraBridgeCore. Do not add microphone support or multi-session logic.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: List concrete conditions that define done.
+      placeholder: |
+        - New endpoint is documented
+        - Handler tests cover success and failure cases
+        - No unrelated API routes are added
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: Explain how this slice should be validated.
+      placeholder: Run swift build, swift test, and include any manual verification notes if UI changes are involved.
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out Of Scope
+      description: Record adjacent ideas that should be deferred.
+      placeholder: Do not add session claim/release or preview transport in this issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+Describe the problem and the change in 2-5 sentences.
+
+## Issue
+
+Closes #
+
+## Files Changed
+
+- `path/to/file`
+
+## Testing
+
+- [ ] `swift build`
+- [ ] `swift test`
+- [ ] Manual verification completed
+- [ ] Not run, explained below
+
+Testing notes:
+
+## Deferred
+
+- None
+
+## AGENTS.md Check
+
+- [ ] Scope stayed focused on one issue
+- [ ] Unrelated files were not changed without cause
+- [ ] Docs were updated if public behavior changed

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The initial scaffold does not include camera, API, or UI implementation yet.
 - [Architecture Overview](docs/architecture-overview.md)
 - [v1 Roadmap](docs/roadmap/v1.md)
 - [API v1 Contract](docs/api/v1.md)
+- [Engineering Workflow](docs/workflow.md)
 
 ## Build
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,149 @@
+# Engineering Workflow
+
+This repository uses GitHub as the system of record for planning, review, and merge decisions.
+
+The default workflow is:
+
+1. Create or refine a GitHub issue for the slice of work.
+2. Create one focused branch from `main`.
+3. Implement the smallest complete slice that closes the issue.
+4. Open a draft pull request early.
+5. Run local verification and let CI validate the branch.
+6. Merge on GitHub after the PR is ready.
+
+This keeps `main` releasable and matches the repository rules in `AGENTS.md`.
+
+## Default Policy
+
+- `main` is protected and stays releasable.
+- Use one GitHub issue per branch.
+- Use one pull request per focused slice.
+- Prefer draft PRs while a slice is still moving.
+- Merge through GitHub, not with a local merge to `main`.
+- Keep each PR small enough to review quickly.
+
+Recommended branch naming:
+
+- `codex/health-endpoint`
+- `codex/permissions-status`
+- `codex/device-enumeration`
+
+## What Lives Where
+
+GitHub issue:
+- problem statement
+- acceptance criteria
+- constraints
+- out-of-scope items
+
+Branch:
+- implementation for exactly one issue-sized slice
+
+Pull request:
+- summary of the change
+- files or areas changed
+- test or manual verification notes
+- explicitly deferred follow-up work
+
+Chat with an agent:
+- implementation assistance
+- investigation
+- local iteration
+
+Do not leave final scope or testing decisions only in chat. Capture them in the issue or PR.
+
+## Pull Request Flow
+
+1. Start from up-to-date `main`.
+2. Create a focused branch for a single issue.
+3. Push early and open a draft PR.
+4. Keep the PR scoped to the issue. If scope changes materially, update the issue and PR description.
+5. Resolve CI failures before merge.
+6. Merge on GitHub once the PR summary, testing notes, and deferred work are clear.
+
+Preferred merge style:
+
+- squash merge by default for small focused slices
+
+Alternative merge styles are acceptable when preserving commit history adds value, but avoid merge noise.
+
+## Local Merge Guidance
+
+Do not treat local merges to `main` as the standard workflow.
+
+Local merge to `main` is acceptable only as a narrow exception, such as:
+
+- a trivial docs or typo fix
+- a repository admin change that does not justify review overhead
+- an urgent repair when GitHub is temporarily unavailable
+
+If a local merge exception is used:
+
+1. Push immediately afterward.
+2. Document the reason in the commit message or follow-up issue.
+3. Keep the change as small as possible.
+
+Behavior changes, API changes, architecture changes, and anything that carries regression risk should go through a GitHub PR.
+
+## Agent Workflow
+
+Agents should work inside the same branch and issue boundary as a human contributor.
+
+When using an agent:
+
+1. Start from a GitHub issue with acceptance criteria.
+2. Create the issue branch before implementation begins.
+3. Ask the agent to keep scope narrow and avoid unrelated files.
+4. Require the agent to include tests or manual verification notes.
+5. Open or update the draft PR as the work evolves.
+6. Merge only after the PR describes what changed, how it was tested, and what was deferred.
+
+Useful defaults for agentic work:
+
+- no direct pushes to `main`
+- no silent scope expansion
+- no mixing unrelated fixes into the same PR
+- no architecture changes without updating docs or the relevant issue
+
+## GitHub Repository Settings
+
+Recommended branch protection for `main`:
+
+- require pull requests before merging
+- require status checks to pass before merging
+- require branches to be up to date before merging, if CI cost stays reasonable
+- restrict direct pushes
+- enable squash merge
+- optionally disable merge commits if you want a stricter linear history
+
+Recommended labels:
+
+- `bug`
+- `feature`
+- `docs`
+- `chore`
+- `api`
+- `core`
+- `app`
+- `hardware-needed`
+- `agent-safe`
+
+## Definition Of Ready
+
+Before starting implementation, the issue should answer:
+
+- what problem is being solved
+- what is explicitly in scope
+- what is explicitly out of scope
+- how the change will be verified
+
+## Definition Of Done
+
+A slice is done when:
+
+- the issue acceptance criteria are met
+- the PR explains the change clearly
+- tests pass or manual verification is documented
+- docs are updated if public behavior changed
+- deferred work is called out explicitly
+- the change merges safely into `main`


### PR DESCRIPTION
## Summary\nAdd a repository workflow document plus GitHub issue and PR templates so planning, review, and merge decisions live in GitHub by default.\n\n## Issue\nCloses #16\n\n## Files Changed\n- README docs list\n- docs/workflow.md\n- .github issue templates\n- .github pull request template\n\n## Testing\n- [ ] swift build\n- [ ] swift test\n- [x] Manual verification completed\n- [x] Not run, explained below\n\nTesting notes:\nThis change only adds documentation and GitHub metadata. Verified the staged content and ran .\n\n## Deferred\n- Branch protection settings on GitHub\n- Label creation on GitHub\n- CI workflow setup\n\n## AGENTS.md Check\n- [x] Scope stayed focused on one issue\n- [x] Unrelated files were not changed without cause\n- [x] Docs were updated if public behavior changed