### PR TITLE
Implement session device selection

### DIFF
--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -5,13 +5,20 @@ import Foundation
 struct ServerConfiguration: Sendable, Equatable {
     static let defaultHost = "127.0.0.1"
     static let defaultPort: UInt16 = 8731
+    static let authTokenEnvironmentVariable = "CAMERABRIDGE_AUTH_TOKEN"
 
     var host: String
     var port: UInt16
+    var authToken: String?
 
-    init(host: String = ServerConfiguration.defaultHost, port: UInt16 = ServerConfiguration.defaultPort) {
+    init(
+        host: String = ServerConfiguration.defaultHost,
+        port: UInt16 = ServerConfiguration.defaultPort,
+        authToken: String? = ProcessInfo.processInfo.environment[ServerConfiguration.authTokenEnvironmentVariable]
+    ) {
         self.host = host
         self.port = port
+        self.authToken = authToken
     }
 }
 
@@ -29,30 +36,29 @@ struct CameraBridgeDaemon {
         self.logger = logger
     }
 
-    func makeServer(
-        router: CameraBridgeRouter = CameraBridgeRouter(
+    private func defaultRouter() -> CameraBridgeRouter {
+        let deviceListing = AVFoundationCameraDeviceListing()
+        let sessionController = DefaultCameraSessionController(deviceListing: deviceListing)
+        return CameraBridgeRouter(
             routes: CameraBridgeRoutes.current(
                 permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
-                cameraStateProvider: DefaultCameraStateProvider()
+                cameraStateProvider: sessionController,
+                deviceSelector: sessionController,
+                authorizer: StaticBearerTokenAuthorizer(bearerToken: configuration.authToken)
             )
         )
-    ) -> LocalHTTPServer {
+    }
+
+    func makeServer(router: CameraBridgeRouter? = nil) -> LocalHTTPServer {
         LocalHTTPServer(
             configuration: .init(host: configuration.host, port: configuration.port),
-            router: router,
+            router: router ?? defaultRouter(),
             logger: logger
         )
     }
 
     @discardableResult
-    func start(
-        router: CameraBridgeRouter = CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
-                cameraStateProvider: DefaultCameraStateProvider()
-            )
-        )
-    ) throws -> LocalHTTPServer {
+    func start(router: CameraBridgeRouter? = nil) throws -> LocalHTTPServer {
         logger("starting camd on \(configuration.host):\(configuration.port)")
         let server = makeServer(router: router)
         let port = try server.start()

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -35,6 +35,7 @@ This document defines the early CameraBridge API contract for the v1 service sli
 - successful `POST /v1/session/start` establishes implicit session ownership
 - `POST /v1/session/stop`, `POST /v1/session/select-device`, and `POST /v1/capture/photo` require the current session owner
 - `POST /v1/permissions/request` is token-protected but does not create or transfer session ownership
+- successful `POST /v1/session/select-device` does not create or transfer session ownership
 
 High-level planned error categories for mutating endpoints:
 
@@ -53,7 +54,7 @@ High-level planned error categories for mutating endpoints:
 | `GET /v1/session` | current | read-only session state |
 | `POST /v1/session/start` | planned | token-protected; acquires implicit ownership on success |
 | `POST /v1/session/stop` | planned | token-protected; requires current owner and releases ownership |
-| `POST /v1/session/select-device` | planned | token-protected; follows v1 ownership rules |
+| `POST /v1/session/select-device` | current | token-protected; validates requested device and respects existing ownership |
 | `POST /v1/capture/photo` | planned | token-protected; requires current owner |
 
 ## Fully Specified Early Endpoints
@@ -113,6 +114,51 @@ Response fields:
 - `active_device_id`: selected device identifier, or `null`
 - `owner_id`: current session owner identifier, or `null`
 - `last_error`: last session-related error message, or `null`
+
+### `POST /v1/session/select-device`
+
+Status: `current`
+
+- auth: bearer token required
+- request body:
+
+```json
+{
+  "device_id": "camera-1",
+  "owner_id": "client-1"
+}
+```
+
+Request fields:
+
+- `device_id`: required device identifier to make active
+- `owner_id`: optional caller identity used only for ownership checks when the session already has an owner
+
+Behavior:
+
+- validates `device_id` against the Core device inventory
+- does not auto-start the camera session
+- does not create or transfer ownership
+- if `owner_id` does not match the existing `owner_id`, returns an ownership conflict
+- if no session owner exists yet, device selection may succeed but the response `owner_id` remains unchanged
+
+Successful response: `200 OK`
+
+```json
+{
+  "active_device_id": "camera-1",
+  "last_error": null,
+  "owner_id": null,
+  "state": "stopped"
+}
+```
+
+Error cases:
+
+- `401 unauthorized` when the bearer token is missing or invalid
+- `400 invalid_request` when the body is missing or malformed
+- `409 ownership_conflict` when another owner already controls the session
+- `409 invalid_state` when the requested device is unknown or unavailable
 
 ## Planned Only
 

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -57,11 +57,40 @@ public struct HTTPResponse: Sendable, Equatable {
         )
     }
 
+    public static func error(statusCode: Int, code: String, message: String) -> HTTPResponse {
+        .json(statusCode: statusCode, body: ErrorResponse(error: .init(code: code, message: message)))
+    }
+
     public static func notFound() -> HTTPResponse {
-        .json(
-            statusCode: 404,
-            body: #"{ "error": { "code": "not_found", "message": "Route not found" } }"#
-        )
+        .error(statusCode: 404, code: "not_found", message: "Route not found")
+    }
+
+    public static func badRequest(code: String = "invalid_request", message: String) -> HTTPResponse {
+        .error(statusCode: 400, code: code, message: message)
+    }
+
+    public static func unauthorized() -> HTTPResponse {
+        .error(statusCode: 401, code: "unauthorized", message: "Bearer token missing or invalid")
+    }
+}
+
+public protocol BearerTokenAuthorizing: Sendable {
+    func isAuthorized(request: HTTPRequest) -> Bool
+}
+
+public struct StaticBearerTokenAuthorizer: BearerTokenAuthorizing {
+    public var bearerToken: String?
+
+    public init(bearerToken: String?) {
+        self.bearerToken = bearerToken
+    }
+
+    public func isAuthorized(request: HTTPRequest) -> Bool {
+        guard let bearerToken, !bearerToken.isEmpty else {
+            return false
+        }
+
+        return request.authorizationBearerToken == bearerToken
     }
 }
 
@@ -105,12 +134,15 @@ public struct CameraBridgeRouter: Sendable {
 public enum CameraBridgeRoutes {
     public static func current(
         permissionStatusProvider: any CameraPermissionStatusProviding,
-        cameraStateProvider: any CameraStateProviding
+        cameraStateProvider: any CameraStateProviding,
+        deviceSelector: any CameraDeviceSelecting,
+        authorizer: any BearerTokenAuthorizing
     ) -> [HTTPRoute] {
         [
             health(),
             permissionStatus(provider: permissionStatusProvider),
             sessionState(provider: cameraStateProvider),
+            sessionDeviceSelection(selector: deviceSelector, authorizer: authorizer),
         ]
     }
 
@@ -132,6 +164,51 @@ public enum CameraBridgeRoutes {
     public static func sessionState(provider: any CameraStateProviding) -> HTTPRoute {
         HTTPRoute(method: .get, path: "/v1/session") { _ in
             .json(statusCode: 200, body: SessionStateResponse(state: provider.currentCameraState()))
+        }
+    }
+
+    public static func sessionDeviceSelection(
+        selector: any CameraDeviceSelecting,
+        authorizer: any BearerTokenAuthorizing
+    ) -> HTTPRoute {
+        HTTPRoute(method: .post, path: "/v1/session/select-device") { request in
+            guard authorizer.isAuthorized(request: request) else {
+                return .unauthorized()
+            }
+
+            let selectionRequest: SelectDeviceRequest
+            do {
+                selectionRequest = try JSONDecoder().decode(SelectDeviceRequest.self, from: request.body)
+            } catch {
+                return .badRequest(message: "Request body must be valid JSON")
+            }
+
+            let deviceID = selectionRequest.deviceID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !deviceID.isEmpty else {
+                return .badRequest(message: "device_id is required")
+            }
+
+            do {
+                let state = try selector.selectDevice(id: deviceID, ownerID: selectionRequest.ownerID)
+                return .json(statusCode: 200, body: SessionStateResponse(state: state))
+            } catch let error as CameraDeviceSelectionError {
+                switch error {
+                case .ownershipConflict(let currentOwnerID):
+                    return .error(
+                        statusCode: 409,
+                        code: "ownership_conflict",
+                        message: "Session is owned by \(currentOwnerID)"
+                    )
+                case .unavailableDevice(let id):
+                    return .error(
+                        statusCode: 409,
+                        code: "invalid_state",
+                        message: "Requested device is unavailable: \(id)"
+                    )
+                }
+            } catch {
+                return .error(statusCode: 409, code: "invalid_state", message: "Device selection failed")
+            }
         }
     }
 }
@@ -371,14 +448,46 @@ private enum HTTPResponseSerializer {
 
     private static func reasonPhrase(for statusCode: Int) -> String {
         switch statusCode {
+        case 400:
+            return "Bad Request"
         case 200:
             return "OK"
+        case 401:
+            return "Unauthorized"
+        case 409:
+            return "Conflict"
         case 404:
             return "Not Found"
         default:
             return "Error"
         }
     }
+}
+
+private extension HTTPRequest {
+    var authorizationBearerToken: String? {
+        guard let authorization = headers.first(where: {
+            $0.key.caseInsensitiveCompare("Authorization") == .orderedSame
+        })?.value else {
+            return nil
+        }
+
+        let prefix = "Bearer "
+        guard authorization.hasPrefix(prefix) else {
+            return nil
+        }
+
+        return String(authorization.dropFirst(prefix.count))
+    }
+}
+
+private struct ErrorResponse: Encodable, Equatable {
+    var error: ErrorBody
+}
+
+private struct ErrorBody: Encodable, Equatable {
+    var code: String
+    var message: String
 }
 
 private struct SessionStateResponse: Encodable, Equatable {
@@ -422,5 +531,15 @@ private struct SessionStateResponse: Encodable, Equatable {
         } else {
             try container.encodeNil(forKey: .lastError)
         }
+    }
+}
+
+private struct SelectDeviceRequest: Decodable, Equatable {
+    var deviceID: String
+    var ownerID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case deviceID = "device_id"
+        case ownerID = "owner_id"
     }
 }

--- a/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
+++ b/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
@@ -21,6 +21,24 @@ public enum PreviewState: Sendable, Equatable {
     case running
 }
 
+public enum CameraDevicePosition: String, Sendable, CaseIterable, Equatable {
+    case front
+    case back
+    case external
+}
+
+public struct CameraDevice: Sendable, Equatable {
+    public var id: String
+    public var name: String
+    public var position: CameraDevicePosition
+
+    public init(id: String, name: String, position: CameraDevicePosition) {
+        self.id = id
+        self.name = name
+        self.position = position
+    }
+}
+
 public struct CameraStateError: Error, Sendable, Equatable {
     public let message: String
 
@@ -62,11 +80,50 @@ public protocol CameraStateProviding: Sendable {
     func currentCameraState() -> CameraState
 }
 
+public protocol CameraDeviceListing: Sendable {
+    func availableDevices() -> [CameraDevice]
+}
+
+public protocol CameraDeviceSelecting: Sendable {
+    func selectDevice(id: String, ownerID: String?) throws -> CameraState
+}
+
+public enum CameraDeviceSelectionError: Error, Sendable, Equatable {
+    case ownershipConflict(currentOwnerID: String)
+    case unavailableDevice(id: String)
+}
+
 public struct AVFoundationCameraPermissionStatusProvider: CameraPermissionStatusProviding {
     public init() {}
 
     public func currentPermissionState() -> PermissionState {
         PermissionState(authorizationStatus: AVCaptureDevice.authorizationStatus(for: .video))
+    }
+}
+
+public struct AVFoundationCameraDeviceListing: CameraDeviceListing {
+    public init() {}
+
+    public func availableDevices() -> [CameraDevice] {
+        AVCaptureDevice.DiscoverySession(
+            deviceTypes: [
+                .builtInWideAngleCamera,
+                .continuityCamera,
+                .deskViewCamera,
+                .external,
+            ],
+            mediaType: .video,
+            position: .unspecified
+        )
+        .devices
+        .map(CameraDevice.init(device:))
+        .sorted {
+            if $0.name == $1.name {
+                return $0.id < $1.id
+            }
+
+            return $0.name < $1.name
+        }
     }
 }
 
@@ -79,6 +136,47 @@ public struct DefaultCameraStateProvider: CameraStateProviding {
 
     public func currentCameraState() -> CameraState {
         state
+    }
+}
+
+public final class DefaultCameraSessionController: CameraStateProviding, CameraDeviceSelecting, @unchecked Sendable {
+    private let deviceListing: any CameraDeviceListing
+    private let stateLock = NSLock()
+    private var state: CameraState
+
+    public init(
+        deviceListing: any CameraDeviceListing,
+        initialState: CameraState = CameraState()
+    ) {
+        self.deviceListing = deviceListing
+        self.state = initialState
+    }
+
+    public func currentCameraState() -> CameraState {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return state
+    }
+
+    public func selectDevice(id: String, ownerID: String?) throws -> CameraState {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        if let currentOwnerID = state.currentOwnerID, currentOwnerID != ownerID {
+            let message = "Session is owned by \(currentOwnerID)"
+            state.lastError = CameraStateError(message: message)
+            throw CameraDeviceSelectionError.ownershipConflict(currentOwnerID: currentOwnerID)
+        }
+
+        guard deviceListing.availableDevices().contains(where: { $0.id == id }) else {
+            let message = "Requested device is unavailable: \(id)"
+            state.lastError = CameraStateError(message: message)
+            throw CameraDeviceSelectionError.unavailableDevice(id: id)
+        }
+
+        state.activeDeviceID = id
+        state.lastError = nil
+        return state
     }
 }
 
@@ -96,5 +194,30 @@ extension PermissionState {
         @unknown default:
             self = .denied
         }
+    }
+}
+
+extension CameraDevicePosition {
+    init(position: AVCaptureDevice.Position) {
+        switch position {
+        case .front:
+            self = .front
+        case .back:
+            self = .back
+        case .unspecified:
+            self = .external
+        @unknown default:
+            self = .external
+        }
+    }
+}
+
+private extension CameraDevice {
+    init(device: AVCaptureDevice) {
+        self.init(
+            id: device.uniqueID,
+            name: device.localizedName,
+            position: CameraDevicePosition(position: device.position)
+        )
     }
 }

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -14,17 +14,16 @@ func routerReturnsNotFoundForUnknownRoute() {
     let response = router.response(for: HTTPRequest(method: .get, path: "/missing"))
 
     #expect(response.statusCode == 404)
-    #expect(String(decoding: response.body, as: UTF8.self) == #"{ "error": { "code": "not_found", "message": "Route not found" } }"#)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"not_found","message":"Route not found"}}"#
+    )
 }
 
 @Test
 func routerReturnsHealthResponseForHealthRoute() {
-    let router = CameraBridgeRouter(
-        routes: CameraBridgeRoutes.current(
-            permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
-            cameraStateProvider: FixedCameraStateProvider(state: CameraState())
-        )
-    )
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController)
     let response = router.response(for: HTTPRequest(method: .get, path: "/health"))
 
     #expect(response.statusCode == 200)
@@ -34,14 +33,10 @@ func routerReturnsHealthResponseForHealthRoute() {
 @Test
 func localHTTPServerReturnsHealthResponse() async throws {
     let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController()
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
-                cameraStateProvider: FixedCameraStateProvider(state: CameraState())
-            )
-        )
+        router: makeRouter(sessionController: sessionController)
     )
 
     defer { server.stop() }
@@ -58,14 +53,10 @@ func localHTTPServerReturnsHealthResponse() async throws {
 @Test
 func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
     let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController()
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
-                cameraStateProvider: FixedCameraStateProvider(state: CameraState())
-            )
-        )
+        router: makeRouter(sessionController: sessionController)
     )
 
     defer { server.stop() }
@@ -77,17 +68,16 @@ func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
     let httpResponse = try #require(response as? HTTPURLResponse)
 
     #expect(httpResponse.statusCode == 404)
-    #expect(String(decoding: data, as: UTF8.self) == #"{ "error": { "code": "not_found", "message": "Route not found" } }"#)
+    #expect(
+        String(decoding: data, as: UTF8.self) ==
+        #"{"error":{"code":"not_found","message":"Route not found"}}"#
+    )
 }
 
 @Test(arguments: PermissionState.allCases)
 func routerReturnsPermissionStatusForProviderState(_ state: PermissionState) {
-    let router = CameraBridgeRouter(
-        routes: CameraBridgeRoutes.current(
-            permissionStatusProvider: FixedPermissionStatusProvider(state: state),
-            cameraStateProvider: FixedCameraStateProvider(state: CameraState())
-        )
-    )
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController, permissionState: state)
     let response = router.response(for: HTTPRequest(method: .get, path: "/v1/permissions"))
 
     #expect(response.statusCode == 200)
@@ -97,14 +87,10 @@ func routerReturnsPermissionStatusForProviderState(_ state: PermissionState) {
 @Test
 func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
     let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController()
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted),
-                cameraStateProvider: FixedCameraStateProvider(state: CameraState())
-            )
-        )
+        router: makeRouter(sessionController: sessionController, permissionState: .restricted)
     )
 
     defer { server.stop() }
@@ -120,20 +106,17 @@ func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
 
 @Test
 func routerReturnsSessionStateForSessionRoute() {
-    let state = CameraState(
-        permissionState: .authorized,
-        sessionState: .running,
-        previewState: .stopped,
-        activeDeviceID: "camera-1",
-        currentOwnerID: "client-1",
-        lastError: CameraStateError(message: "session failed")
-    )
-    let router = CameraBridgeRouter(
-        routes: CameraBridgeRoutes.current(
-            permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
-            cameraStateProvider: FixedCameraStateProvider(state: state)
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: CameraStateError(message: "session failed")
         )
     )
+    let router = makeRouter(sessionController: sessionController)
     let response = router.response(for: HTTPRequest(method: .get, path: "/v1/session"))
 
     #expect(response.statusCode == 200)
@@ -146,22 +129,19 @@ func routerReturnsSessionStateForSessionRoute() {
 @Test
 func localHTTPServerReturnsSessionStateWithoutAuth() async throws {
     let port = try reserveEphemeralPort()
-    let state = CameraState(
-        permissionState: .restricted,
-        sessionState: .stopped,
-        previewState: .stopped,
-        activeDeviceID: nil,
-        currentOwnerID: nil,
-        lastError: nil
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .restricted,
+            sessionState: .stopped,
+            previewState: .stopped,
+            activeDeviceID: nil,
+            currentOwnerID: nil,
+            lastError: nil
+        )
     )
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted),
-                cameraStateProvider: FixedCameraStateProvider(state: state)
-            )
-        )
+        router: makeRouter(sessionController: sessionController, permissionState: .restricted)
     )
 
     defer { server.stop() }
@@ -178,6 +158,192 @@ func localHTTPServerReturnsSessionStateWithoutAuth() async throws {
     )
 }
 
+@Test
+func routerRejectsDeviceSelectionWithoutBearerToken() {
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/select-device",
+            body: Data(#"{"device_id":"camera-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 401)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"unauthorized","message":"Bearer token missing or invalid"}}"#
+    )
+    #expect(sessionController.currentCameraState().activeDeviceID == nil)
+}
+
+@Test
+func routerRejectsDeviceSelectionWithMalformedRequestBody() {
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/select-device",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data("not-json".utf8)
+        )
+    )
+
+    #expect(response.statusCode == 400)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_request","message":"Request body must be valid JSON"}}"#
+    )
+}
+
+@Test
+func routerRejectsDeviceSelectionForUnknownDevice() {
+    let sessionController = makeSessionController(
+        state: CameraState(activeDeviceID: "camera-1"),
+        devices: [CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front)]
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/select-device",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"device_id":"camera-2"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_state","message":"Requested device is unavailable: camera-2"}}"#
+    )
+    #expect(sessionController.currentCameraState().activeDeviceID == "camera-1")
+}
+
+@Test
+func routerRejectsDeviceSelectionForOwnerMismatch() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        ),
+        devices: [
+            CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
+        ]
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/select-device",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"device_id":"camera-2","owner_id":"client-2"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"ownership_conflict","message":"Session is owned by client-1"}}"#
+    )
+    #expect(sessionController.currentCameraState().activeDeviceID == "camera-1")
+}
+
+@Test
+func routerReturnsUpdatedSessionStateForAuthorizedDeviceSelection() {
+    let sessionController = makeSessionController(
+        devices: [
+            CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
+        ]
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/select-device",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"device_id":"camera-2"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 200)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"active_device_id":"camera-2","last_error":null,"owner_id":null,"state":"stopped"}"#
+    )
+    #expect(sessionController.currentCameraState().activeDeviceID == "camera-2")
+}
+
+@Test
+func localHTTPServerReturnsUpdatedSessionStateForAuthorizedDeviceSelection() async throws {
+    let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController(
+        devices: [
+            CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
+        ]
+    )
+    let server = LocalHTTPServer(
+        configuration: .init(host: "127.0.0.1", port: port),
+        router: makeRouter(sessionController: sessionController)
+    )
+
+    defer { server.stop() }
+
+    let boundPort = try server.start()
+    var request = URLRequest(
+        url: try #require(URL(string: "http://127.0.0.1:\(boundPort)/v1/session/select-device"))
+    )
+    request.httpMethod = "POST"
+    request.httpBody = Data(#"{"device_id":"camera-2"}"#.utf8)
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("Bearer test-token", forHTTPHeaderField: "Authorization")
+    let (data, response) = try await URLSession.shared.data(for: request)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+
+    #expect(httpResponse.statusCode == 200)
+    #expect(
+        String(decoding: data, as: UTF8.self) ==
+        #"{"active_device_id":"camera-2","last_error":null,"owner_id":null,"state":"stopped"}"#
+    )
+    #expect(sessionController.currentCameraState().activeDeviceID == "camera-2")
+}
+
+private func makeRouter(
+    sessionController: DefaultCameraSessionController,
+    permissionState: PermissionState = .authorized,
+    bearerToken: String = "test-token"
+) -> CameraBridgeRouter {
+    CameraBridgeRouter(
+        routes: CameraBridgeRoutes.current(
+            permissionStatusProvider: FixedPermissionStatusProvider(state: permissionState),
+            cameraStateProvider: sessionController,
+            deviceSelector: sessionController,
+            authorizer: StaticBearerTokenAuthorizer(bearerToken: bearerToken)
+        )
+    )
+}
+
+private func makeSessionController(
+    state: CameraState = CameraState(),
+    devices: [CameraDevice] = [
+        CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+    ]
+) -> DefaultCameraSessionController {
+    DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(devices: devices),
+        initialState: state
+    )
+}
+
 private struct FixedPermissionStatusProvider: CameraPermissionStatusProviding {
     let state: PermissionState
 
@@ -186,11 +352,11 @@ private struct FixedPermissionStatusProvider: CameraPermissionStatusProviding {
     }
 }
 
-private struct FixedCameraStateProvider: CameraStateProviding {
-    let state: CameraState
+private struct FixedDeviceListing: CameraDeviceListing {
+    let devices: [CameraDevice]
 
-    func currentCameraState() -> CameraState {
-        state
+    func availableDevices() -> [CameraDevice] {
+        devices
     }
 }
 

--- a/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
+++ b/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
@@ -34,6 +34,13 @@ func sessionStateRawValuesMatchAPIVocabulary() {
 }
 
 @Test
+func cameraDevicePositionRawValuesMatchAPIVocabulary() {
+    #expect(CameraDevicePosition.front.rawValue == "front")
+    #expect(CameraDevicePosition.back.rawValue == "back")
+    #expect(CameraDevicePosition.external.rawValue == "external")
+}
+
+@Test
 func cameraStateRetainsExplicitValues() {
     let error = CameraStateError(message: "permission unavailable")
     let state = CameraState(
@@ -62,6 +69,22 @@ func permissionStateMapsAVFoundationStatusValues() {
 }
 
 @Test
+func cameraDeviceRetainsExplicitValues() {
+    let device = CameraDevice(id: "camera-1", name: "Desk Camera", position: .external)
+
+    #expect(device.id == "camera-1")
+    #expect(device.name == "Desk Camera")
+    #expect(device.position == .external)
+}
+
+@Test
+func cameraDevicePositionMapsAVFoundationPositionValues() {
+    #expect(CameraDevicePosition(position: .front) == .front)
+    #expect(CameraDevicePosition(position: .back) == .back)
+    #expect(CameraDevicePosition(position: .unspecified) == .external)
+}
+
+@Test
 func defaultCameraStateProviderReturnsConfiguredState() {
     let state = CameraState(
         permissionState: .authorized,
@@ -74,4 +97,89 @@ func defaultCameraStateProviderReturnsConfiguredState() {
     let provider = DefaultCameraStateProvider(state: state)
 
     #expect(provider.currentCameraState() == state)
+}
+
+@Test
+func defaultCameraSessionControllerSelectsAvailableDevice() throws {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+                CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
+            ]
+        )
+    )
+
+    let state = try controller.selectDevice(id: "camera-2", ownerID: nil)
+
+    #expect(state.activeDeviceID == "camera-2")
+    #expect(state.currentOwnerID == nil)
+    #expect(state.lastError == nil)
+    #expect(controller.currentCameraState().activeDeviceID == "camera-2")
+}
+
+@Test
+func defaultCameraSessionControllerRejectsUnavailableDevice() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        initialState: CameraState(activeDeviceID: "camera-1")
+    )
+
+    do {
+        _ = try controller.selectDevice(id: "missing-camera", ownerID: nil)
+        Issue.record("Expected unavailable device selection to fail")
+    } catch let error as CameraDeviceSelectionError {
+        #expect(error == .unavailableDevice(id: "missing-camera"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    let state = controller.currentCameraState()
+    #expect(state.activeDeviceID == "camera-1")
+    #expect(state.lastError == CameraStateError(message: "Requested device is unavailable: missing-camera"))
+}
+
+@Test
+func defaultCameraSessionControllerRejectsMismatchedOwner() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.selectDevice(id: "camera-1", ownerID: "client-2")
+        Issue.record("Expected owner mismatch to fail")
+    } catch let error as CameraDeviceSelectionError {
+        #expect(error == .ownershipConflict(currentOwnerID: "client-1"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    let state = controller.currentCameraState()
+    #expect(state.activeDeviceID == "camera-1")
+    #expect(state.currentOwnerID == "client-1")
+    #expect(state.lastError == CameraStateError(message: "Session is owned by client-1"))
+}
+
+private struct FixedDeviceListing: CameraDeviceListing {
+    let devices: [CameraDevice]
+
+    func availableDevices() -> [CameraDevice] {
+        devices
+    }
 }


### PR DESCRIPTION
## Summary
- add Core device inventory and in-memory session selection behavior
- add authenticated `POST /v1/session/select-device` with ownership and device validation
- wire daemon auth token and shared session state, with docs and tests for the new endpoint

## Files Changed
- `packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift`
- `packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift`
- `apps/camd/Sources/camd/CameraBridgeDaemon.swift`
- `tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift`
- `tests/CameraBridgeAPITests/CameraBridgeAPITests.swift`
- `docs/api/v1.md`

## How Tested
- `swift test`
- `git diff --check`

## Intentionally Deferred
- session start/stop ownership establishment
- public `GET /v1/devices` route work remains separate from this slice
- preview and capture behavior remain out of scope