### PR TITLE
Implement session start and stop endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ This repository is intentionally scaffolded with strict package boundaries:
 - `docs/` for RFCs and API documentation
 - `examples/` for small example clients
 
-The repository currently includes the earliest daemon and API slices, with the
-remaining v1 surface defined in the docs.
+The repository currently includes early daemon and API slices for health,
+permission status, session state, device selection, and basic session
+lifecycle control, with the remaining v1 surface defined in the docs.
 
 ## v1 Auth And Ownership
 

--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -44,6 +44,8 @@ struct CameraBridgeDaemon {
                 permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
                 cameraStateProvider: sessionController,
                 deviceSelector: sessionController,
+                sessionStarter: sessionController,
+                sessionStopper: sessionController,
                 authorizer: StaticBearerTokenAuthorizer(bearerToken: configuration.authToken)
             )
         )

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -33,6 +33,7 @@ This document defines the early CameraBridge API contract for the v1 service sli
 - all planned mutating endpoints require a bearer token or equivalent local secret
 - v1 does not add separate `claim` or `release` endpoints
 - successful `POST /v1/session/start` establishes implicit session ownership
+- successful `POST /v1/session/stop` releases implicit session ownership
 - `POST /v1/session/stop`, `POST /v1/session/select-device`, and `POST /v1/capture/photo` require the current session owner
 - `POST /v1/permissions/request` is token-protected but does not create or transfer session ownership
 - successful `POST /v1/session/select-device` does not create or transfer session ownership
@@ -52,8 +53,8 @@ High-level planned error categories for mutating endpoints:
 | `POST /v1/permissions/request` | planned | token-protected; no session ownership effect |
 | `GET /v1/devices` | planned | deferred |
 | `GET /v1/session` | current | read-only session state |
-| `POST /v1/session/start` | planned | token-protected; acquires implicit ownership on success |
-| `POST /v1/session/stop` | planned | token-protected; requires current owner and releases ownership |
+| `POST /v1/session/start` | current | token-protected; requires selected device and acquires implicit ownership on success |
+| `POST /v1/session/stop` | current | token-protected; requires current owner and releases ownership |
 | `POST /v1/session/select-device` | current | token-protected; validates requested device and respects existing ownership |
 | `POST /v1/capture/photo` | planned | token-protected; requires current owner |
 
@@ -114,6 +115,91 @@ Response fields:
 - `active_device_id`: selected device identifier, or `null`
 - `owner_id`: current session owner identifier, or `null`
 - `last_error`: last session-related error message, or `null`
+
+### `POST /v1/session/start`
+
+Status: `current`
+
+- auth: bearer token required
+- request body:
+
+```json
+{
+  "owner_id": "client-1"
+}
+```
+
+Request fields:
+
+- `owner_id`: required caller identity used to establish session ownership on success
+
+Behavior:
+
+- requires camera permission state `authorized`
+- requires a previously selected `active_device_id`
+- does not implicitly pick or change the active device
+- successful start sets `state` to `running` and `owner_id` to the provided caller identity
+- if another owner already holds the session, returns an ownership conflict
+
+Successful response: `200 OK`
+
+```json
+{
+  "active_device_id": "camera-1",
+  "last_error": null,
+  "owner_id": "client-1",
+  "state": "running"
+}
+```
+
+Error cases:
+
+- `401 unauthorized` when the bearer token is missing or invalid
+- `400 invalid_request` when the body is missing, malformed, or `owner_id` is blank
+- `409 ownership_conflict` when another owner already controls the session
+- `409 invalid_state` when permission is not authorized, no active device is selected, or the session is already running
+
+### `POST /v1/session/stop`
+
+Status: `current`
+
+- auth: bearer token required
+- request body:
+
+```json
+{
+  "owner_id": "client-1"
+}
+```
+
+Request fields:
+
+- `owner_id`: required caller identity that must match the current session owner
+
+Behavior:
+
+- requires the session to already be `running`
+- requires the provided `owner_id` to match the current session owner
+- successful stop sets `state` to `stopped` and clears `owner_id`
+- successful stop preserves `active_device_id` for a later restart
+
+Successful response: `200 OK`
+
+```json
+{
+  "active_device_id": "camera-1",
+  "last_error": null,
+  "owner_id": null,
+  "state": "stopped"
+}
+```
+
+Error cases:
+
+- `401 unauthorized` when the bearer token is missing or invalid
+- `400 invalid_request` when the body is missing, malformed, or `owner_id` is blank
+- `409 ownership_conflict` when another owner already controls the running session
+- `409 invalid_state` when the session is already stopped or otherwise not in a stoppable state
 
 ### `POST /v1/session/select-device`
 

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -136,12 +136,20 @@ public enum CameraBridgeRoutes {
         permissionStatusProvider: any CameraPermissionStatusProviding,
         cameraStateProvider: any CameraStateProviding,
         deviceSelector: any CameraDeviceSelecting,
+        sessionStarter: any CameraSessionStarting,
+        sessionStopper: any CameraSessionStopping,
         authorizer: any BearerTokenAuthorizing
     ) -> [HTTPRoute] {
         [
             health(),
             permissionStatus(provider: permissionStatusProvider),
             sessionState(provider: cameraStateProvider),
+            sessionStart(
+                starter: sessionStarter,
+                permissionStatusProvider: permissionStatusProvider,
+                authorizer: authorizer
+            ),
+            sessionStop(stopper: sessionStopper, authorizer: authorizer),
             sessionDeviceSelection(selector: deviceSelector, authorizer: authorizer),
         ]
     }
@@ -164,6 +172,74 @@ public enum CameraBridgeRoutes {
     public static func sessionState(provider: any CameraStateProviding) -> HTTPRoute {
         HTTPRoute(method: .get, path: "/v1/session") { _ in
             .json(statusCode: 200, body: SessionStateResponse(state: provider.currentCameraState()))
+        }
+    }
+
+    public static func sessionStart(
+        starter: any CameraSessionStarting,
+        permissionStatusProvider: any CameraPermissionStatusProviding,
+        authorizer: any BearerTokenAuthorizing
+    ) -> HTTPRoute {
+        HTTPRoute(method: .post, path: "/v1/session/start") { request in
+            guard authorizer.isAuthorized(request: request) else {
+                return .unauthorized()
+            }
+
+            let ownerRequest: SessionOwnerRequest
+            do {
+                ownerRequest = try JSONDecoder().decode(SessionOwnerRequest.self, from: request.body)
+            } catch {
+                return .badRequest(message: "Request body must be valid JSON")
+            }
+
+            let ownerID = ownerRequest.ownerID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !ownerID.isEmpty else {
+                return .badRequest(message: "owner_id is required")
+            }
+
+            do {
+                let state = try starter.startSession(
+                    ownerID: ownerID,
+                    permissionState: permissionStatusProvider.currentPermissionState()
+                )
+                return .json(statusCode: 200, body: SessionStateResponse(state: state))
+            } catch let error as CameraSessionLifecycleError {
+                return sessionLifecycleErrorResponse(error)
+            } catch {
+                return .error(statusCode: 409, code: "invalid_state", message: "Session start failed")
+            }
+        }
+    }
+
+    public static func sessionStop(
+        stopper: any CameraSessionStopping,
+        authorizer: any BearerTokenAuthorizing
+    ) -> HTTPRoute {
+        HTTPRoute(method: .post, path: "/v1/session/stop") { request in
+            guard authorizer.isAuthorized(request: request) else {
+                return .unauthorized()
+            }
+
+            let ownerRequest: SessionOwnerRequest
+            do {
+                ownerRequest = try JSONDecoder().decode(SessionOwnerRequest.self, from: request.body)
+            } catch {
+                return .badRequest(message: "Request body must be valid JSON")
+            }
+
+            let ownerID = ownerRequest.ownerID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !ownerID.isEmpty else {
+                return .badRequest(message: "owner_id is required")
+            }
+
+            do {
+                let state = try stopper.stopSession(ownerID: ownerID)
+                return .json(statusCode: 200, body: SessionStateResponse(state: state))
+            } catch let error as CameraSessionLifecycleError {
+                return sessionLifecycleErrorResponse(error)
+            } catch {
+                return .error(statusCode: 409, code: "invalid_state", message: "Session stop failed")
+            }
         }
     }
 
@@ -210,6 +286,35 @@ public enum CameraBridgeRoutes {
                 return .error(statusCode: 409, code: "invalid_state", message: "Device selection failed")
             }
         }
+    }
+}
+
+private func sessionLifecycleErrorResponse(_ error: CameraSessionLifecycleError) -> HTTPResponse {
+    switch error {
+    case .ownershipConflict(let currentOwnerID):
+        return .error(
+            statusCode: 409,
+            code: "ownership_conflict",
+            message: "Session is owned by \(currentOwnerID)"
+        )
+    case .permissionRequired(let status):
+        return .error(
+            statusCode: 409,
+            code: "invalid_state",
+            message: "Camera permission is \(status.rawValue)"
+        )
+    case .missingActiveDevice:
+        return .error(
+            statusCode: 409,
+            code: "invalid_state",
+            message: "Cannot start session without an active device"
+        )
+    case .alreadyRunning:
+        return .error(statusCode: 409, code: "invalid_state", message: "Session is already running")
+    case .alreadyStopped:
+        return .error(statusCode: 409, code: "invalid_state", message: "Session is already stopped")
+    case .missingOwner:
+        return .error(statusCode: 409, code: "invalid_state", message: "Running session has no owner")
     }
 }
 
@@ -540,6 +645,14 @@ private struct SelectDeviceRequest: Decodable, Equatable {
 
     enum CodingKeys: String, CodingKey {
         case deviceID = "device_id"
+        case ownerID = "owner_id"
+    }
+}
+
+private struct SessionOwnerRequest: Decodable, Equatable {
+    var ownerID: String
+
+    enum CodingKeys: String, CodingKey {
         case ownerID = "owner_id"
     }
 }

--- a/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
+++ b/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
@@ -88,9 +88,26 @@ public protocol CameraDeviceSelecting: Sendable {
     func selectDevice(id: String, ownerID: String?) throws -> CameraState
 }
 
+public protocol CameraSessionStarting: Sendable {
+    func startSession(ownerID: String, permissionState: PermissionState) throws -> CameraState
+}
+
+public protocol CameraSessionStopping: Sendable {
+    func stopSession(ownerID: String) throws -> CameraState
+}
+
 public enum CameraDeviceSelectionError: Error, Sendable, Equatable {
     case ownershipConflict(currentOwnerID: String)
     case unavailableDevice(id: String)
+}
+
+public enum CameraSessionLifecycleError: Error, Sendable, Equatable {
+    case ownershipConflict(currentOwnerID: String)
+    case permissionRequired(status: PermissionState)
+    case missingActiveDevice
+    case alreadyRunning
+    case alreadyStopped
+    case missingOwner
 }
 
 public struct AVFoundationCameraPermissionStatusProvider: CameraPermissionStatusProviding {
@@ -139,7 +156,7 @@ public struct DefaultCameraStateProvider: CameraStateProviding {
     }
 }
 
-public final class DefaultCameraSessionController: CameraStateProviding, CameraDeviceSelecting, @unchecked Sendable {
+public final class DefaultCameraSessionController: CameraStateProviding, CameraDeviceSelecting, CameraSessionStarting, CameraSessionStopping, @unchecked Sendable {
     private let deviceListing: any CameraDeviceListing
     private let stateLock = NSLock()
     private var state: CameraState
@@ -175,6 +192,71 @@ public final class DefaultCameraSessionController: CameraStateProviding, CameraD
         }
 
         state.activeDeviceID = id
+        state.lastError = nil
+        return state
+    }
+
+    public func startSession(ownerID: String, permissionState: PermissionState) throws -> CameraState {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        state.permissionState = permissionState
+
+        if let currentOwnerID = state.currentOwnerID, currentOwnerID != ownerID {
+            let message = "Session is owned by \(currentOwnerID)"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.ownershipConflict(currentOwnerID: currentOwnerID)
+        }
+
+        guard permissionState == .authorized else {
+            let message = "Camera permission is \(permissionState.rawValue)"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.permissionRequired(status: permissionState)
+        }
+
+        guard state.activeDeviceID != nil else {
+            let message = "Cannot start session without an active device"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.missingActiveDevice
+        }
+
+        guard state.sessionState != .running else {
+            let message = "Session is already running"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.alreadyRunning
+        }
+
+        state.sessionState = .running
+        state.currentOwnerID = ownerID
+        state.lastError = nil
+        return state
+    }
+
+    public func stopSession(ownerID: String) throws -> CameraState {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        guard state.sessionState == .running else {
+            let message = "Session is already stopped"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.alreadyStopped
+        }
+
+        guard let currentOwnerID = state.currentOwnerID else {
+            let message = "Running session has no owner"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.missingOwner
+        }
+
+        guard currentOwnerID == ownerID else {
+            let message = "Session is owned by \(currentOwnerID)"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.ownershipConflict(currentOwnerID: currentOwnerID)
+        }
+
+        state.sessionState = .stopped
+        state.previewState = .stopped
+        state.currentOwnerID = nil
         state.lastError = nil
         return state
     }

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -159,6 +159,219 @@ func localHTTPServerReturnsSessionStateWithoutAuth() async throws {
 }
 
 @Test
+func routerRejectsSessionStartWithoutBearerToken() {
+    let sessionController = makeSessionController(
+        state: CameraState(activeDeviceID: "camera-1")
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/start",
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 401)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"unauthorized","message":"Bearer token missing or invalid"}}"#
+    )
+}
+
+@Test
+func routerRejectsSessionStartWithoutOwnerID() {
+    let sessionController = makeSessionController(
+        state: CameraState(activeDeviceID: "camera-1")
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/start",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":" "}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 400)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_request","message":"owner_id is required"}}"#
+    )
+}
+
+@Test
+func routerRejectsSessionStartWithoutSelectedDevice() {
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/start",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_state","message":"Cannot start session without an active device"}}"#
+    )
+}
+
+@Test
+func routerRejectsSessionStartWithoutAuthorizedPermission() {
+    let sessionController = makeSessionController(
+        state: CameraState(activeDeviceID: "camera-1")
+    )
+    let router = makeRouter(sessionController: sessionController, permissionState: .denied)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/start",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_state","message":"Camera permission is denied"}}"#
+    )
+}
+
+@Test
+func routerReturnsRunningSessionForAuthorizedSessionStart() {
+    let sessionController = makeSessionController(
+        state: CameraState(activeDeviceID: "camera-1")
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/start",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 200)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"active_device_id":"camera-1","last_error":null,"owner_id":"client-1","state":"running"}"#
+    )
+    #expect(sessionController.currentCameraState().sessionState == .running)
+    #expect(sessionController.currentCameraState().currentOwnerID == "client-1")
+}
+
+@Test
+func routerRejectsSessionStopWithoutBearerToken() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/stop",
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 401)
+}
+
+@Test
+func routerRejectsSessionStopWhenAlreadyStopped() {
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/stop",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_state","message":"Session is already stopped"}}"#
+    )
+}
+
+@Test
+func routerRejectsSessionStopForOwnerMismatch() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/stop",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-2"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"ownership_conflict","message":"Session is owned by client-1"}}"#
+    )
+}
+
+@Test
+func routerReturnsStoppedSessionForAuthorizedSessionStop() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .running,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/stop",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 200)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"active_device_id":"camera-1","last_error":null,"owner_id":null,"state":"stopped"}"#
+    )
+    #expect(sessionController.currentCameraState().sessionState == .stopped)
+    #expect(sessionController.currentCameraState().currentOwnerID == nil)
+}
+
+@Test
 func routerRejectsDeviceSelectionWithoutBearerToken() {
     let sessionController = makeSessionController()
     let router = makeRouter(sessionController: sessionController)
@@ -317,6 +530,54 @@ func localHTTPServerReturnsUpdatedSessionStateForAuthorizedDeviceSelection() asy
     #expect(sessionController.currentCameraState().activeDeviceID == "camera-2")
 }
 
+@Test
+func localHTTPServerSupportsSessionStartThenStop() async throws {
+    let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController(
+        state: CameraState(activeDeviceID: "camera-1")
+    )
+    let server = LocalHTTPServer(
+        configuration: .init(host: "127.0.0.1", port: port),
+        router: makeRouter(sessionController: sessionController)
+    )
+
+    defer { server.stop() }
+
+    let boundPort = try server.start()
+
+    var startRequest = URLRequest(
+        url: try #require(URL(string: "http://127.0.0.1:\(boundPort)/v1/session/start"))
+    )
+    startRequest.httpMethod = "POST"
+    startRequest.httpBody = Data(#"{"owner_id":"client-1"}"#.utf8)
+    startRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    startRequest.setValue("Bearer test-token", forHTTPHeaderField: "Authorization")
+    let (startData, startResponse) = try await URLSession.shared.data(for: startRequest)
+    let startHTTPResponse = try #require(startResponse as? HTTPURLResponse)
+
+    #expect(startHTTPResponse.statusCode == 200)
+    #expect(
+        String(decoding: startData, as: UTF8.self) ==
+        #"{"active_device_id":"camera-1","last_error":null,"owner_id":"client-1","state":"running"}"#
+    )
+
+    var stopRequest = URLRequest(
+        url: try #require(URL(string: "http://127.0.0.1:\(boundPort)/v1/session/stop"))
+    )
+    stopRequest.httpMethod = "POST"
+    stopRequest.httpBody = Data(#"{"owner_id":"client-1"}"#.utf8)
+    stopRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    stopRequest.setValue("Bearer test-token", forHTTPHeaderField: "Authorization")
+    let (stopData, stopResponse) = try await URLSession.shared.data(for: stopRequest)
+    let stopHTTPResponse = try #require(stopResponse as? HTTPURLResponse)
+
+    #expect(stopHTTPResponse.statusCode == 200)
+    #expect(
+        String(decoding: stopData, as: UTF8.self) ==
+        #"{"active_device_id":"camera-1","last_error":null,"owner_id":null,"state":"stopped"}"#
+    )
+}
+
 private func makeRouter(
     sessionController: DefaultCameraSessionController,
     permissionState: PermissionState = .authorized,
@@ -327,6 +588,8 @@ private func makeRouter(
             permissionStatusProvider: FixedPermissionStatusProvider(state: permissionState),
             cameraStateProvider: sessionController,
             deviceSelector: sessionController,
+            sessionStarter: sessionController,
+            sessionStopper: sessionController,
             authorizer: StaticBearerTokenAuthorizer(bearerToken: bearerToken)
         )
     )

--- a/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
+++ b/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
@@ -176,6 +176,185 @@ func defaultCameraSessionControllerRejectsMismatchedOwner() {
     #expect(state.lastError == CameraStateError(message: "Session is owned by client-1"))
 }
 
+@Test
+func defaultCameraSessionControllerStartsSessionWithSelectedDeviceAndOwner() throws {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        initialState: CameraState(
+            permissionState: .notDetermined,
+            sessionState: .stopped,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: nil,
+            lastError: nil
+        )
+    )
+
+    let state = try controller.startSession(ownerID: "client-1", permissionState: .authorized)
+
+    #expect(state.permissionState == .authorized)
+    #expect(state.sessionState == .running)
+    #expect(state.activeDeviceID == "camera-1")
+    #expect(state.currentOwnerID == "client-1")
+    #expect(state.lastError == nil)
+}
+
+@Test
+func defaultCameraSessionControllerRejectsStartWithoutActiveDevice() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        )
+    )
+
+    do {
+        _ = try controller.startSession(ownerID: "client-1", permissionState: .authorized)
+        Issue.record("Expected session start without device to fail")
+    } catch let error as CameraSessionLifecycleError {
+        #expect(error == .missingActiveDevice)
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    let state = controller.currentCameraState()
+    #expect(state.sessionState == .stopped)
+    #expect(state.currentOwnerID == nil)
+    #expect(state.lastError == CameraStateError(message: "Cannot start session without an active device"))
+}
+
+@Test
+func defaultCameraSessionControllerRejectsStartWithoutAuthorizedPermission() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        initialState: CameraState(activeDeviceID: "camera-1")
+    )
+
+    do {
+        _ = try controller.startSession(ownerID: "client-1", permissionState: .denied)
+        Issue.record("Expected session start without permission to fail")
+    } catch let error as CameraSessionLifecycleError {
+        #expect(error == .permissionRequired(status: .denied))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    let state = controller.currentCameraState()
+    #expect(state.permissionState == .denied)
+    #expect(state.sessionState == .stopped)
+    #expect(state.lastError == CameraStateError(message: "Camera permission is denied"))
+}
+
+@Test
+func defaultCameraSessionControllerRejectsStartForOwnerConflict() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .stopped,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.startSession(ownerID: "client-2", permissionState: .authorized)
+        Issue.record("Expected owner conflict on start")
+    } catch let error as CameraSessionLifecycleError {
+        #expect(error == .ownershipConflict(currentOwnerID: "client-1"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(controller.currentCameraState().lastError == CameraStateError(message: "Session is owned by client-1"))
+}
+
+@Test
+func defaultCameraSessionControllerStopsRunningSessionAndReleasesOwner() throws {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .running,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    let state = try controller.stopSession(ownerID: "client-1")
+
+    #expect(state.sessionState == .stopped)
+    #expect(state.previewState == .stopped)
+    #expect(state.activeDeviceID == "camera-1")
+    #expect(state.currentOwnerID == nil)
+    #expect(state.lastError == nil)
+}
+
+@Test
+func defaultCameraSessionControllerRejectsStopWhenAlreadyStopped() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(devices: [])
+    )
+
+    do {
+        _ = try controller.stopSession(ownerID: "client-1")
+        Issue.record("Expected stop on stopped session to fail")
+    } catch let error as CameraSessionLifecycleError {
+        #expect(error == .alreadyStopped)
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(controller.currentCameraState().lastError == CameraStateError(message: "Session is already stopped"))
+}
+
+@Test
+func defaultCameraSessionControllerRejectsStopForOwnerMismatch() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(devices: []),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.stopSession(ownerID: "client-2")
+        Issue.record("Expected owner conflict on stop")
+    } catch let error as CameraSessionLifecycleError {
+        #expect(error == .ownershipConflict(currentOwnerID: "client-1"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(controller.currentCameraState().lastError == CameraStateError(message: "Session is owned by client-1"))
+}
+
 private struct FixedDeviceListing: CameraDeviceListing {
     let devices: [CameraDevice]
 


### PR DESCRIPTION
## Summary
- add Core session lifecycle transitions for start and stop with explicit ownership and invalid-state errors
- add authenticated `POST /v1/session/start` and `POST /v1/session/stop` routes backed by the shared session controller
- update tests and docs for lifecycle behavior, and refresh the README slice status

## Files Changed
- `README.md`
- `packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift`
- `packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift`
- `apps/camd/Sources/camd/CameraBridgeDaemon.swift`
- `tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift`
- `tests/CameraBridgeAPITests/CameraBridgeAPITests.swift`
- `docs/api/v1.md`

## How Tested
- `swift test`
- `git diff --check`

## Intentionally Deferred
- real AVFoundation session startup and teardown beyond explicit state transitions
- preview transport and photo capture behavior
- public `GET /v1/devices` remains a separate slice from this stacked branch