### PR TITLE
Implement camera permission request endpoint

### DIFF
--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -5,13 +5,20 @@ import Foundation
 struct ServerConfiguration: Sendable, Equatable {
     static let defaultHost = "127.0.0.1"
     static let defaultPort: UInt16 = 8731
+    static let authTokenEnvironmentVariable = "CAMERABRIDGE_AUTH_TOKEN"
 
     var host: String
     var port: UInt16
+    var authToken: String?
 
-    init(host: String = ServerConfiguration.defaultHost, port: UInt16 = ServerConfiguration.defaultPort) {
+    init(
+        host: String = ServerConfiguration.defaultHost,
+        port: UInt16 = ServerConfiguration.defaultPort,
+        authToken: String? = ProcessInfo.processInfo.environment[ServerConfiguration.authTokenEnvironmentVariable]
+    ) {
         self.host = host
         self.port = port
+        self.authToken = authToken
     }
 }
 
@@ -29,28 +36,26 @@ struct CameraBridgeDaemon {
         self.logger = logger
     }
 
-    func makeServer(
-        router: CameraBridgeRouter = CameraBridgeRouter(
+    private func defaultRouter() -> CameraBridgeRouter {
+        CameraBridgeRouter(
             routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider()
+                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
+                permissionRequester: AVFoundationCameraPermissionRequester(),
+                authorizer: StaticBearerTokenAuthorizer(bearerToken: configuration.authToken)
             )
         )
-    ) -> LocalHTTPServer {
+    }
+
+    func makeServer(router: CameraBridgeRouter? = nil) -> LocalHTTPServer {
         LocalHTTPServer(
             configuration: .init(host: configuration.host, port: configuration.port),
-            router: router,
+            router: router ?? defaultRouter(),
             logger: logger
         )
     }
 
     @discardableResult
-    func start(
-        router: CameraBridgeRouter = CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider()
-            )
-        )
-    ) throws -> LocalHTTPServer {
+    func start(router: CameraBridgeRouter? = nil) throws -> LocalHTTPServer {
         logger("starting camd on \(configuration.host):\(configuration.port)")
         let server = makeServer(router: router)
         let port = try server.start()

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -48,7 +48,7 @@ High-level planned error categories for mutating endpoints:
 | --- | --- | --- |
 | `GET /health` | current | implemented and unauthenticated |
 | `GET /v1/permissions` | current | read-only permission status |
-| `POST /v1/permissions/request` | planned | token-protected; no session ownership effect |
+| `POST /v1/permissions/request` | current | token-protected; no session ownership effect |
 | `GET /v1/devices` | planned | deferred |
 | `GET /v1/session` | planned | read-only session state |
 | `POST /v1/session/start` | planned | token-protected; acquires implicit ownership on success |
@@ -90,6 +90,38 @@ Allowed `status` values:
 - `restricted`
 - `denied`
 - `authorized`
+
+### `POST /v1/permissions/request`
+
+Status: `current`
+
+- auth: bearer token required
+- current early daemon wiring expects the token from the `CAMERABRIDGE_AUTH_TOKEN` environment variable
+- ownership: does not create or transfer session ownership
+- response: `200 OK`
+
+```json
+{
+  "prompted": true,
+  "status": "authorized"
+}
+```
+
+Response fields:
+
+- `status`: one of `not_determined`, `restricted`, `denied`, or `authorized`
+- `prompted`: `true` when the system permission prompt was requested during this call, otherwise `false`
+
+Auth failure response: `401 Unauthorized`
+
+```json
+{
+  "error": {
+    "code": "unauthorized",
+    "message": "Bearer token missing or invalid"
+  }
+}
+```
 
 ## Planned Only
 

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -46,11 +46,47 @@ public struct HTTPResponse: Sendable, Equatable {
         )
     }
 
-    public static func notFound() -> HTTPResponse {
-        .json(
-            statusCode: 404,
-            body: #"{ "error": { "code": "not_found", "message": "Route not found" } }"#
+    public static func json<T: Encodable>(statusCode: Int, body: T) -> HTTPResponse {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try! encoder.encode(body)
+        return HTTPResponse(
+            statusCode: statusCode,
+            headers: ["Content-Type": "application/json"],
+            body: data
         )
+    }
+
+    public static func error(statusCode: Int, code: String, message: String) -> HTTPResponse {
+        .json(statusCode: statusCode, body: ErrorResponse(error: .init(code: code, message: message)))
+    }
+
+    public static func notFound() -> HTTPResponse {
+        .error(statusCode: 404, code: "not_found", message: "Route not found")
+    }
+
+    public static func unauthorized() -> HTTPResponse {
+        .error(statusCode: 401, code: "unauthorized", message: "Bearer token missing or invalid")
+    }
+}
+
+public protocol BearerTokenAuthorizing: Sendable {
+    func isAuthorized(request: HTTPRequest) -> Bool
+}
+
+public struct StaticBearerTokenAuthorizer: BearerTokenAuthorizing {
+    public var bearerToken: String?
+
+    public init(bearerToken: String?) {
+        self.bearerToken = bearerToken
+    }
+
+    public func isAuthorized(request: HTTPRequest) -> Bool {
+        guard let bearerToken, !bearerToken.isEmpty else {
+            return false
+        }
+
+        return request.authorizationBearerToken == bearerToken
     }
 }
 
@@ -92,10 +128,15 @@ public struct CameraBridgeRouter: Sendable {
 }
 
 public enum CameraBridgeRoutes {
-    public static func current(permissionStatusProvider: any CameraPermissionStatusProviding) -> [HTTPRoute] {
+    public static func current(
+        permissionStatusProvider: any CameraPermissionStatusProviding,
+        permissionRequester: any CameraPermissionRequesting,
+        authorizer: any BearerTokenAuthorizing
+    ) -> [HTTPRoute] {
         [
             health(),
             permissionStatus(provider: permissionStatusProvider),
+            permissionRequest(requester: permissionRequester, authorizer: authorizer),
         ]
     }
 
@@ -110,6 +151,34 @@ public enum CameraBridgeRoutes {
             .json(
                 statusCode: 200,
                 body: #"{ "status": "\#(provider.currentPermissionState().rawValue)" }"#
+            )
+        }
+    }
+
+    public static func permissionRequest(
+        requester: any CameraPermissionRequesting,
+        authorizer: any BearerTokenAuthorizing
+    ) -> HTTPRoute {
+        HTTPRoute(method: .post, path: "/v1/permissions/request") { request in
+            guard authorizer.isAuthorized(request: request) else {
+                return .unauthorized()
+            }
+
+            let semaphore = DispatchSemaphore(value: 0)
+            let resultBox = PermissionRequestResultBox()
+
+            requester.requestPermission { permissionResult in
+                resultBox.result = permissionResult
+                semaphore.signal()
+            }
+
+            semaphore.wait()
+
+            return .json(
+                statusCode: 200,
+                body: PermissionRequestResponse(
+                    result: resultBox.result ?? .init(status: .denied, prompted: false)
+                )
             )
         }
     }
@@ -352,10 +421,52 @@ private enum HTTPResponseSerializer {
         switch statusCode {
         case 200:
             return "OK"
+        case 401:
+            return "Unauthorized"
         case 404:
             return "Not Found"
         default:
             return "Error"
         }
     }
+}
+
+private extension HTTPRequest {
+    var authorizationBearerToken: String? {
+        guard let authorization = headers.first(where: {
+            $0.key.caseInsensitiveCompare("Authorization") == .orderedSame
+        })?.value else {
+            return nil
+        }
+
+        let prefix = "Bearer "
+        guard authorization.hasPrefix(prefix) else {
+            return nil
+        }
+
+        return String(authorization.dropFirst(prefix.count))
+    }
+}
+
+private struct ErrorResponse: Encodable, Equatable {
+    var error: ErrorBody
+}
+
+private struct ErrorBody: Encodable, Equatable {
+    var code: String
+    var message: String
+}
+
+private struct PermissionRequestResponse: Encodable, Equatable {
+    var status: String
+    var prompted: Bool
+
+    init(result: PermissionRequestResult) {
+        self.status = result.status.rawValue
+        self.prompted = result.prompted
+    }
+}
+
+private final class PermissionRequestResultBox: @unchecked Sendable {
+    var result: PermissionRequestResult?
 }

--- a/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
+++ b/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
@@ -21,6 +21,16 @@ public enum PreviewState: Sendable, Equatable {
     case running
 }
 
+public struct PermissionRequestResult: Sendable, Equatable {
+    public var status: PermissionState
+    public var prompted: Bool
+
+    public init(status: PermissionState, prompted: Bool) {
+        self.status = status
+        self.prompted = prompted
+    }
+}
+
 public struct CameraStateError: Error, Sendable, Equatable {
     public let message: String
 
@@ -55,11 +65,43 @@ public protocol CameraPermissionStatusProviding: Sendable {
     func currentPermissionState() -> PermissionState
 }
 
+public protocol CameraPermissionRequesting: Sendable {
+    func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void)
+}
+
 public struct AVFoundationCameraPermissionStatusProvider: CameraPermissionStatusProviding {
     public init() {}
 
     public func currentPermissionState() -> PermissionState {
         PermissionState(authorizationStatus: AVCaptureDevice.authorizationStatus(for: .video))
+    }
+}
+
+public struct AVFoundationCameraPermissionRequester: CameraPermissionRequesting {
+    public init() {}
+
+    public func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void) {
+        let currentStatus = AVCaptureDevice.authorizationStatus(for: .video)
+        guard currentStatus == .notDetermined else {
+            completion(
+                PermissionRequestResult(
+                    status: PermissionState(authorizationStatus: currentStatus),
+                    prompted: false
+                )
+            )
+            return
+        }
+
+        AVCaptureDevice.requestAccess(for: .video) { _ in
+            completion(
+                PermissionRequestResult(
+                    status: PermissionState(
+                        authorizationStatus: AVCaptureDevice.authorizationStatus(for: .video)
+                    ),
+                    prompted: true
+                )
+            )
+        }
     }
 }
 

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -14,13 +14,17 @@ func routerReturnsNotFoundForUnknownRoute() {
     let response = router.response(for: HTTPRequest(method: .get, path: "/missing"))
 
     #expect(response.statusCode == 404)
-    #expect(String(decoding: response.body, as: UTF8.self) == #"{ "error": { "code": "not_found", "message": "Route not found" } }"#)
+    #expect(String(decoding: response.body, as: UTF8.self) == #"{"error":{"code":"not_found","message":"Route not found"}}"#)
 }
 
 @Test
 func routerReturnsHealthResponseForHealthRoute() {
     let router = CameraBridgeRouter(
-        routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized))
+        routes: CameraBridgeRoutes.current(
+            permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
+            permissionRequester: FixedPermissionRequester(result: .init(status: .authorized, prompted: true)),
+            authorizer: StaticBearerTokenAuthorizer(bearerToken: "test-token")
+        )
     )
     let response = router.response(for: HTTPRequest(method: .get, path: "/health"))
 
@@ -34,7 +38,11 @@ func localHTTPServerReturnsHealthResponse() async throws {
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
         router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized))
+            routes: CameraBridgeRoutes.current(
+                permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
+                permissionRequester: FixedPermissionRequester(result: .init(status: .authorized, prompted: true)),
+                authorizer: StaticBearerTokenAuthorizer(bearerToken: "test-token")
+            )
         )
     )
 
@@ -55,7 +63,11 @@ func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
         router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized))
+            routes: CameraBridgeRoutes.current(
+                permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
+                permissionRequester: FixedPermissionRequester(result: .init(status: .authorized, prompted: true)),
+                authorizer: StaticBearerTokenAuthorizer(bearerToken: "test-token")
+            )
         )
     )
 
@@ -68,13 +80,17 @@ func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
     let httpResponse = try #require(response as? HTTPURLResponse)
 
     #expect(httpResponse.statusCode == 404)
-    #expect(String(decoding: data, as: UTF8.self) == #"{ "error": { "code": "not_found", "message": "Route not found" } }"#)
+    #expect(String(decoding: data, as: UTF8.self) == #"{"error":{"code":"not_found","message":"Route not found"}}"#)
 }
 
 @Test(arguments: PermissionState.allCases)
 func routerReturnsPermissionStatusForProviderState(_ state: PermissionState) {
     let router = CameraBridgeRouter(
-        routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: state))
+        routes: CameraBridgeRoutes.current(
+            permissionStatusProvider: FixedPermissionStatusProvider(state: state),
+            permissionRequester: FixedPermissionRequester(result: .init(status: state, prompted: false)),
+            authorizer: StaticBearerTokenAuthorizer(bearerToken: "test-token")
+        )
     )
     let response = router.response(for: HTTPRequest(method: .get, path: "/v1/permissions"))
 
@@ -88,7 +104,11 @@ func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
         router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted))
+            routes: CameraBridgeRoutes.current(
+                permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted),
+                permissionRequester: FixedPermissionRequester(result: .init(status: .restricted, prompted: false)),
+                authorizer: StaticBearerTokenAuthorizer(bearerToken: "test-token")
+            )
         )
     )
 
@@ -103,11 +123,100 @@ func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
     #expect(String(decoding: data, as: UTF8.self) == #"{ "status": "restricted" }"#)
 }
 
+@Test
+func routerRejectsPermissionRequestWithoutBearerToken() {
+    let requester = RecordingPermissionRequester(result: .init(status: .authorized, prompted: true))
+    let router = CameraBridgeRouter(
+        routes: CameraBridgeRoutes.current(
+            permissionStatusProvider: FixedPermissionStatusProvider(state: .notDetermined),
+            permissionRequester: requester,
+            authorizer: StaticBearerTokenAuthorizer(bearerToken: "test-token")
+        )
+    )
+    let response = router.response(for: HTTPRequest(method: .post, path: "/v1/permissions/request"))
+
+    #expect(response.statusCode == 401)
+    #expect(String(decoding: response.body, as: UTF8.self) == #"{"error":{"code":"unauthorized","message":"Bearer token missing or invalid"}}"#)
+    #expect(requester.requestCount == 0)
+}
+
+@Test
+func routerReturnsPermissionRequestResultForAuthorizedRequest() {
+    let requester = RecordingPermissionRequester(result: .init(status: .authorized, prompted: true))
+    let router = CameraBridgeRouter(
+        routes: CameraBridgeRoutes.current(
+            permissionStatusProvider: FixedPermissionStatusProvider(state: .notDetermined),
+            permissionRequester: requester,
+            authorizer: StaticBearerTokenAuthorizer(bearerToken: "test-token")
+        )
+    )
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/permissions/request",
+            headers: ["Authorization": "Bearer test-token"]
+        )
+    )
+
+    #expect(response.statusCode == 200)
+    #expect(String(decoding: response.body, as: UTF8.self) == #"{"prompted":true,"status":"authorized"}"#)
+    #expect(requester.requestCount == 1)
+}
+
+@Test
+func localHTTPServerReturnsPermissionRequestResultForAuthorizedRequest() async throws {
+    let port = try reserveEphemeralPort()
+    let server = LocalHTTPServer(
+        configuration: .init(host: "127.0.0.1", port: port),
+        router: CameraBridgeRouter(
+            routes: CameraBridgeRoutes.current(
+                permissionStatusProvider: FixedPermissionStatusProvider(state: .notDetermined),
+                permissionRequester: FixedPermissionRequester(result: .init(status: .denied, prompted: true)),
+                authorizer: StaticBearerTokenAuthorizer(bearerToken: "test-token")
+            )
+        )
+    )
+
+    defer { server.stop() }
+
+    let boundPort = try server.start()
+    var request = URLRequest(url: try #require(URL(string: "http://127.0.0.1:\(boundPort)/v1/permissions/request")))
+    request.httpMethod = "POST"
+    request.setValue("Bearer test-token", forHTTPHeaderField: "Authorization")
+    let (data, response) = try await URLSession.shared.data(for: request)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+
+    #expect(httpResponse.statusCode == 200)
+    #expect(String(decoding: data, as: UTF8.self) == #"{"prompted":true,"status":"denied"}"#)
+}
+
 private struct FixedPermissionStatusProvider: CameraPermissionStatusProviding {
     let state: PermissionState
 
     func currentPermissionState() -> PermissionState {
         state
+    }
+}
+
+private struct FixedPermissionRequester: CameraPermissionRequesting {
+    let result: PermissionRequestResult
+
+    func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void) {
+        completion(result)
+    }
+}
+
+private final class RecordingPermissionRequester: CameraPermissionRequesting, @unchecked Sendable {
+    private(set) var requestCount = 0
+    let result: PermissionRequestResult
+
+    init(result: PermissionRequestResult) {
+        self.result = result
+    }
+
+    func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void) {
+        requestCount += 1
+        completion(result)
     }
 }
 

--- a/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
+++ b/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
@@ -51,3 +51,11 @@ func permissionStateMapsAVFoundationStatusValues() {
     #expect(PermissionState(authorizationStatus: .denied) == .denied)
     #expect(PermissionState(authorizationStatus: .authorized) == .authorized)
 }
+
+@Test
+func permissionRequestResultRetainsExplicitValues() {
+    let result = PermissionRequestResult(status: .authorized, prompted: true)
+
+    #expect(result.status == .authorized)
+    #expect(result.prompted)
+}


### PR DESCRIPTION
## Summary

Implement `POST /v1/permissions/request` as the first protected mutating route. This adds a mockable Core permission requester backed by AVFoundation, a minimal bearer-token authorizer for protected routes, the API handler and response model for permission requests, daemon wiring for token-based auth via `CAMERABRIDGE_AUTH_TOKEN`, and tests plus API docs that match the implemented behavior.

## Issue

Refs #22
Depends on #21

## Files Changed

- `packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift`
- `packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift`
- `apps/camd/Sources/camd/CameraBridgeDaemon.swift`
- `tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift`
- `tests/CameraBridgeAPITests/CameraBridgeAPITests.swift`
- `docs/api/v1.md`

## Testing

- [ ] `swift build`
- [x] `swift test`
- [ ] Manual verification completed
- [ ] Not run, explained below

Testing notes:
- `swift test`
- Real macOS permission-prompt verification was not run in this environment.

## Deferred

- Broader auth config and token persistence remain deferred.
- Session ownership and other protected mutating routes remain deferred to #23, #24, #25, and #26.
- Device enumeration from #20 is on a separate branch and will need merge resolution when both slices land.

## AGENTS.md Check

- [x] Scope stayed focused on one issue
- [x] Unrelated files were not changed without cause
- [x] Docs were updated if public behavior changed
