### PR TITLE
Add quick start docs and a minimal capture example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ CameraBridge v1 keeps the trust model intentionally narrow:
 
 ## Docs
 
+- [Quick Start](docs/quick-start.md)
 - [Architecture Overview](docs/architecture-overview.md)
 - [v1 Roadmap](docs/roadmap/v1.md)
 - [API v1 Contract](docs/api/v1.md)
@@ -60,4 +61,31 @@ The packaged app bundle, including the bundled `camd` executable, is written to:
 
 ```text
 $(swift build --show-bin-path)/CameraBridgeApp.app
+```
+
+## First Capture
+
+Follow the full setup and first-capture path in [docs/quick-start.md](docs/quick-start.md).
+
+The shortest successful path is:
+
+1. package and launch `CameraBridgeApp.app`
+2. click `Start Service`
+3. confirm `Permission: authorized`
+4. run the minimal Python example with a real device id from `GET /v1/devices`
+
+```bash
+python3 examples/python/capture_photo.py --device-id "YOUR_DEVICE_ID"
+```
+
+The example reads the bearer token from:
+
+```text
+~/Library/Application Support/CameraBridge/auth-token
+```
+
+and writes captures under:
+
+```text
+~/Library/Application Support/CameraBridge/Captures/
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,140 @@
+# CameraBridge Quick Start
+
+This guide walks through the current working v1 loop on macOS:
+
+1. build the repo
+2. package and launch `CameraBridgeApp`
+3. start the local service and confirm camera permission
+4. run one minimal example client that selects a device, starts a session, captures a still image, and stops the session
+
+## Prerequisites
+
+- macOS 14 or newer
+- Swift 5.10 toolchain available through Xcode or Command Line Tools
+- at least one working local camera device
+
+## Build The Repo
+
+From the repo root:
+
+```bash
+swift build
+swift test
+```
+
+## Package And Launch The App
+
+Package the app bundle:
+
+```bash
+apps/CameraBridgeApp/scripts/package-app.sh
+```
+
+Launch the packaged app:
+
+```bash
+open "$(swift build --show-bin-path)/CameraBridgeApp.app"
+```
+
+You can also open the bundle directly from Finder at:
+
+```text
+$(swift build --show-bin-path)/CameraBridgeApp.app
+```
+
+## Start The Service And Confirm Permission
+
+From the menu bar app:
+
+1. click `Start Service`
+2. confirm the app shows `Service: running`
+3. click `Request Camera Access` if permission is still undecided
+4. confirm the app shows `Permission: authorized`
+
+When the app starts the service, it stores the local bearer token at:
+
+```text
+~/Library/Application Support/CameraBridge/auth-token
+```
+
+Camera captures are stored under:
+
+```text
+~/Library/Application Support/CameraBridge/Captures/
+```
+
+## Verify The Local API
+
+Check the service health and current permission state:
+
+```bash
+curl -s http://127.0.0.1:8731/health
+curl -s http://127.0.0.1:8731/v1/permissions
+curl -s http://127.0.0.1:8731/v1/devices
+```
+
+The mutating endpoints use the bearer token from Application Support:
+
+```bash
+TOKEN="$(cat ~/Library/Application\ Support/CameraBridge/auth-token)"
+```
+
+## Run The Minimal Example Client
+
+The repository includes one minimal Python example with no external dependencies:
+
+```bash
+python3 examples/python/capture_photo.py --device-id "YOUR_DEVICE_ID"
+```
+
+Get a real device id from `GET /v1/devices`. Example output includes:
+
+- selected device response
+- started session response
+- capture metadata including `local_path`
+- stopped session response
+
+Optional arguments:
+
+```bash
+python3 examples/python/capture_photo.py \
+  --device-id "YOUR_DEVICE_ID" \
+  --owner-id "client-1" \
+  --token-file "$HOME/Library/Application Support/CameraBridge/auth-token"
+```
+
+The example is safe to rerun when the same `owner_id` already owns an active session. In that case it stops the existing session first and then repeats the flow.
+
+## Manual Flow Without The Example Script
+
+If you want to exercise the same flow manually:
+
+```bash
+TOKEN="$(cat ~/Library/Application\ Support/CameraBridge/auth-token)"
+
+curl -s -X POST http://127.0.0.1:8731/v1/session/select-device \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"device_id":"YOUR_DEVICE_ID","owner_id":"client-1"}'
+
+curl -s -X POST http://127.0.0.1:8731/v1/session/start \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"owner_id":"client-1"}'
+
+curl -s -X POST http://127.0.0.1:8731/v1/capture/photo \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"owner_id":"client-1"}'
+
+curl -s -X POST http://127.0.0.1:8731/v1/session/stop \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"owner_id":"client-1"}'
+```
+
+## Next References
+
+- [API v1 Contract](./api/v1.md)
+- [CameraBridgeApp README](../apps/CameraBridgeApp/README.md)
+- [Python Example](../examples/python/capture_photo.py)

--- a/examples/python/capture_photo.py
+++ b/examples/python/capture_photo.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8731"
+DEFAULT_OWNER_ID = "client-1"
+DEFAULT_TOKEN_FILE = Path.home() / "Library/Application Support/CameraBridge/auth-token"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Select a CameraBridge device, start a session, capture one photo, and stop."
+    )
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL, help="CameraBridge base URL")
+    parser.add_argument("--device-id", required=True, help="Device id from GET /v1/devices")
+    parser.add_argument("--owner-id", default=DEFAULT_OWNER_ID, help="Owner id for session control")
+    parser.add_argument(
+        "--token-file",
+        default=str(DEFAULT_TOKEN_FILE),
+        help="Path to the CameraBridge bearer token file",
+    )
+    return parser.parse_args()
+
+
+def load_token(token_file: str) -> str:
+    env_token = os.environ.get("CAMERABRIDGE_AUTH_TOKEN")
+    if env_token:
+        return env_token.strip()
+
+    token = Path(token_file).read_text(encoding="utf-8").strip()
+    if not token:
+        raise RuntimeError(f"Token file is empty: {token_file}")
+    return token
+
+
+def api_request(
+    base_url: str,
+    method: str,
+    path: str,
+    token: Optional[str] = None,
+    body: Optional[dict] = None,
+) -> dict:
+    data = None
+    headers = {"Accept": "application/json"}
+
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = urllib.request.Request(
+        f"{base_url}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+
+    try:
+        with urllib.request.urlopen(request) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        payload = error.read().decode("utf-8")
+        raise RuntimeError(f"{method} {path} failed with {error.code}: {payload}") from error
+
+
+def pretty_print(label: str, payload: dict) -> None:
+    print(f"{label}:")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        token = load_token(args.token_file)
+    except Exception as error:
+        print(f"Failed to load auth token: {error}", file=sys.stderr)
+        return 1
+
+    try:
+        permissions = api_request(args.base_url, "GET", "/v1/permissions")
+        devices = api_request(args.base_url, "GET", "/v1/devices")
+        session_before = api_request(args.base_url, "GET", "/v1/session")
+
+        stopped_existing_session = None
+        if (
+            session_before.get("state") == "running"
+            and session_before.get("owner_id") == args.owner_id
+        ):
+            stopped_existing_session = api_request(
+                args.base_url,
+                "POST",
+                "/v1/session/stop",
+                token=token,
+                body={"owner_id": args.owner_id},
+            )
+
+        select_device = api_request(
+            args.base_url,
+            "POST",
+            "/v1/session/select-device",
+            token=token,
+            body={"device_id": args.device_id, "owner_id": args.owner_id},
+        )
+        start_session = api_request(
+            args.base_url,
+            "POST",
+            "/v1/session/start",
+            token=token,
+            body={"owner_id": args.owner_id},
+        )
+        capture = api_request(
+            args.base_url,
+            "POST",
+            "/v1/capture/photo",
+            token=token,
+            body={"owner_id": args.owner_id},
+        )
+        stop_session = api_request(
+            args.base_url,
+            "POST",
+            "/v1/session/stop",
+            token=token,
+            body={"owner_id": args.owner_id},
+        )
+    except Exception as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    pretty_print("Permission status", permissions)
+    pretty_print("Devices", devices)
+    pretty_print("Initial session state", session_before)
+    if stopped_existing_session is not None:
+        pretty_print("Stopped existing session", stopped_existing_session)
+    pretty_print("Selected device", select_device)
+    pretty_print("Started session", start_session)
+    pretty_print("Captured photo", capture)
+    pretty_print("Stopped session", stop_session)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/CameraBridgeClientSwift/README.md
+++ b/packages/CameraBridgeClientSwift/README.md
@@ -1,3 +1,14 @@
 # CameraBridgeClientSwift
 
-`CameraBridgeClientSwift` will provide a small Swift client for internal app use and example integrations.
+`CameraBridgeClientSwift` is the small Swift client currently used by `CameraBridgeApp`.
+
+Current onboarding-focused surface:
+
+- `health()` to confirm the local daemon is reachable
+- `permissionStatus()` for `GET /v1/permissions`
+- `requestPermission()` for `POST /v1/permissions/request`
+- `serviceIsRunning()` convenience check for the app shell
+
+This package is intentionally narrow in the current slice. It does not yet expose session or capture helpers.
+
+For the current repo-level setup and first capture flow, see [docs/quick-start.md](../../docs/quick-start.md).


### PR DESCRIPTION
## Summary
- add a repo-level quick start guide for the verified app-owned CameraBridge flow
- add one minimal Python example that exercises select, start, capture, and stop with no external dependencies
- update the README and Swift client docs to point at the real first-capture path

## Files Changed
- `README.md`
- `docs/quick-start.md`
- `examples/python/capture_photo.py`
- `packages/CameraBridgeClientSwift/README.md`

## How Tested
- `curl -s http://127.0.0.1:8731/v1/devices`
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/python/capture_photo.py --device-id 0x1000002e1a4c04`
- `git diff --check`

## Manual Verification Notes
- verified the example against the live local daemon started from the app-owned flow
- the documented Python command succeeded end to end and wrote `/Users/ryanschroeder/Library/Application Support/CameraBridge/Captures/capture-20260321T032718706Z-d0739d19-0b9f-45fb-b411-8d9322f5ec5d.jpg`
- the example is safe to rerun for the same owner and will stop an existing owned session before repeating the flow

## Deferred
- additional language examples
- broader docs or marketing-site copy overhaul
- session or capture helpers in `CameraBridgeClientSwift`

Closes #27