### PR TITLE
Implement read-only session status endpoint

### DIFF
--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -32,7 +32,8 @@ struct CameraBridgeDaemon {
     func makeServer(
         router: CameraBridgeRouter = CameraBridgeRouter(
             routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider()
+                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
+                cameraStateProvider: DefaultCameraStateProvider()
             )
         )
     ) -> LocalHTTPServer {
@@ -47,7 +48,8 @@ struct CameraBridgeDaemon {
     func start(
         router: CameraBridgeRouter = CameraBridgeRouter(
             routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider()
+                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
+                cameraStateProvider: DefaultCameraStateProvider()
             )
         )
     ) throws -> LocalHTTPServer {

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -50,7 +50,7 @@ High-level planned error categories for mutating endpoints:
 | `GET /v1/permissions` | current | read-only permission status |
 | `POST /v1/permissions/request` | planned | token-protected; no session ownership effect |
 | `GET /v1/devices` | planned | deferred |
-| `GET /v1/session` | planned | read-only session state |
+| `GET /v1/session` | current | read-only session state |
 | `POST /v1/session/start` | planned | token-protected; acquires implicit ownership on success |
 | `POST /v1/session/stop` | planned | token-protected; requires current owner and releases ownership |
 | `POST /v1/session/select-device` | planned | token-protected; follows v1 ownership rules |
@@ -90,6 +90,29 @@ Allowed `status` values:
 - `restricted`
 - `denied`
 - `authorized`
+
+### `GET /v1/session`
+
+Status: `current`
+
+- auth: none for the early read-only slice
+- response: `200 OK`
+
+```json
+{
+  "active_device_id": null,
+  "last_error": null,
+  "owner_id": null,
+  "state": "stopped"
+}
+```
+
+Response fields:
+
+- `state`: `stopped` or `running`
+- `active_device_id`: selected device identifier, or `null`
+- `owner_id`: current session owner identifier, or `null`
+- `last_error`: last session-related error message, or `null`
 
 ## Planned Only
 

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -46,6 +46,17 @@ public struct HTTPResponse: Sendable, Equatable {
         )
     }
 
+    public static func json<T: Encodable>(statusCode: Int, body: T) -> HTTPResponse {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try! encoder.encode(body)
+        return HTTPResponse(
+            statusCode: statusCode,
+            headers: ["Content-Type": "application/json"],
+            body: data
+        )
+    }
+
     public static func notFound() -> HTTPResponse {
         .json(
             statusCode: 404,
@@ -92,10 +103,14 @@ public struct CameraBridgeRouter: Sendable {
 }
 
 public enum CameraBridgeRoutes {
-    public static func current(permissionStatusProvider: any CameraPermissionStatusProviding) -> [HTTPRoute] {
+    public static func current(
+        permissionStatusProvider: any CameraPermissionStatusProviding,
+        cameraStateProvider: any CameraStateProviding
+    ) -> [HTTPRoute] {
         [
             health(),
             permissionStatus(provider: permissionStatusProvider),
+            sessionState(provider: cameraStateProvider),
         ]
     }
 
@@ -111,6 +126,12 @@ public enum CameraBridgeRoutes {
                 statusCode: 200,
                 body: #"{ "status": "\#(provider.currentPermissionState().rawValue)" }"#
             )
+        }
+    }
+
+    public static func sessionState(provider: any CameraStateProviding) -> HTTPRoute {
+        HTTPRoute(method: .get, path: "/v1/session") { _ in
+            .json(statusCode: 200, body: SessionStateResponse(state: provider.currentCameraState()))
         }
     }
 }
@@ -356,6 +377,50 @@ private enum HTTPResponseSerializer {
             return "Not Found"
         default:
             return "Error"
+        }
+    }
+}
+
+private struct SessionStateResponse: Encodable, Equatable {
+    var state: String
+    var activeDeviceID: String?
+    var ownerID: String?
+    var lastError: String?
+
+    enum CodingKeys: String, CodingKey {
+        case state
+        case activeDeviceID = "active_device_id"
+        case ownerID = "owner_id"
+        case lastError = "last_error"
+    }
+
+    init(state: CameraState) {
+        self.state = state.sessionState.rawValue
+        self.activeDeviceID = state.activeDeviceID
+        self.ownerID = state.currentOwnerID
+        self.lastError = state.lastError?.message
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(state, forKey: .state)
+
+        if let activeDeviceID {
+            try container.encode(activeDeviceID, forKey: .activeDeviceID)
+        } else {
+            try container.encodeNil(forKey: .activeDeviceID)
+        }
+
+        if let ownerID {
+            try container.encode(ownerID, forKey: .ownerID)
+        } else {
+            try container.encodeNil(forKey: .ownerID)
+        }
+
+        if let lastError {
+            try container.encode(lastError, forKey: .lastError)
+        } else {
+            try container.encodeNil(forKey: .lastError)
         }
     }
 }

--- a/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
+++ b/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
@@ -11,7 +11,7 @@ public enum PermissionState: String, Sendable, CaseIterable, Equatable {
     case authorized
 }
 
-public enum SessionState: Sendable, Equatable {
+public enum SessionState: String, Sendable, CaseIterable, Equatable {
     case stopped
     case running
 }
@@ -34,6 +34,7 @@ public struct CameraState: Sendable, Equatable {
     public var sessionState: SessionState
     public var previewState: PreviewState
     public var activeDeviceID: String?
+    public var currentOwnerID: String?
     public var lastError: CameraStateError?
 
     public init(
@@ -41,12 +42,14 @@ public struct CameraState: Sendable, Equatable {
         sessionState: SessionState = .stopped,
         previewState: PreviewState = .stopped,
         activeDeviceID: String? = nil,
+        currentOwnerID: String? = nil,
         lastError: CameraStateError? = nil
     ) {
         self.permissionState = permissionState
         self.sessionState = sessionState
         self.previewState = previewState
         self.activeDeviceID = activeDeviceID
+        self.currentOwnerID = currentOwnerID
         self.lastError = lastError
     }
 }
@@ -55,11 +58,27 @@ public protocol CameraPermissionStatusProviding: Sendable {
     func currentPermissionState() -> PermissionState
 }
 
+public protocol CameraStateProviding: Sendable {
+    func currentCameraState() -> CameraState
+}
+
 public struct AVFoundationCameraPermissionStatusProvider: CameraPermissionStatusProviding {
     public init() {}
 
     public func currentPermissionState() -> PermissionState {
         PermissionState(authorizationStatus: AVCaptureDevice.authorizationStatus(for: .video))
+    }
+}
+
+public struct DefaultCameraStateProvider: CameraStateProviding {
+    public var state: CameraState
+
+    public init(state: CameraState = CameraState()) {
+        self.state = state
+    }
+
+    public func currentCameraState() -> CameraState {
+        state
     }
 }
 

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -20,7 +20,10 @@ func routerReturnsNotFoundForUnknownRoute() {
 @Test
 func routerReturnsHealthResponseForHealthRoute() {
     let router = CameraBridgeRouter(
-        routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized))
+        routes: CameraBridgeRoutes.current(
+            permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
+            cameraStateProvider: FixedCameraStateProvider(state: CameraState())
+        )
     )
     let response = router.response(for: HTTPRequest(method: .get, path: "/health"))
 
@@ -34,7 +37,10 @@ func localHTTPServerReturnsHealthResponse() async throws {
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
         router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized))
+            routes: CameraBridgeRoutes.current(
+                permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
+                cameraStateProvider: FixedCameraStateProvider(state: CameraState())
+            )
         )
     )
 
@@ -55,7 +61,10 @@ func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
         router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized))
+            routes: CameraBridgeRoutes.current(
+                permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
+                cameraStateProvider: FixedCameraStateProvider(state: CameraState())
+            )
         )
     )
 
@@ -74,7 +83,10 @@ func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
 @Test(arguments: PermissionState.allCases)
 func routerReturnsPermissionStatusForProviderState(_ state: PermissionState) {
     let router = CameraBridgeRouter(
-        routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: state))
+        routes: CameraBridgeRoutes.current(
+            permissionStatusProvider: FixedPermissionStatusProvider(state: state),
+            cameraStateProvider: FixedCameraStateProvider(state: CameraState())
+        )
     )
     let response = router.response(for: HTTPRequest(method: .get, path: "/v1/permissions"))
 
@@ -88,7 +100,10 @@ func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
         router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted))
+            routes: CameraBridgeRoutes.current(
+                permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted),
+                cameraStateProvider: FixedCameraStateProvider(state: CameraState())
+            )
         )
     )
 
@@ -103,10 +118,78 @@ func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
     #expect(String(decoding: data, as: UTF8.self) == #"{ "status": "restricted" }"#)
 }
 
+@Test
+func routerReturnsSessionStateForSessionRoute() {
+    let state = CameraState(
+        permissionState: .authorized,
+        sessionState: .running,
+        previewState: .stopped,
+        activeDeviceID: "camera-1",
+        currentOwnerID: "client-1",
+        lastError: CameraStateError(message: "session failed")
+    )
+    let router = CameraBridgeRouter(
+        routes: CameraBridgeRoutes.current(
+            permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
+            cameraStateProvider: FixedCameraStateProvider(state: state)
+        )
+    )
+    let response = router.response(for: HTTPRequest(method: .get, path: "/v1/session"))
+
+    #expect(response.statusCode == 200)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"active_device_id":"camera-1","last_error":"session failed","owner_id":"client-1","state":"running"}"#
+    )
+}
+
+@Test
+func localHTTPServerReturnsSessionStateWithoutAuth() async throws {
+    let port = try reserveEphemeralPort()
+    let state = CameraState(
+        permissionState: .restricted,
+        sessionState: .stopped,
+        previewState: .stopped,
+        activeDeviceID: nil,
+        currentOwnerID: nil,
+        lastError: nil
+    )
+    let server = LocalHTTPServer(
+        configuration: .init(host: "127.0.0.1", port: port),
+        router: CameraBridgeRouter(
+            routes: CameraBridgeRoutes.current(
+                permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted),
+                cameraStateProvider: FixedCameraStateProvider(state: state)
+            )
+        )
+    )
+
+    defer { server.stop() }
+
+    let boundPort = try server.start()
+    let url = try #require(URL(string: "http://127.0.0.1:\(boundPort)/v1/session"))
+    let (data, response) = try await URLSession.shared.data(from: url)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+
+    #expect(httpResponse.statusCode == 200)
+    #expect(
+        String(decoding: data, as: UTF8.self) ==
+        #"{"active_device_id":null,"last_error":null,"owner_id":null,"state":"stopped"}"#
+    )
+}
+
 private struct FixedPermissionStatusProvider: CameraPermissionStatusProviding {
     let state: PermissionState
 
     func currentPermissionState() -> PermissionState {
+        state
+    }
+}
+
+private struct FixedCameraStateProvider: CameraStateProviding {
+    let state: CameraState
+
+    func currentCameraState() -> CameraState {
         state
     }
 }

--- a/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
+++ b/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
@@ -15,6 +15,7 @@ func cameraStateDefaultsMatchEarlySlice() {
     #expect(state.sessionState == .stopped)
     #expect(state.previewState == .stopped)
     #expect(state.activeDeviceID == nil)
+    #expect(state.currentOwnerID == nil)
     #expect(state.lastError == nil)
 }
 
@@ -27,6 +28,12 @@ func permissionStateRawValuesMatchAPIVocabulary() {
 }
 
 @Test
+func sessionStateRawValuesMatchAPIVocabulary() {
+    #expect(SessionState.stopped.rawValue == "stopped")
+    #expect(SessionState.running.rawValue == "running")
+}
+
+@Test
 func cameraStateRetainsExplicitValues() {
     let error = CameraStateError(message: "permission unavailable")
     let state = CameraState(
@@ -34,6 +41,7 @@ func cameraStateRetainsExplicitValues() {
         sessionState: .running,
         previewState: .running,
         activeDeviceID: "camera-1",
+        currentOwnerID: "client-1",
         lastError: error
     )
 
@@ -41,6 +49,7 @@ func cameraStateRetainsExplicitValues() {
     #expect(state.sessionState == .running)
     #expect(state.previewState == .running)
     #expect(state.activeDeviceID == "camera-1")
+    #expect(state.currentOwnerID == "client-1")
     #expect(state.lastError == error)
 }
 
@@ -50,4 +59,19 @@ func permissionStateMapsAVFoundationStatusValues() {
     #expect(PermissionState(authorizationStatus: .restricted) == .restricted)
     #expect(PermissionState(authorizationStatus: .denied) == .denied)
     #expect(PermissionState(authorizationStatus: .authorized) == .authorized)
+}
+
+@Test
+func defaultCameraStateProviderReturnsConfiguredState() {
+    let state = CameraState(
+        permissionState: .authorized,
+        sessionState: .running,
+        previewState: .stopped,
+        activeDeviceID: "camera-1",
+        currentOwnerID: "client-1",
+        lastError: CameraStateError(message: "session failed")
+    )
+    let provider = DefaultCameraStateProvider(state: state)
+
+    #expect(provider.currentCameraState() == state)
 }


### PR DESCRIPTION
## Summary

Implement `GET /v1/session` as the read-only session-state slice before session control work. This adds a centralized Core camera-state provider, exposes a machine-readable session response with state, active device, owner, and last error summary, wires the default provider through `camd`, adds Core/API tests, and documents the endpoint in the API contract.

## Issue

Closes #23
Depends on #21

## Files Changed

- `packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift`
- `packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift`
- `apps/camd/Sources/camd/CameraBridgeDaemon.swift`
- `tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift`
- `tests/CameraBridgeAPITests/CameraBridgeAPITests.swift`
- `docs/api/v1.md`

## Testing

- [ ] `swift build`
- [x] `swift test`
- [ ] Manual verification completed
- [ ] Not run, explained below

Testing notes:
- `swift test`

## Deferred

- Session start/stop, device selection, and capture behavior remain deferred to #24, #25, and #26.
- Device enumeration from #20 is on a separate branch and will need merge resolution when both slices land.
- Protected mutating endpoint implementation from #22 is intentionally not included in this branch.

## AGENTS.md Check

- [x] Scope stayed focused on one issue
- [x] Unrelated files were not changed without cause
- [x] Docs were updated if public behavior changed
