### PR TITLE
Implement read-only device enumeration

### DIFF
--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -32,7 +32,8 @@ struct CameraBridgeDaemon {
     func makeServer(
         router: CameraBridgeRouter = CameraBridgeRouter(
             routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider()
+                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
+                deviceListing: AVFoundationCameraDeviceListing()
             )
         )
     ) -> LocalHTTPServer {
@@ -47,7 +48,8 @@ struct CameraBridgeDaemon {
     func start(
         router: CameraBridgeRouter = CameraBridgeRouter(
             routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider()
+                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
+                deviceListing: AVFoundationCameraDeviceListing()
             )
         )
     ) throws -> LocalHTTPServer {

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -32,8 +32,8 @@ This document defines the early CameraBridge API contract for the v1 service sli
 | --- | --- | --- |
 | `GET /health` | current | implemented and unauthenticated |
 | `GET /v1/permissions` | current | read-only permission status |
+| `GET /v1/devices` | current | read-only device enumeration |
 | `POST /v1/permissions/request` | planned | deferred until after permission status |
-| `GET /v1/devices` | planned | deferred |
 | `GET /v1/session` | planned | deferred |
 | `POST /v1/session/start` | planned | deferred |
 | `POST /v1/session/stop` | planned | deferred |
@@ -74,6 +74,31 @@ Allowed `status` values:
 - `restricted`
 - `denied`
 - `authorized`
+
+### `GET /v1/devices`
+
+Status: `current`
+
+- auth: none for the early read-only slice
+- response: `200 OK`
+
+```json
+{
+  "devices": [
+    {
+      "id": "camera-1",
+      "name": "Built-in Camera",
+      "position": "front"
+    }
+  ]
+}
+```
+
+Device fields:
+
+- `id`: stable device identifier
+- `name`: display name
+- `position`: one of `front`, `back`, or `external`
 
 ## Planned Only
 

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -46,6 +46,17 @@ public struct HTTPResponse: Sendable, Equatable {
         )
     }
 
+    public static func json<T: Encodable>(statusCode: Int, body: T) -> HTTPResponse {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try! encoder.encode(body)
+        return HTTPResponse(
+            statusCode: statusCode,
+            headers: ["Content-Type": "application/json"],
+            body: data
+        )
+    }
+
     public static func notFound() -> HTTPResponse {
         .json(
             statusCode: 404,
@@ -92,10 +103,14 @@ public struct CameraBridgeRouter: Sendable {
 }
 
 public enum CameraBridgeRoutes {
-    public static func current(permissionStatusProvider: any CameraPermissionStatusProviding) -> [HTTPRoute] {
+    public static func current(
+        permissionStatusProvider: any CameraPermissionStatusProviding,
+        deviceListing: any CameraDeviceListing
+    ) -> [HTTPRoute] {
         [
             health(),
             permissionStatus(provider: permissionStatusProvider),
+            devices(deviceListing: deviceListing),
         ]
     }
 
@@ -110,6 +125,15 @@ public enum CameraBridgeRoutes {
             .json(
                 statusCode: 200,
                 body: #"{ "status": "\#(provider.currentPermissionState().rawValue)" }"#
+            )
+        }
+    }
+
+    public static func devices(deviceListing: any CameraDeviceListing) -> HTTPRoute {
+        HTTPRoute(method: .get, path: "/v1/devices") { _ in
+            .json(
+                statusCode: 200,
+                body: DevicesResponse(devices: deviceListing.availableDevices())
             )
         }
     }
@@ -357,5 +381,25 @@ private enum HTTPResponseSerializer {
         default:
             return "Error"
         }
+    }
+}
+
+private struct DevicesResponse: Encodable, Equatable {
+    var devices: [DeviceResponse]
+
+    init(devices: [CameraDevice]) {
+        self.devices = devices.map(DeviceResponse.init(device:))
+    }
+}
+
+private struct DeviceResponse: Encodable, Equatable {
+    var id: String
+    var name: String
+    var position: String
+
+    init(device: CameraDevice) {
+        self.id = device.id
+        self.name = device.name
+        self.position = device.position.rawValue
     }
 }

--- a/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
+++ b/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
@@ -21,6 +21,24 @@ public enum PreviewState: Sendable, Equatable {
     case running
 }
 
+public enum CameraDevicePosition: String, Sendable, CaseIterable, Equatable {
+    case front
+    case back
+    case external
+}
+
+public struct CameraDevice: Sendable, Equatable {
+    public var id: String
+    public var name: String
+    public var position: CameraDevicePosition
+
+    public init(id: String, name: String, position: CameraDevicePosition) {
+        self.id = id
+        self.name = name
+        self.position = position
+    }
+}
+
 public struct CameraStateError: Error, Sendable, Equatable {
     public let message: String
 
@@ -55,11 +73,41 @@ public protocol CameraPermissionStatusProviding: Sendable {
     func currentPermissionState() -> PermissionState
 }
 
+public protocol CameraDeviceListing: Sendable {
+    func availableDevices() -> [CameraDevice]
+}
+
 public struct AVFoundationCameraPermissionStatusProvider: CameraPermissionStatusProviding {
     public init() {}
 
     public func currentPermissionState() -> PermissionState {
         PermissionState(authorizationStatus: AVCaptureDevice.authorizationStatus(for: .video))
+    }
+}
+
+public struct AVFoundationCameraDeviceListing: CameraDeviceListing {
+    public init() {}
+
+    public func availableDevices() -> [CameraDevice] {
+        AVCaptureDevice.DiscoverySession(
+            deviceTypes: [
+                .builtInWideAngleCamera,
+                .continuityCamera,
+                .deskViewCamera,
+                .external,
+            ],
+            mediaType: .video,
+            position: .unspecified
+        )
+        .devices
+        .map(CameraDevice.init(device:))
+        .sorted {
+            if $0.name == $1.name {
+                return $0.id < $1.id
+            }
+
+            return $0.name < $1.name
+        }
     }
 }
 
@@ -77,5 +125,30 @@ extension PermissionState {
         @unknown default:
             self = .denied
         }
+    }
+}
+
+extension CameraDevicePosition {
+    init(position: AVCaptureDevice.Position) {
+        switch position {
+        case .front:
+            self = .front
+        case .back:
+            self = .back
+        case .unspecified:
+            self = .external
+        @unknown default:
+            self = .external
+        }
+    }
+}
+
+private extension CameraDevice {
+    init(device: AVCaptureDevice) {
+        self.init(
+            id: device.uniqueID,
+            name: device.localizedName,
+            position: CameraDevicePosition(position: device.position)
+        )
     }
 }

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -20,7 +20,10 @@ func routerReturnsNotFoundForUnknownRoute() {
 @Test
 func routerReturnsHealthResponseForHealthRoute() {
     let router = CameraBridgeRouter(
-        routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized))
+        routes: CameraBridgeRoutes.current(
+            permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
+            deviceListing: FixedDeviceListing(devices: [])
+        )
     )
     let response = router.response(for: HTTPRequest(method: .get, path: "/health"))
 
@@ -34,7 +37,10 @@ func localHTTPServerReturnsHealthResponse() async throws {
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
         router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized))
+            routes: CameraBridgeRoutes.current(
+                permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
+                deviceListing: FixedDeviceListing(devices: [])
+            )
         )
     )
 
@@ -55,7 +61,10 @@ func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
         router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized))
+            routes: CameraBridgeRoutes.current(
+                permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
+                deviceListing: FixedDeviceListing(devices: [])
+            )
         )
     )
 
@@ -74,7 +83,10 @@ func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
 @Test(arguments: PermissionState.allCases)
 func routerReturnsPermissionStatusForProviderState(_ state: PermissionState) {
     let router = CameraBridgeRouter(
-        routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: state))
+        routes: CameraBridgeRoutes.current(
+            permissionStatusProvider: FixedPermissionStatusProvider(state: state),
+            deviceListing: FixedDeviceListing(devices: [])
+        )
     )
     let response = router.response(for: HTTPRequest(method: .get, path: "/v1/permissions"))
 
@@ -88,7 +100,10 @@ func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
         router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted))
+            routes: CameraBridgeRoutes.current(
+                permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted),
+                deviceListing: FixedDeviceListing(devices: [])
+            )
         )
     )
 
@@ -103,11 +118,71 @@ func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
     #expect(String(decoding: data, as: UTF8.self) == #"{ "status": "restricted" }"#)
 }
 
+@Test
+func routerReturnsDeviceListForDeviceRoute() {
+    let devices = [
+        CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+        CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
+    ]
+    let router = CameraBridgeRouter(
+        routes: CameraBridgeRoutes.current(
+            permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
+            deviceListing: FixedDeviceListing(devices: devices)
+        )
+    )
+    let response = router.response(for: HTTPRequest(method: .get, path: "/v1/devices"))
+
+    #expect(response.statusCode == 200)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"devices":[{"id":"camera-1","name":"Built-in Camera","position":"front"},{"id":"camera-2","name":"Desk Camera","position":"external"}]}"#
+    )
+}
+
+@Test
+func localHTTPServerReturnsDeviceListWithoutAuth() async throws {
+    let port = try reserveEphemeralPort()
+    let devices = [
+        CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+        CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
+    ]
+    let server = LocalHTTPServer(
+        configuration: .init(host: "127.0.0.1", port: port),
+        router: CameraBridgeRouter(
+            routes: CameraBridgeRoutes.current(
+                permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
+                deviceListing: FixedDeviceListing(devices: devices)
+            )
+        )
+    )
+
+    defer { server.stop() }
+
+    let boundPort = try server.start()
+    let url = try #require(URL(string: "http://127.0.0.1:\(boundPort)/v1/devices"))
+    let (data, response) = try await URLSession.shared.data(from: url)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+
+    #expect(httpResponse.statusCode == 200)
+    #expect(
+        String(decoding: data, as: UTF8.self) ==
+        #"{"devices":[{"id":"camera-1","name":"Built-in Camera","position":"front"},{"id":"camera-2","name":"Desk Camera","position":"external"}]}"#
+    )
+}
+
 private struct FixedPermissionStatusProvider: CameraPermissionStatusProviding {
     let state: PermissionState
 
     func currentPermissionState() -> PermissionState {
         state
+    }
+}
+
+private struct FixedDeviceListing: CameraDeviceListing {
+    let devices: [CameraDevice]
+
+    func availableDevices() -> [CameraDevice] {
+        devices
     }
 }
 

--- a/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
+++ b/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
@@ -27,6 +27,13 @@ func permissionStateRawValuesMatchAPIVocabulary() {
 }
 
 @Test
+func cameraDevicePositionRawValuesMatchAPIVocabulary() {
+    #expect(CameraDevicePosition.front.rawValue == "front")
+    #expect(CameraDevicePosition.back.rawValue == "back")
+    #expect(CameraDevicePosition.external.rawValue == "external")
+}
+
+@Test
 func cameraStateRetainsExplicitValues() {
     let error = CameraStateError(message: "permission unavailable")
     let state = CameraState(
@@ -50,4 +57,20 @@ func permissionStateMapsAVFoundationStatusValues() {
     #expect(PermissionState(authorizationStatus: .restricted) == .restricted)
     #expect(PermissionState(authorizationStatus: .denied) == .denied)
     #expect(PermissionState(authorizationStatus: .authorized) == .authorized)
+}
+
+@Test
+func cameraDeviceRetainsExplicitValues() {
+    let device = CameraDevice(id: "camera-1", name: "Desk Camera", position: .external)
+
+    #expect(device.id == "camera-1")
+    #expect(device.name == "Desk Camera")
+    #expect(device.position == .external)
+}
+
+@Test
+func cameraDevicePositionMapsAVFoundationPositionValues() {
+    #expect(CameraDevicePosition(position: .front) == .front)
+    #expect(CameraDevicePosition(position: .back) == .back)
+    #expect(CameraDevicePosition(position: .unspecified) == .external)
 }


### PR DESCRIPTION
## Summary

Add the remaining Milestone 1 read-only service slice for device discovery. This introduces a minimal Core device model and AVFoundation-backed listing abstraction, exposes `GET /v1/devices`, wires the provider through `camd`, adds Core/API tests, and updates the API contract docs to match the implemented behavior.

## Issue

Closes #20

## Files Changed

- `packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift`
- `packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift`
- `apps/camd/Sources/camd/CameraBridgeDaemon.swift`
- `tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift`
- `tests/CameraBridgeAPITests/CameraBridgeAPITests.swift`
- `docs/api/v1.md`

## Testing

- [ ] `swift build`
- [x] `swift test`
- [ ] Manual verification completed
- [ ] Not run, explained below

Testing notes:
- `swift test`

## Deferred

- Auth and ownership decisions for mutating endpoints remain in #21.
- Device selection remains in #24.
- Session and capture behavior remain out of scope for this slice.

## AGENTS.md Check

- [x] Scope stayed focused on one issue
- [x] Unrelated files were not changed without cause
- [x] Docs were updated if public behavior changed
