### PR TITLE
Add static GitHub Pages marketing site

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ The initial scaffold does not include camera, API, or UI implementation yet.
 - [API v1 Contract](docs/api/v1.md)
 - [Engineering Workflow](docs/workflow.md)
 
+## Marketing Site
+
+- Source lives in `site/`
+- GitHub Pages deploys the static files from `site/` via `.github/workflows/github-pages.yml`
+- Update page copy in `site/index.html` and styling in `site/styles.css`
+- Default Pages URL: `https://rschroed.github.io/CameraBridge/`
+
 ## Build
 
 ```bash

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CameraBridge | Native macOS camera access over localhost</title>
+    <meta
+      name="description"
+      content="CameraBridge is a local macOS camera service that exposes AVFoundation over a stable localhost API for apps, scripts, and local web tools."
+    />
+    <meta
+      property="og:title"
+      content="CameraBridge | Native macOS camera access over localhost"
+    />
+    <meta
+      property="og:description"
+      content="A narrow local macOS camera service with explicit permissions, device discovery, session control, and still capture."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://rschroed.github.io/CameraBridge/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="CameraBridge | Native macOS camera access over localhost"
+    />
+    <meta
+      name="twitter:description"
+      content="Local macOS camera access for apps and scripts without embedding AVFoundation."
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="hero">
+        <nav class="topbar" aria-label="Primary">
+          <a class="brand" href="#top">CameraBridge</a>
+          <div class="nav-links">
+            <a href="#how-it-works">How it works</a>
+            <a href="#v1">v1</a>
+            <a href="#example">Example</a>
+          </div>
+        </nav>
+
+        <section class="hero-content" id="top">
+          <p class="eyebrow">Local-only macOS camera service</p>
+          <h1>Native macOS camera access over localhost.</h1>
+          <p class="hero-copy">
+            CameraBridge exposes AVFoundation through a small, versioned local
+            API so desktop apps, local web tools, and scripts can use the camera
+            without embedding native macOS code.
+          </p>
+          <div class="hero-actions">
+            <a class="button button-primary" href="https://github.com/rschroed/CameraBridge"
+              >View on GitHub</a
+            >
+            <a class="button button-secondary" href="https://github.com/rschroed/CameraBridge/blob/main/README.md"
+              >Read the README</a
+            >
+          </div>
+          <ul class="hero-points" aria-label="Highlights">
+            <li>Explicit camera permission state</li>
+            <li>Localhost API for device and session control</li>
+            <li>Still photo capture with local artifact metadata</li>
+          </ul>
+        </section>
+      </header>
+
+      <main>
+        <section class="section problem">
+          <div class="section-heading">
+            <p class="section-label">Why this exists</p>
+            <h2>Keep AVFoundation out of every host app.</h2>
+          </div>
+          <div class="grid grid-three">
+            <article class="card">
+              <h3>Native glue is expensive</h3>
+              <p>
+                Local apps and tools should not each reinvent camera discovery,
+                permission handling, and session lifecycle in native macOS code.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Permission state should be explicit</h3>
+              <p>
+                CameraBridge centralizes camera permission visibility and request
+                flow in a trusted local process instead of scattering it across
+                clients.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Local workflows need a stable boundary</h3>
+              <p>
+                Scripts, local web apps, and desktop apps can talk to one narrow
+                localhost API instead of embedding AVFoundation directly.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section architecture" id="how-it-works">
+          <div class="section-heading">
+            <p class="section-label">How it works</p>
+            <h2>A narrow service between your app and macOS.</h2>
+          </div>
+          <div class="flow" aria-label="CameraBridge architecture">
+            <div class="flow-step">Your app</div>
+            <div class="flow-arrow" aria-hidden="true">→</div>
+            <div class="flow-step">CameraBridge</div>
+            <div class="flow-arrow" aria-hidden="true">→</div>
+            <div class="flow-step">AVFoundation</div>
+            <div class="flow-arrow" aria-hidden="true">→</div>
+            <div class="flow-step">macOS camera</div>
+          </div>
+          <p class="section-copy">
+            Clients talk HTTP. CameraBridge owns native camera interaction. macOS
+            still owns permissions. The result is a predictable local boundary
+            instead of app-specific native camera code.
+          </p>
+        </section>
+
+        <section class="section features" id="v1">
+          <div class="section-heading">
+            <p class="section-label">What is in v1</p>
+            <h2>Small, explicit capabilities.</h2>
+          </div>
+          <div class="grid grid-two">
+            <article class="card feature-list">
+              <h3>Runtime surface</h3>
+              <ul>
+                <li><code>GET /health</code></li>
+                <li><code>GET /v1/permissions</code></li>
+                <li>Device discovery</li>
+                <li>Session claim, start, stop, and device selection</li>
+                <li>Still photo capture</li>
+              </ul>
+            </article>
+            <article class="card feature-list">
+              <h3>Local product shape</h3>
+              <ul>
+                <li><code>camd</code> daemon and CLI entrypoint</li>
+                <li>Menu bar app for onboarding and status</li>
+                <li>Single active camera session model</li>
+                <li>Structured logs and local artifact metadata</li>
+                <li>Versioned localhost API under <code>/v1</code></li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="section trust">
+          <div class="section-heading">
+            <p class="section-label">Trust model</p>
+            <h2>Local-first constraints, stated clearly.</h2>
+          </div>
+          <div class="grid grid-two">
+            <article class="card">
+              <h3>What CameraBridge is</h3>
+              <ul>
+                <li>macOS only</li>
+                <li>localhost only</li>
+                <li>Bearer-token protected for mutating endpoints</li>
+                <li>Single-user machine assumption</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>What CameraBridge is not</h3>
+              <ul>
+                <li>Not remote access</li>
+                <li>Not cloud sync</li>
+                <li>Not a browser permission bypass</li>
+                <li>Not a general media pipeline</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="section example" id="example">
+          <div class="section-heading">
+            <p class="section-label">Quick example</p>
+            <h2>Health and permissions over a local HTTP boundary.</h2>
+          </div>
+          <div class="example-card">
+            <pre><code>curl http://127.0.0.1:PORT/health
+
+{
+  "status": "ok"
+}
+
+curl http://127.0.0.1:PORT/v1/permissions
+
+{
+  "status": "not_determined"
+}</code></pre>
+          </div>
+          <p class="section-copy">
+            The early public surface is intentionally small. Start with health
+            and permission visibility, then grow into device, session, preview,
+            and capture flows as v1 is completed.
+          </p>
+        </section>
+
+        <section class="section cta">
+          <div class="cta-panel">
+            <div>
+              <p class="section-label">Get started</p>
+              <h2>Use the repo as the source of truth.</h2>
+              <p>
+                Read the docs, track the current implementation status, and
+                follow the API contract as CameraBridge v1 comes together.
+              </p>
+            </div>
+            <div class="cta-actions">
+              <a class="button button-primary" href="https://github.com/rschroed/CameraBridge"
+                >Open the GitHub repo</a
+              >
+              <a class="button button-secondary" href="https://github.com/rschroed/CameraBridge/blob/main/docs/api/v1.md"
+                >API contract</a
+              >
+              <a class="button button-secondary" href="https://github.com/rschroed/CameraBridge/blob/main/docs/roadmap/v1.md"
+                >v1 roadmap</a
+              >
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,408 @@
+:root {
+  --bg: #f5f1e8;
+  --bg-panel: rgba(255, 252, 246, 0.82);
+  --surface: #fffdfa;
+  --surface-strong: #fffefc;
+  --border: rgba(46, 60, 52, 0.14);
+  --border-strong: rgba(46, 60, 52, 0.24);
+  --text: #18211d;
+  --text-muted: #49564e;
+  --accent: #006b5a;
+  --accent-strong: #0d4f43;
+  --shadow: 0 24px 60px rgba(21, 34, 28, 0.12);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --page-width: 1120px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino,
+    Georgia, serif;
+  background:
+    radial-gradient(circle at top left, rgba(0, 107, 90, 0.12), transparent 32%),
+    linear-gradient(180deg, #f7f4ec 0%, #f2ede3 100%);
+  color: var(--text);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+code,
+pre {
+  font-family: "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono",
+    Menlo, monospace;
+}
+
+.page-shell {
+  width: min(calc(100% - 2rem), var(--page-width));
+  margin: 0 auto;
+  padding: 1rem 0 4rem;
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius-lg) + 8px);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.94), rgba(247, 243, 234, 0.8)),
+    radial-gradient(circle at right top, rgba(0, 107, 90, 0.14), transparent 34%);
+  box-shadow: var(--shadow);
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: auto -8% -24% auto;
+  width: 20rem;
+  height: 20rem;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(0, 107, 90, 0.14), transparent 68%);
+  pointer-events: none;
+}
+
+.topbar,
+.hero-content,
+.section,
+.cta-panel {
+  position: relative;
+  z-index: 1;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.brand,
+.section-label,
+.eyebrow {
+  font-family: "Avenir Next Condensed", "Franklin Gothic Medium", "Arial Narrow",
+    Arial, sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  color: var(--text-muted);
+  font-family: "Avenir Next", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 0.95rem;
+}
+
+.hero-content {
+  max-width: 46rem;
+  padding: 5rem 1rem 4.25rem;
+}
+
+.eyebrow,
+.section-label {
+  margin: 0 0 0.75rem;
+  color: var(--accent-strong);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  line-height: 1;
+}
+
+h1 {
+  max-width: 12ch;
+  font-size: clamp(3.3rem, 9vw, 6.2rem);
+  font-weight: 700;
+  letter-spacing: -0.05em;
+}
+
+h2 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+h3 {
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+p,
+li {
+  line-height: 1.65;
+}
+
+.hero-copy,
+.section-copy,
+.cta-panel p,
+.card p,
+.card li,
+.nav-links {
+  font-family: "Avenir Next", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.hero-copy {
+  margin: 1.4rem 0 0;
+  max-width: 42rem;
+  font-size: 1.16rem;
+  color: var(--text-muted);
+}
+
+.hero-actions,
+.cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.hero-actions {
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.9rem;
+  padding: 0.8rem 1.15rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  font-family: "Avenir Next", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 0.96rem;
+  font-weight: 600;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+}
+
+.button-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #f8fbf9;
+}
+
+.button-primary:hover,
+.button-primary:focus-visible {
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+}
+
+.button-secondary {
+  background: rgba(255, 255, 255, 0.64);
+  color: var(--text);
+}
+
+.button-secondary:hover,
+.button-secondary:focus-visible {
+  background: rgba(255, 255, 255, 0.88);
+}
+
+.hero-points {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin: 2.2rem 0 0;
+  padding: 0;
+  list-style: none;
+  font-family: "Avenir Next", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.hero-points li,
+.card,
+.example-card,
+.cta-panel {
+  border: 1px solid var(--border);
+  background: var(--bg-panel);
+  backdrop-filter: blur(10px);
+}
+
+.hero-points li {
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+}
+
+.section {
+  padding: 4.6rem 0 0;
+}
+
+.section-heading {
+  max-width: 44rem;
+  margin-bottom: 1.8rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.grid-three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.grid-two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.card {
+  padding: 1.4rem;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 8px 24px rgba(21, 34, 28, 0.04);
+}
+
+.card p,
+.card ul {
+  margin: 0.8rem 0 0;
+  color: var(--text-muted);
+}
+
+.card ul {
+  padding-left: 1.2rem;
+}
+
+.flow {
+  display: grid;
+  grid-template-columns: repeat(7, auto);
+  justify-content: start;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.25rem 1.35rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-strong);
+  box-shadow: 0 10px 28px rgba(21, 34, 28, 0.06);
+}
+
+.flow-step,
+.flow-arrow {
+  font-family: "Avenir Next", "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+.flow-step {
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.92);
+  font-weight: 600;
+}
+
+.flow-arrow {
+  font-size: 1.35rem;
+  color: var(--accent);
+}
+
+.example-card {
+  overflow-x: auto;
+  padding: 1.25rem;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 10px 28px rgba(21, 34, 28, 0.08);
+}
+
+.example-card pre {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #103f35;
+}
+
+.cta-panel {
+  display: grid;
+  grid-template-columns: 1.25fr 1fr;
+  gap: 1.5rem;
+  align-items: center;
+  padding: 1.6rem;
+  border-radius: calc(var(--radius-lg) + 4px);
+  box-shadow: 0 16px 40px rgba(21, 34, 28, 0.08);
+}
+
+.cta-panel p {
+  margin: 0.85rem 0 0;
+  color: var(--text-muted);
+}
+
+@media (max-width: 960px) {
+  .hero-points,
+  .grid-three,
+  .grid-two,
+  .cta-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .flow {
+    grid-template-columns: 1fr;
+    justify-items: start;
+  }
+
+  .flow-arrow {
+    transform: rotate(90deg);
+    margin-left: 0.35rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .page-shell {
+    width: min(calc(100% - 1rem), var(--page-width));
+    padding-top: 0.5rem;
+  }
+
+  .hero {
+    padding: 1rem;
+    border-radius: 28px;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero-content {
+    padding: 3.5rem 0.25rem 2.75rem;
+  }
+
+  h1 {
+    font-size: clamp(2.8rem, 16vw, 4.2rem);
+  }
+
+  h2 {
+    font-size: clamp(1.7rem, 9vw, 2.5rem);
+  }
+
+  .button,
+  .hero-actions .button,
+  .cta-actions .button {
+    width: 100%;
+  }
+
+  .section {
+    padding-top: 3.5rem;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a standalone static marketing site for CameraBridge under `site/` and a GitHub Pages workflow to publish it from the repository. The page is intentionally narrow and technical, aligned with the current README, architecture, roadmap, and API docs rather than broader marketing claims. README now documents where the site lives and how it is deployed.

## Issue

Closes #

## Files Changed

- `.github/workflows/github-pages.yml`
- `README.md`
- `site/index.html`
- `site/styles.css`

## Testing

- [ ] `swift build`
- [ ] `swift test`
- [x] Manual verification completed
- [x] Not run, explained below

Testing notes:
- Served `site/` locally with `python3 -m http.server` and verified a `200 OK` response plus the expected homepage HTML at `http://127.0.0.1:8123/`.
- Confirmed the site is plain static HTML/CSS with no build step.
- Did not run `swift build` or `swift test` because this change only adds the marketing site, Pages workflow, and README documentation; it does not touch Swift packages or runtime code.

## Deferred

- Enabling GitHub Pages in repository settings so the workflow can publish on `main`
- Custom domain / `CNAME` setup

## AGENTS.md Check

- [x] Scope stayed focused on one issue
- [x] Unrelated files were not changed without cause
- [x] Docs were updated if public behavior changed
