### PR TITLE
Implement still photo capture and artifact metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ This repository is intentionally scaffolded with strict package boundaries:
 - `examples/` for small example clients
 
 The repository currently includes early daemon and API slices for health,
-permission status, session state, device selection, and basic session
-lifecycle control, with the remaining v1 surface defined in the docs.
+permission status, session state, device selection, basic session
+lifecycle control, and still photo capture with local artifact metadata,
+with the remaining v1 surface defined in the docs.
 
 ## v1 Auth And Ownership
 

--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -38,7 +38,11 @@ struct CameraBridgeDaemon {
 
     private func defaultRouter() -> CameraBridgeRouter {
         let deviceListing = AVFoundationCameraDeviceListing()
-        let sessionController = DefaultCameraSessionController(deviceListing: deviceListing)
+        let sessionController = DefaultCameraSessionController(
+            deviceListing: deviceListing,
+            photoProducer: AVFoundationStillPhotoProducer(),
+            artifactStore: DefaultPhotoArtifactStore()
+        )
         return CameraBridgeRouter(
             routes: CameraBridgeRoutes.current(
                 permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
@@ -46,6 +50,7 @@ struct CameraBridgeDaemon {
                 deviceSelector: sessionController,
                 sessionStarter: sessionController,
                 sessionStopper: sessionController,
+                photoCapturer: sessionController,
                 authorizer: StaticBearerTokenAuthorizer(bearerToken: configuration.authToken)
             )
         )

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -56,7 +56,7 @@ High-level planned error categories for mutating endpoints:
 | `POST /v1/session/start` | current | token-protected; requires selected device and acquires implicit ownership on success |
 | `POST /v1/session/stop` | current | token-protected; requires current owner and releases ownership |
 | `POST /v1/session/select-device` | current | token-protected; validates requested device and respects existing ownership |
-| `POST /v1/capture/photo` | planned | token-protected; requires current owner |
+| `POST /v1/capture/photo` | current | token-protected; requires current owner and returns local artifact metadata |
 
 ## Fully Specified Early Endpoints
 
@@ -245,6 +245,56 @@ Error cases:
 - `400 invalid_request` when the body is missing or malformed
 - `409 ownership_conflict` when another owner already controls the session
 - `409 invalid_state` when the requested device is unknown or unavailable
+
+### `POST /v1/capture/photo`
+
+Status: `current`
+
+- auth: bearer token required
+- request body:
+
+```json
+{
+  "owner_id": "client-1"
+}
+```
+
+Request fields:
+
+- `owner_id`: required caller identity that must match the current session owner
+
+Behavior:
+
+- requires the session to already be `running`
+- requires the provided `owner_id` to match the current session owner
+- requires an `active_device_id` to already be selected for the running session
+- captures a single still image and stores it under `~/Library/Application Support/CameraBridge/Captures/`
+- returns metadata only; the API does not serve the image bytes directly in v1
+- successful capture does not change `state`, `owner_id`, or `active_device_id`
+
+Successful response: `200 OK`
+
+```json
+{
+  "captured_at": "2026-03-20T22:10:29.123Z",
+  "device_id": "camera-1",
+  "local_path": "/Users/example/Library/Application Support/CameraBridge/Captures/capture-20260320T221029123Z-01234567-89ab-cdef-0123-456789abcdef.jpg"
+}
+```
+
+Response fields:
+
+- `captured_at`: ISO 8601 UTC timestamp for when the service recorded the artifact metadata
+- `device_id`: active device identifier used for the capture
+- `local_path`: absolute local filesystem path to the stored JPEG artifact
+
+Error cases:
+
+- `401 unauthorized` when the bearer token is missing or invalid
+- `400 invalid_request` when the body is missing, malformed, or `owner_id` is blank
+- `409 ownership_conflict` when another owner already controls the running session
+- `409 invalid_state` when the session is not running, has no owner, has no active device, or the selected device is no longer available
+- `500 capture_failed` when AVFoundation capture or artifact persistence fails after request validation
 
 ## Planned Only
 

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -138,6 +138,7 @@ public enum CameraBridgeRoutes {
         deviceSelector: any CameraDeviceSelecting,
         sessionStarter: any CameraSessionStarting,
         sessionStopper: any CameraSessionStopping,
+        photoCapturer: any CameraPhotoCapturing,
         authorizer: any BearerTokenAuthorizing
     ) -> [HTTPRoute] {
         [
@@ -151,6 +152,7 @@ public enum CameraBridgeRoutes {
             ),
             sessionStop(stopper: sessionStopper, authorizer: authorizer),
             sessionDeviceSelection(selector: deviceSelector, authorizer: authorizer),
+            photoCapture(capturer: photoCapturer, authorizer: authorizer),
         ]
     }
 
@@ -287,6 +289,38 @@ public enum CameraBridgeRoutes {
             }
         }
     }
+
+    public static func photoCapture(
+        capturer: any CameraPhotoCapturing,
+        authorizer: any BearerTokenAuthorizing
+    ) -> HTTPRoute {
+        HTTPRoute(method: .post, path: "/v1/capture/photo") { request in
+            guard authorizer.isAuthorized(request: request) else {
+                return .unauthorized()
+            }
+
+            let ownerRequest: SessionOwnerRequest
+            do {
+                ownerRequest = try JSONDecoder().decode(SessionOwnerRequest.self, from: request.body)
+            } catch {
+                return .badRequest(message: "Request body must be valid JSON")
+            }
+
+            let ownerID = ownerRequest.ownerID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !ownerID.isEmpty else {
+                return .badRequest(message: "owner_id is required")
+            }
+
+            do {
+                let artifact = try capturer.capturePhoto(ownerID: ownerID)
+                return .json(statusCode: 200, body: PhotoCaptureResponse(artifact: artifact))
+            } catch let error as CameraPhotoCaptureError {
+                return photoCaptureErrorResponse(error)
+            } catch {
+                return .error(statusCode: 500, code: "capture_failed", message: "Photo capture failed")
+            }
+        }
+    }
 }
 
 private func sessionLifecycleErrorResponse(_ error: CameraSessionLifecycleError) -> HTTPResponse {
@@ -315,6 +349,35 @@ private func sessionLifecycleErrorResponse(_ error: CameraSessionLifecycleError)
         return .error(statusCode: 409, code: "invalid_state", message: "Session is already stopped")
     case .missingOwner:
         return .error(statusCode: 409, code: "invalid_state", message: "Running session has no owner")
+    }
+}
+
+private func photoCaptureErrorResponse(_ error: CameraPhotoCaptureError) -> HTTPResponse {
+    switch error {
+    case .ownershipConflict(let currentOwnerID):
+        return .error(
+            statusCode: 409,
+            code: "ownership_conflict",
+            message: "Session is owned by \(currentOwnerID)"
+        )
+    case .sessionNotRunning:
+        return .error(statusCode: 409, code: "invalid_state", message: "Session is not running")
+    case .missingOwner:
+        return .error(statusCode: 409, code: "invalid_state", message: "Running session has no owner")
+    case .missingActiveDevice:
+        return .error(
+            statusCode: 409,
+            code: "invalid_state",
+            message: "Cannot capture photo without an active device"
+        )
+    case .unavailableDevice(let id):
+        return .error(
+            statusCode: 409,
+            code: "invalid_state",
+            message: "Requested device is unavailable: \(id)"
+        )
+    case .captureFailed(let message):
+        return .error(statusCode: 500, code: "capture_failed", message: message)
     }
 }
 
@@ -639,6 +702,24 @@ private struct SessionStateResponse: Encodable, Equatable {
     }
 }
 
+private struct PhotoCaptureResponse: Encodable, Equatable {
+    var localPath: String
+    var capturedAt: String
+    var deviceID: String
+
+    enum CodingKeys: String, CodingKey {
+        case localPath = "local_path"
+        case capturedAt = "captured_at"
+        case deviceID = "device_id"
+    }
+
+    init(artifact: CapturedPhotoArtifact) {
+        self.localPath = artifact.localPath
+        self.capturedAt = iso8601Timestamp(artifact.capturedAt)
+        self.deviceID = artifact.deviceID
+    }
+}
+
 private struct SelectDeviceRequest: Decodable, Equatable {
     var deviceID: String
     var ownerID: String?
@@ -655,4 +736,10 @@ private struct SessionOwnerRequest: Decodable, Equatable {
     enum CodingKeys: String, CodingKey {
         case ownerID = "owner_id"
     }
+}
+
+private func iso8601Timestamp(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
 }

--- a/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
+++ b/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Foundation
 
 public enum CameraBridgeCoreModule {
     public static let name = "CameraBridgeCore"
@@ -96,6 +97,10 @@ public protocol CameraSessionStopping: Sendable {
     func stopSession(ownerID: String) throws -> CameraState
 }
 
+public protocol CameraPhotoCapturing: Sendable {
+    func capturePhoto(ownerID: String) throws -> CapturedPhotoArtifact
+}
+
 public enum CameraDeviceSelectionError: Error, Sendable, Equatable {
     case ownershipConflict(currentOwnerID: String)
     case unavailableDevice(id: String)
@@ -108,6 +113,35 @@ public enum CameraSessionLifecycleError: Error, Sendable, Equatable {
     case alreadyRunning
     case alreadyStopped
     case missingOwner
+}
+
+public struct CapturedPhotoArtifact: Sendable, Equatable {
+    public var localPath: String
+    public var capturedAt: Date
+    public var deviceID: String
+
+    public init(localPath: String, capturedAt: Date, deviceID: String) {
+        self.localPath = localPath
+        self.capturedAt = capturedAt
+        self.deviceID = deviceID
+    }
+}
+
+public enum CameraPhotoCaptureError: Error, Sendable, Equatable {
+    case ownershipConflict(currentOwnerID: String)
+    case sessionNotRunning
+    case missingOwner
+    case missingActiveDevice
+    case unavailableDevice(id: String)
+    case captureFailed(message: String)
+}
+
+public protocol CameraStillPhotoProducing: Sendable {
+    func capturePhotoData(deviceID: String) throws -> Data
+}
+
+public protocol PhotoArtifactStoring: Sendable {
+    func storePhotoData(_ data: Data, deviceID: String, capturedAt: Date) throws -> URL
 }
 
 public struct AVFoundationCameraPermissionStatusProvider: CameraPermissionStatusProviding {
@@ -144,6 +178,122 @@ public struct AVFoundationCameraDeviceListing: CameraDeviceListing {
     }
 }
 
+public struct DefaultPhotoArtifactStore: PhotoArtifactStoring {
+    public var baseDirectoryURL: URL
+
+    public init(baseDirectoryURL: URL? = nil) {
+        self.baseDirectoryURL = baseDirectoryURL ?? Self.defaultBaseDirectoryURL()
+    }
+
+    public func storePhotoData(_ data: Data, deviceID: String, capturedAt: Date) throws -> URL {
+        try FileManager.default.createDirectory(
+            at: baseDirectoryURL,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        let fileURL = baseDirectoryURL.appendingPathComponent(
+            "capture-\(Self.filenameTimestamp(from: capturedAt))-\(UUID().uuidString.lowercased()).jpg",
+            isDirectory: false
+        )
+        try data.write(to: fileURL, options: .atomic)
+        return fileURL
+    }
+
+    private static func defaultBaseDirectoryURL() -> URL {
+        let applicationSupportURL =
+            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ??
+            URL(fileURLWithPath: NSHomeDirectory())
+                .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return applicationSupportURL
+            .appendingPathComponent("CameraBridge", isDirectory: true)
+            .appendingPathComponent("Captures", isDirectory: true)
+    }
+
+    private static func filenameTimestamp(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd'T'HHmmssSSS'Z'"
+        return formatter.string(from: date)
+    }
+}
+
+public struct UnimplementedStillPhotoProducer: CameraStillPhotoProducing {
+    public init() {}
+
+    public func capturePhotoData(deviceID: String) throws -> Data {
+        throw CameraPhotoCaptureError.captureFailed(message: "Still photo capture is not configured")
+    }
+}
+
+public struct AVFoundationStillPhotoProducer: CameraStillPhotoProducing {
+    public var timeout: TimeInterval
+
+    public init(timeout: TimeInterval = 10) {
+        self.timeout = timeout
+    }
+
+    public func capturePhotoData(deviceID: String) throws -> Data {
+        guard let device = discoverDevice(id: deviceID) else {
+            throw CameraPhotoCaptureError.unavailableDevice(id: deviceID)
+        }
+
+        let session = AVCaptureSession()
+        session.beginConfiguration()
+        session.sessionPreset = .photo
+
+        let input: AVCaptureDeviceInput
+        do {
+            input = try AVCaptureDeviceInput(device: device)
+        } catch {
+            throw CameraPhotoCaptureError.captureFailed(message: "Unable to create AVCaptureDeviceInput")
+        }
+
+        guard session.canAddInput(input) else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Unable to add camera input to capture session")
+        }
+
+        let output = AVCapturePhotoOutput()
+        guard session.canAddOutput(output) else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Unable to add photo output to capture session")
+        }
+
+        session.addInput(input)
+        session.addOutput(output)
+        session.commitConfiguration()
+        session.startRunning()
+        defer { session.stopRunning() }
+
+        let delegate = StillPhotoCaptureDelegate()
+        let settings: AVCapturePhotoSettings
+        if output.availablePhotoCodecTypes.contains(.jpeg) {
+            settings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.jpeg])
+        } else {
+            settings = AVCapturePhotoSettings()
+        }
+
+        output.capturePhoto(with: settings, delegate: delegate)
+        return try delegate.waitForPhotoData(timeout: timeout)
+    }
+
+    private func discoverDevice(id: String) -> AVCaptureDevice? {
+        AVCaptureDevice.DiscoverySession(
+            deviceTypes: [
+                .builtInWideAngleCamera,
+                .continuityCamera,
+                .deskViewCamera,
+                .external,
+            ],
+            mediaType: .video,
+            position: .unspecified
+        )
+        .devices
+        .first(where: { $0.uniqueID == id })
+    }
+}
+
 public struct DefaultCameraStateProvider: CameraStateProviding {
     public var state: CameraState
 
@@ -156,16 +306,25 @@ public struct DefaultCameraStateProvider: CameraStateProviding {
     }
 }
 
-public final class DefaultCameraSessionController: CameraStateProviding, CameraDeviceSelecting, CameraSessionStarting, CameraSessionStopping, @unchecked Sendable {
+public final class DefaultCameraSessionController: CameraStateProviding, CameraDeviceSelecting, CameraSessionStarting, CameraSessionStopping, CameraPhotoCapturing, @unchecked Sendable {
     private let deviceListing: any CameraDeviceListing
+    private let photoProducer: any CameraStillPhotoProducing
+    private let artifactStore: any PhotoArtifactStoring
+    private let now: @Sendable () -> Date
     private let stateLock = NSLock()
     private var state: CameraState
 
     public init(
         deviceListing: any CameraDeviceListing,
+        photoProducer: any CameraStillPhotoProducing = UnimplementedStillPhotoProducer(),
+        artifactStore: any PhotoArtifactStoring = DefaultPhotoArtifactStore(),
+        now: @escaping @Sendable () -> Date = { Date() },
         initialState: CameraState = CameraState()
     ) {
         self.deviceListing = deviceListing
+        self.photoProducer = photoProducer
+        self.artifactStore = artifactStore
+        self.now = now
         self.state = initialState
     }
 
@@ -260,6 +419,62 @@ public final class DefaultCameraSessionController: CameraStateProviding, CameraD
         state.lastError = nil
         return state
     }
+
+    public func capturePhoto(ownerID: String) throws -> CapturedPhotoArtifact {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        guard state.sessionState == .running else {
+            let error = CameraPhotoCaptureError.sessionNotRunning
+            state.lastError = CameraStateError(message: error.message)
+            throw error
+        }
+
+        guard let currentOwnerID = state.currentOwnerID else {
+            let error = CameraPhotoCaptureError.missingOwner
+            state.lastError = CameraStateError(message: error.message)
+            throw error
+        }
+
+        guard currentOwnerID == ownerID else {
+            let error = CameraPhotoCaptureError.ownershipConflict(currentOwnerID: currentOwnerID)
+            state.lastError = CameraStateError(message: error.message)
+            throw error
+        }
+
+        guard let activeDeviceID = state.activeDeviceID else {
+            let error = CameraPhotoCaptureError.missingActiveDevice
+            state.lastError = CameraStateError(message: error.message)
+            throw error
+        }
+
+        let capturedAt = now()
+
+        do {
+            let data = try photoProducer.capturePhotoData(deviceID: activeDeviceID)
+            let fileURL = try artifactStore.storePhotoData(
+                data,
+                deviceID: activeDeviceID,
+                capturedAt: capturedAt
+            )
+            let artifact = CapturedPhotoArtifact(
+                localPath: fileURL.path,
+                capturedAt: capturedAt,
+                deviceID: activeDeviceID
+            )
+            state.lastError = nil
+            return artifact
+        } catch let error as CameraPhotoCaptureError {
+            state.lastError = CameraStateError(message: error.message)
+            throw error
+        } catch {
+            let captureError = CameraPhotoCaptureError.captureFailed(
+                message: error.localizedDescription
+            )
+            state.lastError = CameraStateError(message: captureError.message)
+            throw captureError
+        }
+    }
 }
 
 extension PermissionState {
@@ -301,5 +516,77 @@ private extension CameraDevice {
             name: device.localizedName,
             position: CameraDevicePosition(position: device.position)
         )
+    }
+}
+
+private extension CameraPhotoCaptureError {
+    var message: String {
+        switch self {
+        case .ownershipConflict(let currentOwnerID):
+            return "Session is owned by \(currentOwnerID)"
+        case .sessionNotRunning:
+            return "Session is not running"
+        case .missingOwner:
+            return "Running session has no owner"
+        case .missingActiveDevice:
+            return "Cannot capture photo without an active device"
+        case .unavailableDevice(let id):
+            return "Requested device is unavailable: \(id)"
+        case .captureFailed(let message):
+            return message
+        }
+    }
+}
+
+private final class StillPhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate, @unchecked Sendable {
+    private let lock = NSLock()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var result: Result<Data, CameraPhotoCaptureError>?
+
+    func photoOutput(
+        _ output: AVCapturePhotoOutput,
+        didFinishProcessingPhoto photo: AVCapturePhoto,
+        error: Error?
+    ) {
+        if let error {
+            complete(with: .failure(.captureFailed(message: error.localizedDescription)))
+            return
+        }
+
+        guard let data = photo.fileDataRepresentation() else {
+            complete(with: .failure(.captureFailed(message: "AVFoundation did not produce photo data")))
+            return
+        }
+
+        complete(with: .success(data))
+    }
+
+    func waitForPhotoData(timeout: TimeInterval) throws -> Data {
+        let waitResult = semaphore.wait(timeout: .now() + timeout)
+        guard waitResult == .success else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Photo capture timed out")
+        }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let result else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Photo capture finished without a result")
+        }
+
+        return try result.get()
+    }
+
+    private func complete(with result: Result<Data, CameraPhotoCaptureError>) {
+        lock.lock()
+        let shouldSignal = self.result == nil
+        if shouldSignal {
+            self.result = result
+        }
+        lock.unlock()
+
+        if shouldSignal {
+            semaphore.signal()
+        }
     }
 }

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -496,6 +496,132 @@ func routerReturnsUpdatedSessionStateForAuthorizedDeviceSelection() {
 }
 
 @Test
+func routerRejectsPhotoCaptureWithoutBearerToken() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/capture/photo",
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 401)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"unauthorized","message":"Bearer token missing or invalid"}}"#
+    )
+}
+
+@Test
+func routerRejectsPhotoCaptureWhenSessionIsStopped() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .stopped,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/capture/photo",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_state","message":"Session is not running"}}"#
+    )
+}
+
+@Test
+func routerRejectsPhotoCaptureForOwnerMismatch() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/capture/photo",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-2"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"ownership_conflict","message":"Session is owned by client-1"}}"#
+    )
+}
+
+@Test
+func routerReturnsPhotoCaptureMetadataForAuthorizedOwner() throws {
+    let directoryURL = makeTemporaryDirectory()
+    let capturedAt = Date(timeIntervalSince1970: 1_710_000_000.123)
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        ),
+        photoProducer: FixedStillPhotoProducer(data: Data([0x01, 0x02, 0x03])),
+        artifactStore: DefaultPhotoArtifactStore(baseDirectoryURL: directoryURL),
+        now: { capturedAt }
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/capture/photo",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 200)
+
+    let payload = try #require(
+        JSONSerialization.jsonObject(with: response.body) as? [String: String]
+    )
+    let localPath = try #require(payload["local_path"])
+    #expect(payload["device_id"] == "camera-1")
+    #expect(payload["captured_at"] == "2024-03-09T16:00:00.123Z")
+    #expect(localPath.hasPrefix(directoryURL.path))
+    #expect(localPath.hasSuffix(".jpg"))
+    #expect(FileManager.default.fileExists(atPath: localPath))
+}
+
+@Test
 func localHTTPServerReturnsUpdatedSessionStateForAuthorizedDeviceSelection() async throws {
     let port = try reserveEphemeralPort()
     let sessionController = makeSessionController(
@@ -590,6 +716,7 @@ private func makeRouter(
             deviceSelector: sessionController,
             sessionStarter: sessionController,
             sessionStopper: sessionController,
+            photoCapturer: sessionController,
             authorizer: StaticBearerTokenAuthorizer(bearerToken: bearerToken)
         )
     )
@@ -599,10 +726,19 @@ private func makeSessionController(
     state: CameraState = CameraState(),
     devices: [CameraDevice] = [
         CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
-    ]
+    ],
+    photoProducer: any CameraStillPhotoProducing = UnimplementedStillPhotoProducer(),
+    artifactStore: any PhotoArtifactStoring = DefaultPhotoArtifactStore(
+        baseDirectoryURL: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("CameraBridgeAPITests", isDirectory: true)
+    ),
+    now: @escaping @Sendable () -> Date = { Date() }
 ) -> DefaultCameraSessionController {
     DefaultCameraSessionController(
         deviceListing: FixedDeviceListing(devices: devices),
+        photoProducer: photoProducer,
+        artifactStore: artifactStore,
+        now: now,
         initialState: state
     )
 }
@@ -621,6 +757,25 @@ private struct FixedDeviceListing: CameraDeviceListing {
     func availableDevices() -> [CameraDevice] {
         devices
     }
+}
+
+private struct FixedStillPhotoProducer: CameraStillPhotoProducing {
+    let data: Data
+
+    func capturePhotoData(deviceID: String) throws -> Data {
+        data
+    }
+}
+
+private func makeTemporaryDirectory() -> URL {
+    let directoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("CameraBridgeAPITests-\(UUID().uuidString)", isDirectory: true)
+    try! FileManager.default.createDirectory(
+        at: directoryURL,
+        withIntermediateDirectories: true,
+        attributes: nil
+    )
+    return directoryURL
 }
 
 private func reserveEphemeralPort() throws -> UInt16 {

--- a/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
+++ b/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
@@ -1,6 +1,7 @@
+import AVFoundation
+import Foundation
 import Testing
 @testable import CameraBridgeCore
-import AVFoundation
 
 @Test
 func coreModuleNameMatchesTarget() {
@@ -355,10 +356,169 @@ func defaultCameraSessionControllerRejectsStopForOwnerMismatch() {
     #expect(controller.currentCameraState().lastError == CameraStateError(message: "Session is owned by client-1"))
 }
 
+@Test
+func defaultPhotoArtifactStoreWritesPhotoDataToConfiguredDirectory() throws {
+    let directoryURL = makeTemporaryDirectory()
+    let store = DefaultPhotoArtifactStore(baseDirectoryURL: directoryURL)
+    let capturedAt = Date(timeIntervalSince1970: 1_710_000_000.123)
+    let data = Data([0xFF, 0xD8, 0xFF, 0xD9])
+
+    let fileURL = try store.storePhotoData(data, deviceID: "camera-1", capturedAt: capturedAt)
+
+    #expect(fileURL.path.hasPrefix(directoryURL.path))
+    #expect(fileURL.pathExtension == "jpg")
+    #expect(try Data(contentsOf: fileURL) == data)
+}
+
+@Test
+func defaultCameraSessionControllerCapturesPhotoForRunningOwnedSession() throws {
+    let directoryURL = makeTemporaryDirectory()
+    let capturedAt = Date(timeIntervalSince1970: 1_710_000_000.123)
+    let expectedData = Data([0x01, 0x02, 0x03, 0x04])
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front)]
+        ),
+        photoProducer: FixedStillPhotoProducer(data: expectedData),
+        artifactStore: DefaultPhotoArtifactStore(baseDirectoryURL: directoryURL),
+        now: { capturedAt },
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    let artifact = try controller.capturePhoto(ownerID: "client-1")
+
+    #expect(artifact.deviceID == "camera-1")
+    #expect(artifact.capturedAt == capturedAt)
+    #expect(artifact.localPath.hasPrefix(directoryURL.path))
+    #expect(try Data(contentsOf: URL(fileURLWithPath: artifact.localPath)) == expectedData)
+    #expect(controller.currentCameraState().lastError == nil)
+}
+
+@Test
+func defaultCameraSessionControllerRejectsCaptureWhenSessionIsStopped() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front)]
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .stopped,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.capturePhoto(ownerID: "client-1")
+        Issue.record("Expected photo capture on stopped session to fail")
+    } catch let error as CameraPhotoCaptureError {
+        #expect(error == .sessionNotRunning)
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(controller.currentCameraState().lastError == CameraStateError(message: "Session is not running"))
+}
+
+@Test
+func defaultCameraSessionControllerRejectsCaptureForOwnerMismatch() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front)]
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.capturePhoto(ownerID: "client-2")
+        Issue.record("Expected photo capture owner mismatch to fail")
+    } catch let error as CameraPhotoCaptureError {
+        #expect(error == .ownershipConflict(currentOwnerID: "client-1"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(controller.currentCameraState().lastError == CameraStateError(message: "Session is owned by client-1"))
+}
+
+@Test
+func defaultCameraSessionControllerRetainsCaptureFailureAsLastError() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front)]
+        ),
+        photoProducer: FailingStillPhotoProducer(
+            error: .captureFailed(message: "AVFoundation timed out")
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.capturePhoto(ownerID: "client-1")
+        Issue.record("Expected photo capture failure to surface producer error")
+    } catch let error as CameraPhotoCaptureError {
+        #expect(error == .captureFailed(message: "AVFoundation timed out"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(controller.currentCameraState().lastError == CameraStateError(message: "AVFoundation timed out"))
+}
+
 private struct FixedDeviceListing: CameraDeviceListing {
     let devices: [CameraDevice]
 
     func availableDevices() -> [CameraDevice] {
         devices
     }
+}
+
+private struct FixedStillPhotoProducer: CameraStillPhotoProducing {
+    let data: Data
+
+    func capturePhotoData(deviceID: String) throws -> Data {
+        data
+    }
+}
+
+private struct FailingStillPhotoProducer: CameraStillPhotoProducing {
+    let error: CameraPhotoCaptureError
+
+    func capturePhotoData(deviceID: String) throws -> Data {
+        throw error
+    }
+}
+
+private func makeTemporaryDirectory() -> URL {
+    let directoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("CameraBridgeCoreTests-\(UUID().uuidString)", isDirectory: true)
+    try! FileManager.default.createDirectory(
+        at: directoryURL,
+        withIntermediateDirectories: true,
+        attributes: nil
+    )
+    return directoryURL
 }


### PR DESCRIPTION
Closes #26

## Summary
- add Core still-photo capture abstractions, local artifact storage, and an AVFoundation-backed producer
- expose `POST /v1/capture/photo` and wire the daemon to return artifact metadata
- add Core and API tests and document the capture contract and storage location

## Files Changed
- `packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift`
- `packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift`
- `apps/camd/Sources/camd/CameraBridgeDaemon.swift`
- `tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift`
- `tests/CameraBridgeAPITests/CameraBridgeAPITests.swift`
- `docs/api/v1.md`
- `README.md`

## How It Was Tested
- `swift test`
- `git diff --check`

## Intentionally Deferred
- real hardware/manual verification of the AVFoundation capture path
- preview, streaming, and direct file-serving endpoints
