### PR TITLE
Consolidate validated backend v1 camera flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ This repository is intentionally scaffolded with strict package boundaries:
 - `docs/` for RFCs and API documentation
 - `examples/` for small example clients
 
-Current implementation includes the local daemon, health and permission endpoints, device discovery,
-session control, still photo capture, and a minimal menu bar app shell. Preview transport,
-example clients, and fuller onboarding UI are still in progress.
+The repository currently includes early daemon and API slices for health,
+permission status and request, device listing and selection, session state,
+basic session lifecycle control, and still photo capture with local artifact
+metadata, plus a minimal menu bar app shell. Preview transport, example clients,
+and fuller onboarding UI are still in progress.
 
 ## v1 Auth And Ownership
 

--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -5,13 +5,20 @@ import Foundation
 struct ServerConfiguration: Sendable, Equatable {
     static let defaultHost = "127.0.0.1"
     static let defaultPort: UInt16 = 8731
+    static let authTokenEnvironmentVariable = "CAMERABRIDGE_AUTH_TOKEN"
 
     var host: String
     var port: UInt16
+    var authToken: String?
 
-    init(host: String = ServerConfiguration.defaultHost, port: UInt16 = ServerConfiguration.defaultPort) {
+    init(
+        host: String = ServerConfiguration.defaultHost,
+        port: UInt16 = ServerConfiguration.defaultPort,
+        authToken: String? = ProcessInfo.processInfo.environment[ServerConfiguration.authTokenEnvironmentVariable]
+    ) {
         self.host = host
         self.port = port
+        self.authToken = authToken
     }
 }
 
@@ -29,30 +36,38 @@ struct CameraBridgeDaemon {
         self.logger = logger
     }
 
-    func makeServer(
-        router: CameraBridgeRouter = CameraBridgeRouter(
+    private func defaultRouter() -> CameraBridgeRouter {
+        let deviceListing = AVFoundationCameraDeviceListing()
+        let sessionController = DefaultCameraSessionController(
+            deviceListing: deviceListing,
+            photoProducer: AVFoundationStillPhotoProducer(),
+            artifactStore: DefaultPhotoArtifactStore()
+        )
+        return CameraBridgeRouter(
             routes: CameraBridgeRoutes.current(
                 permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
-                deviceListing: AVFoundationCameraDeviceListing()
+                permissionRequester: AVFoundationCameraPermissionRequester(),
+                deviceListing: sessionController,
+                cameraStateProvider: sessionController,
+                deviceSelector: sessionController,
+                sessionStarter: sessionController,
+                sessionStopper: sessionController,
+                photoCapturer: sessionController,
+                authorizer: StaticBearerTokenAuthorizer(bearerToken: configuration.authToken)
             )
         )
-    ) -> LocalHTTPServer {
+    }
+
+    func makeServer(router: CameraBridgeRouter? = nil) -> LocalHTTPServer {
         LocalHTTPServer(
             configuration: .init(host: configuration.host, port: configuration.port),
-            router: router,
+            router: router ?? defaultRouter(),
             logger: logger
         )
     }
 
     @discardableResult
-    func start(
-        router: CameraBridgeRouter = CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
-                deviceListing: AVFoundationCameraDeviceListing()
-            )
-        )
-    ) throws -> LocalHTTPServer {
+    func start(router: CameraBridgeRouter? = nil) throws -> LocalHTTPServer {
         logger("starting camd on \(configuration.host):\(configuration.port)")
         let server = makeServer(router: router)
         let port = try server.start()

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -33,8 +33,10 @@ This document defines the early CameraBridge API contract for the v1 service sli
 - all planned mutating endpoints require a bearer token or equivalent local secret
 - v1 does not add separate `claim` or `release` endpoints
 - successful `POST /v1/session/start` establishes implicit session ownership
+- successful `POST /v1/session/stop` releases implicit session ownership
 - `POST /v1/session/stop`, `POST /v1/session/select-device`, and `POST /v1/capture/photo` require the current session owner
 - `POST /v1/permissions/request` is token-protected but does not create or transfer session ownership
+- successful `POST /v1/session/select-device` does not create or transfer session ownership
 
 High-level planned error categories for mutating endpoints:
 
@@ -48,13 +50,13 @@ High-level planned error categories for mutating endpoints:
 | --- | --- | --- |
 | `GET /health` | current | implemented and unauthenticated |
 | `GET /v1/permissions` | current | read-only permission status |
-| `GET /v1/devices` | current | read-only device enumeration |
-| `POST /v1/permissions/request` | planned | token-protected; no session ownership effect |
-| `GET /v1/session` | planned | read-only session state |
-| `POST /v1/session/start` | planned | token-protected; acquires implicit ownership on success |
-| `POST /v1/session/stop` | planned | token-protected; requires current owner and releases ownership |
-| `POST /v1/session/select-device` | planned | token-protected; follows v1 ownership rules |
-| `POST /v1/capture/photo` | planned | token-protected; requires current owner |
+| `POST /v1/permissions/request` | current | token-protected; no session ownership effect |
+| `GET /v1/devices` | current | read-only device inventory |
+| `GET /v1/session` | current | read-only session state |
+| `POST /v1/session/start` | current | token-protected; requires selected device and acquires implicit ownership on success |
+| `POST /v1/session/stop` | current | token-protected; requires current owner and releases ownership |
+| `POST /v1/session/select-device` | current | token-protected; validates requested device and respects existing ownership |
+| `POST /v1/capture/photo` | current | token-protected; requires current owner and returns local artifact metadata |
 
 ## Fully Specified Early Endpoints
 
@@ -91,6 +93,33 @@ Allowed `status` values:
 - `denied`
 - `authorized`
 
+### `POST /v1/permissions/request`
+
+Status: `current`
+
+- auth: bearer token required
+- request body: none
+
+Behavior:
+
+- requests camera permission through the macOS system prompt only when the status is `not_determined`
+- when permission has already been decided, returns the current state without prompting again
+- does not create or transfer session ownership
+
+Successful response: `200 OK`
+
+```json
+{
+  "prompted": true,
+  "status": "authorized"
+}
+```
+
+Response fields:
+
+- `status`: resulting permission state
+- `prompted`: `true` if the system prompt was shown during the request
+
 ### `GET /v1/devices`
 
 Status: `current`
@@ -110,11 +139,215 @@ Status: `current`
 }
 ```
 
-Device fields:
+Response fields:
 
-- `id`: stable device identifier
-- `name`: display name
-- `position`: one of `front`, `back`, or `external`
+- `devices`: available camera devices sorted by display name and identifier
+- device `id`: stable device identifier
+- device `name`: human-readable display name
+- device `position`: `front`, `back`, or `external`
+
+### `GET /v1/session`
+
+Status: `current`
+
+- auth: none for the early read-only slice
+- response: `200 OK`
+
+```json
+{
+  "active_device_id": null,
+  "last_error": null,
+  "owner_id": null,
+  "state": "stopped"
+}
+```
+
+Response fields:
+
+- `state`: `stopped` or `running`
+- `active_device_id`: selected device identifier, or `null`
+- `owner_id`: current session owner identifier, or `null`
+- `last_error`: last session-related error message, or `null`
+
+### `POST /v1/session/start`
+
+Status: `current`
+
+- auth: bearer token required
+- request body:
+
+```json
+{
+  "owner_id": "client-1"
+}
+```
+
+Request fields:
+
+- `owner_id`: required caller identity used to establish session ownership on success
+
+Behavior:
+
+- requires camera permission state `authorized`
+- requires a previously selected `active_device_id`
+- does not implicitly pick or change the active device
+- successful start sets `state` to `running` and `owner_id` to the provided caller identity
+- if another owner already holds the session, returns an ownership conflict
+
+Successful response: `200 OK`
+
+```json
+{
+  "active_device_id": "camera-1",
+  "last_error": null,
+  "owner_id": "client-1",
+  "state": "running"
+}
+```
+
+Error cases:
+
+- `401 unauthorized` when the bearer token is missing or invalid
+- `400 invalid_request` when the body is missing, malformed, or `owner_id` is blank
+- `409 ownership_conflict` when another owner already controls the session
+- `409 invalid_state` when permission is not authorized, no active device is selected, or the session is already running
+
+### `POST /v1/session/stop`
+
+Status: `current`
+
+- auth: bearer token required
+- request body:
+
+```json
+{
+  "owner_id": "client-1"
+}
+```
+
+Request fields:
+
+- `owner_id`: required caller identity that must match the current session owner
+
+Behavior:
+
+- requires the session to already be `running`
+- requires the provided `owner_id` to match the current session owner
+- successful stop sets `state` to `stopped` and clears `owner_id`
+- successful stop preserves `active_device_id` for a later restart
+
+Successful response: `200 OK`
+
+```json
+{
+  "active_device_id": "camera-1",
+  "last_error": null,
+  "owner_id": null,
+  "state": "stopped"
+}
+```
+
+Error cases:
+
+- `401 unauthorized` when the bearer token is missing or invalid
+- `400 invalid_request` when the body is missing, malformed, or `owner_id` is blank
+- `409 ownership_conflict` when another owner already controls the running session
+- `409 invalid_state` when the session is already stopped or otherwise not in a stoppable state
+
+### `POST /v1/session/select-device`
+
+Status: `current`
+
+- auth: bearer token required
+- request body:
+
+```json
+{
+  "device_id": "camera-1",
+  "owner_id": "client-1"
+}
+```
+
+Request fields:
+
+- `device_id`: required device identifier to make active
+- `owner_id`: optional caller identity used only for ownership checks when the session already has an owner
+
+Behavior:
+
+- validates `device_id` against the Core device inventory
+- does not auto-start the camera session
+- does not create or transfer ownership
+- if `owner_id` does not match the existing `owner_id`, returns an ownership conflict
+- if no session owner exists yet, device selection may succeed but the response `owner_id` remains unchanged
+
+Successful response: `200 OK`
+
+```json
+{
+  "active_device_id": "camera-1",
+  "last_error": null,
+  "owner_id": null,
+  "state": "stopped"
+}
+```
+
+Error cases:
+
+- `401 unauthorized` when the bearer token is missing or invalid
+- `400 invalid_request` when the body is missing or malformed
+- `409 ownership_conflict` when another owner already controls the session
+- `409 invalid_state` when the requested device is unknown or unavailable
+
+### `POST /v1/capture/photo`
+
+Status: `current`
+
+- auth: bearer token required
+- request body:
+
+```json
+{
+  "owner_id": "client-1"
+}
+```
+
+Request fields:
+
+- `owner_id`: required caller identity that must match the current session owner
+
+Behavior:
+
+- requires the session to already be `running`
+- requires the provided `owner_id` to match the current session owner
+- requires an `active_device_id` to already be selected for the running session
+- captures a single still image and stores it under `~/Library/Application Support/CameraBridge/Captures/`
+- returns metadata only; the API does not serve the image bytes directly in v1
+- successful capture does not change `state`, `owner_id`, or `active_device_id`
+
+Successful response: `200 OK`
+
+```json
+{
+  "captured_at": "2026-03-20T22:10:29.123Z",
+  "device_id": "camera-1",
+  "local_path": "/Users/example/Library/Application Support/CameraBridge/Captures/capture-20260320T221029123Z-01234567-89ab-cdef-0123-456789abcdef.jpg"
+}
+```
+
+Response fields:
+
+- `captured_at`: ISO 8601 UTC timestamp for when the service recorded the artifact metadata
+- `device_id`: active device identifier used for the capture
+- `local_path`: absolute local filesystem path to the stored JPEG artifact
+
+Error cases:
+
+- `401 unauthorized` when the bearer token is missing or invalid
+- `400 invalid_request` when the body is missing, malformed, or `owner_id` is blank
+- `409 ownership_conflict` when another owner already controls the running session
+- `409 invalid_state` when the session is not running, has no owner, has no active device, or the selected device is no longer available
+- `500 capture_failed` when AVFoundation capture or artifact persistence fails after request validation
 
 ## Planned Only
 

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -57,11 +57,40 @@ public struct HTTPResponse: Sendable, Equatable {
         )
     }
 
+    public static func error(statusCode: Int, code: String, message: String) -> HTTPResponse {
+        .json(statusCode: statusCode, body: ErrorResponse(error: .init(code: code, message: message)))
+    }
+
     public static func notFound() -> HTTPResponse {
-        .json(
-            statusCode: 404,
-            body: #"{ "error": { "code": "not_found", "message": "Route not found" } }"#
-        )
+        .error(statusCode: 404, code: "not_found", message: "Route not found")
+    }
+
+    public static func badRequest(code: String = "invalid_request", message: String) -> HTTPResponse {
+        .error(statusCode: 400, code: code, message: message)
+    }
+
+    public static func unauthorized() -> HTTPResponse {
+        .error(statusCode: 401, code: "unauthorized", message: "Bearer token missing or invalid")
+    }
+}
+
+public protocol BearerTokenAuthorizing: Sendable {
+    func isAuthorized(request: HTTPRequest) -> Bool
+}
+
+public struct StaticBearerTokenAuthorizer: BearerTokenAuthorizing {
+    public var bearerToken: String?
+
+    public init(bearerToken: String?) {
+        self.bearerToken = bearerToken
+    }
+
+    public func isAuthorized(request: HTTPRequest) -> Bool {
+        guard let bearerToken, !bearerToken.isEmpty else {
+            return false
+        }
+
+        return request.authorizationBearerToken == bearerToken
     }
 }
 
@@ -105,12 +134,29 @@ public struct CameraBridgeRouter: Sendable {
 public enum CameraBridgeRoutes {
     public static func current(
         permissionStatusProvider: any CameraPermissionStatusProviding,
-        deviceListing: any CameraDeviceListing
+        permissionRequester: any CameraPermissionRequesting,
+        deviceListing: any CameraDeviceListing,
+        cameraStateProvider: any CameraStateProviding,
+        deviceSelector: any CameraDeviceSelecting,
+        sessionStarter: any CameraSessionStarting,
+        sessionStopper: any CameraSessionStopping,
+        photoCapturer: any CameraPhotoCapturing,
+        authorizer: any BearerTokenAuthorizing
     ) -> [HTTPRoute] {
         [
             health(),
             permissionStatus(provider: permissionStatusProvider),
+            permissionRequest(requester: permissionRequester, authorizer: authorizer),
             devices(deviceListing: deviceListing),
+            sessionState(provider: cameraStateProvider),
+            sessionStart(
+                starter: sessionStarter,
+                permissionStatusProvider: permissionStatusProvider,
+                authorizer: authorizer
+            ),
+            sessionStop(stopper: sessionStopper, authorizer: authorizer),
+            sessionDeviceSelection(selector: deviceSelector, authorizer: authorizer),
+            photoCapture(capturer: photoCapturer, authorizer: authorizer),
         ]
     }
 
@@ -129,6 +175,34 @@ public enum CameraBridgeRoutes {
         }
     }
 
+    public static func permissionRequest(
+        requester: any CameraPermissionRequesting,
+        authorizer: any BearerTokenAuthorizing
+    ) -> HTTPRoute {
+        HTTPRoute(method: .post, path: "/v1/permissions/request") { request in
+            guard authorizer.isAuthorized(request: request) else {
+                return .unauthorized()
+            }
+
+            let semaphore = DispatchSemaphore(value: 0)
+            let resultBox = PermissionRequestResultBox()
+
+            requester.requestPermission { permissionResult in
+                resultBox.result = permissionResult
+                semaphore.signal()
+            }
+
+            semaphore.wait()
+
+            return .json(
+                statusCode: 200,
+                body: PermissionRequestResponse(
+                    result: resultBox.result ?? .init(status: .denied, prompted: false)
+                )
+            )
+        }
+    }
+
     public static func devices(deviceListing: any CameraDeviceListing) -> HTTPRoute {
         HTTPRoute(method: .get, path: "/v1/devices") { _ in
             .json(
@@ -136,6 +210,215 @@ public enum CameraBridgeRoutes {
                 body: DevicesResponse(devices: deviceListing.availableDevices())
             )
         }
+    }
+
+    public static func sessionState(provider: any CameraStateProviding) -> HTTPRoute {
+        HTTPRoute(method: .get, path: "/v1/session") { _ in
+            .json(statusCode: 200, body: SessionStateResponse(state: provider.currentCameraState()))
+        }
+    }
+
+    public static func sessionStart(
+        starter: any CameraSessionStarting,
+        permissionStatusProvider: any CameraPermissionStatusProviding,
+        authorizer: any BearerTokenAuthorizing
+    ) -> HTTPRoute {
+        HTTPRoute(method: .post, path: "/v1/session/start") { request in
+            guard authorizer.isAuthorized(request: request) else {
+                return .unauthorized()
+            }
+
+            let ownerRequest: SessionOwnerRequest
+            do {
+                ownerRequest = try JSONDecoder().decode(SessionOwnerRequest.self, from: request.body)
+            } catch {
+                return .badRequest(message: "Request body must be valid JSON")
+            }
+
+            let ownerID = ownerRequest.ownerID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !ownerID.isEmpty else {
+                return .badRequest(message: "owner_id is required")
+            }
+
+            do {
+                let state = try starter.startSession(
+                    ownerID: ownerID,
+                    permissionState: permissionStatusProvider.currentPermissionState()
+                )
+                return .json(statusCode: 200, body: SessionStateResponse(state: state))
+            } catch let error as CameraSessionLifecycleError {
+                return sessionLifecycleErrorResponse(error)
+            } catch {
+                return .error(statusCode: 409, code: "invalid_state", message: "Session start failed")
+            }
+        }
+    }
+
+    public static func sessionStop(
+        stopper: any CameraSessionStopping,
+        authorizer: any BearerTokenAuthorizing
+    ) -> HTTPRoute {
+        HTTPRoute(method: .post, path: "/v1/session/stop") { request in
+            guard authorizer.isAuthorized(request: request) else {
+                return .unauthorized()
+            }
+
+            let ownerRequest: SessionOwnerRequest
+            do {
+                ownerRequest = try JSONDecoder().decode(SessionOwnerRequest.self, from: request.body)
+            } catch {
+                return .badRequest(message: "Request body must be valid JSON")
+            }
+
+            let ownerID = ownerRequest.ownerID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !ownerID.isEmpty else {
+                return .badRequest(message: "owner_id is required")
+            }
+
+            do {
+                let state = try stopper.stopSession(ownerID: ownerID)
+                return .json(statusCode: 200, body: SessionStateResponse(state: state))
+            } catch let error as CameraSessionLifecycleError {
+                return sessionLifecycleErrorResponse(error)
+            } catch {
+                return .error(statusCode: 409, code: "invalid_state", message: "Session stop failed")
+            }
+        }
+    }
+
+    public static func sessionDeviceSelection(
+        selector: any CameraDeviceSelecting,
+        authorizer: any BearerTokenAuthorizing
+    ) -> HTTPRoute {
+        HTTPRoute(method: .post, path: "/v1/session/select-device") { request in
+            guard authorizer.isAuthorized(request: request) else {
+                return .unauthorized()
+            }
+
+            let selectionRequest: SelectDeviceRequest
+            do {
+                selectionRequest = try JSONDecoder().decode(SelectDeviceRequest.self, from: request.body)
+            } catch {
+                return .badRequest(message: "Request body must be valid JSON")
+            }
+
+            let deviceID = selectionRequest.deviceID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !deviceID.isEmpty else {
+                return .badRequest(message: "device_id is required")
+            }
+
+            do {
+                let state = try selector.selectDevice(id: deviceID, ownerID: selectionRequest.ownerID)
+                return .json(statusCode: 200, body: SessionStateResponse(state: state))
+            } catch let error as CameraDeviceSelectionError {
+                switch error {
+                case .ownershipConflict(let currentOwnerID):
+                    return .error(
+                        statusCode: 409,
+                        code: "ownership_conflict",
+                        message: "Session is owned by \(currentOwnerID)"
+                    )
+                case .unavailableDevice(let id):
+                    return .error(
+                        statusCode: 409,
+                        code: "invalid_state",
+                        message: "Requested device is unavailable: \(id)"
+                    )
+                }
+            } catch {
+                return .error(statusCode: 409, code: "invalid_state", message: "Device selection failed")
+            }
+        }
+    }
+
+    public static func photoCapture(
+        capturer: any CameraPhotoCapturing,
+        authorizer: any BearerTokenAuthorizing
+    ) -> HTTPRoute {
+        HTTPRoute(method: .post, path: "/v1/capture/photo") { request in
+            guard authorizer.isAuthorized(request: request) else {
+                return .unauthorized()
+            }
+
+            let ownerRequest: SessionOwnerRequest
+            do {
+                ownerRequest = try JSONDecoder().decode(SessionOwnerRequest.self, from: request.body)
+            } catch {
+                return .badRequest(message: "Request body must be valid JSON")
+            }
+
+            let ownerID = ownerRequest.ownerID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !ownerID.isEmpty else {
+                return .badRequest(message: "owner_id is required")
+            }
+
+            do {
+                let artifact = try capturer.capturePhoto(ownerID: ownerID)
+                return .json(statusCode: 200, body: PhotoCaptureResponse(artifact: artifact))
+            } catch let error as CameraPhotoCaptureError {
+                return photoCaptureErrorResponse(error)
+            } catch {
+                return .error(statusCode: 500, code: "capture_failed", message: "Photo capture failed")
+            }
+        }
+    }
+}
+
+private func sessionLifecycleErrorResponse(_ error: CameraSessionLifecycleError) -> HTTPResponse {
+    switch error {
+    case .ownershipConflict(let currentOwnerID):
+        return .error(
+            statusCode: 409,
+            code: "ownership_conflict",
+            message: "Session is owned by \(currentOwnerID)"
+        )
+    case .permissionRequired(let status):
+        return .error(
+            statusCode: 409,
+            code: "invalid_state",
+            message: "Camera permission is \(status.rawValue)"
+        )
+    case .missingActiveDevice:
+        return .error(
+            statusCode: 409,
+            code: "invalid_state",
+            message: "Cannot start session without an active device"
+        )
+    case .alreadyRunning:
+        return .error(statusCode: 409, code: "invalid_state", message: "Session is already running")
+    case .alreadyStopped:
+        return .error(statusCode: 409, code: "invalid_state", message: "Session is already stopped")
+    case .missingOwner:
+        return .error(statusCode: 409, code: "invalid_state", message: "Running session has no owner")
+    }
+}
+
+private func photoCaptureErrorResponse(_ error: CameraPhotoCaptureError) -> HTTPResponse {
+    switch error {
+    case .ownershipConflict(let currentOwnerID):
+        return .error(
+            statusCode: 409,
+            code: "ownership_conflict",
+            message: "Session is owned by \(currentOwnerID)"
+        )
+    case .sessionNotRunning:
+        return .error(statusCode: 409, code: "invalid_state", message: "Session is not running")
+    case .missingOwner:
+        return .error(statusCode: 409, code: "invalid_state", message: "Running session has no owner")
+    case .missingActiveDevice:
+        return .error(
+            statusCode: 409,
+            code: "invalid_state",
+            message: "Cannot capture photo without an active device"
+        )
+    case .unavailableDevice(let id):
+        return .error(
+            statusCode: 409,
+            code: "invalid_state",
+            message: "Requested device is unavailable: \(id)"
+        )
+    case .captureFailed(let message):
+        return .error(statusCode: 500, code: "capture_failed", message: message)
     }
 }
 
@@ -374,14 +657,60 @@ private enum HTTPResponseSerializer {
 
     private static func reasonPhrase(for statusCode: Int) -> String {
         switch statusCode {
+        case 400:
+            return "Bad Request"
         case 200:
             return "OK"
+        case 401:
+            return "Unauthorized"
+        case 409:
+            return "Conflict"
         case 404:
             return "Not Found"
         default:
             return "Error"
         }
     }
+}
+
+private extension HTTPRequest {
+    var authorizationBearerToken: String? {
+        guard let authorization = headers.first(where: {
+            $0.key.caseInsensitiveCompare("Authorization") == .orderedSame
+        })?.value else {
+            return nil
+        }
+
+        let prefix = "Bearer "
+        guard authorization.hasPrefix(prefix) else {
+            return nil
+        }
+
+        return String(authorization.dropFirst(prefix.count))
+    }
+}
+
+private struct ErrorResponse: Encodable, Equatable {
+    var error: ErrorBody
+}
+
+private struct ErrorBody: Encodable, Equatable {
+    var code: String
+    var message: String
+}
+
+private struct PermissionRequestResponse: Encodable, Equatable {
+    var status: String
+    var prompted: Bool
+
+    init(result: PermissionRequestResult) {
+        self.status = result.status.rawValue
+        self.prompted = result.prompted
+    }
+}
+
+private final class PermissionRequestResultBox: @unchecked Sendable {
+    var result: PermissionRequestResult?
 }
 
 private struct DevicesResponse: Encodable, Equatable {
@@ -402,4 +731,90 @@ private struct DeviceResponse: Encodable, Equatable {
         self.name = device.name
         self.position = device.position.rawValue
     }
+}
+
+private struct SessionStateResponse: Encodable, Equatable {
+    var state: String
+    var activeDeviceID: String?
+    var ownerID: String?
+    var lastError: String?
+
+    enum CodingKeys: String, CodingKey {
+        case state
+        case activeDeviceID = "active_device_id"
+        case ownerID = "owner_id"
+        case lastError = "last_error"
+    }
+
+    init(state: CameraState) {
+        self.state = state.sessionState.rawValue
+        self.activeDeviceID = state.activeDeviceID
+        self.ownerID = state.currentOwnerID
+        self.lastError = state.lastError?.message
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(state, forKey: .state)
+
+        if let activeDeviceID {
+            try container.encode(activeDeviceID, forKey: .activeDeviceID)
+        } else {
+            try container.encodeNil(forKey: .activeDeviceID)
+        }
+
+        if let ownerID {
+            try container.encode(ownerID, forKey: .ownerID)
+        } else {
+            try container.encodeNil(forKey: .ownerID)
+        }
+
+        if let lastError {
+            try container.encode(lastError, forKey: .lastError)
+        } else {
+            try container.encodeNil(forKey: .lastError)
+        }
+    }
+}
+
+private struct PhotoCaptureResponse: Encodable, Equatable {
+    var localPath: String
+    var capturedAt: String
+    var deviceID: String
+
+    enum CodingKeys: String, CodingKey {
+        case localPath = "local_path"
+        case capturedAt = "captured_at"
+        case deviceID = "device_id"
+    }
+
+    init(artifact: CapturedPhotoArtifact) {
+        self.localPath = artifact.localPath
+        self.capturedAt = iso8601Timestamp(artifact.capturedAt)
+        self.deviceID = artifact.deviceID
+    }
+}
+
+private struct SelectDeviceRequest: Decodable, Equatable {
+    var deviceID: String
+    var ownerID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case deviceID = "device_id"
+        case ownerID = "owner_id"
+    }
+}
+
+private struct SessionOwnerRequest: Decodable, Equatable {
+    var ownerID: String
+
+    enum CodingKeys: String, CodingKey {
+        case ownerID = "owner_id"
+    }
+}
+
+private func iso8601Timestamp(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
 }

--- a/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
+++ b/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Foundation
 
 public enum CameraBridgeCoreModule {
     public static let name = "CameraBridgeCore"
@@ -11,7 +12,7 @@ public enum PermissionState: String, Sendable, CaseIterable, Equatable {
     case authorized
 }
 
-public enum SessionState: Sendable, Equatable {
+public enum SessionState: String, Sendable, CaseIterable, Equatable {
     case stopped
     case running
 }
@@ -39,6 +40,16 @@ public struct CameraDevice: Sendable, Equatable {
     }
 }
 
+public struct PermissionRequestResult: Sendable, Equatable {
+    public var status: PermissionState
+    public var prompted: Bool
+
+    public init(status: PermissionState, prompted: Bool) {
+        self.status = status
+        self.prompted = prompted
+    }
+}
+
 public struct CameraStateError: Error, Sendable, Equatable {
     public let message: String
 
@@ -52,6 +63,7 @@ public struct CameraState: Sendable, Equatable {
     public var sessionState: SessionState
     public var previewState: PreviewState
     public var activeDeviceID: String?
+    public var currentOwnerID: String?
     public var lastError: CameraStateError?
 
     public init(
@@ -59,12 +71,14 @@ public struct CameraState: Sendable, Equatable {
         sessionState: SessionState = .stopped,
         previewState: PreviewState = .stopped,
         activeDeviceID: String? = nil,
+        currentOwnerID: String? = nil,
         lastError: CameraStateError? = nil
     ) {
         self.permissionState = permissionState
         self.sessionState = sessionState
         self.previewState = previewState
         self.activeDeviceID = activeDeviceID
+        self.currentOwnerID = currentOwnerID
         self.lastError = lastError
     }
 }
@@ -73,8 +87,75 @@ public protocol CameraPermissionStatusProviding: Sendable {
     func currentPermissionState() -> PermissionState
 }
 
+public protocol CameraPermissionRequesting: Sendable {
+    func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void)
+}
+
+public protocol CameraStateProviding: Sendable {
+    func currentCameraState() -> CameraState
+}
+
 public protocol CameraDeviceListing: Sendable {
     func availableDevices() -> [CameraDevice]
+}
+
+public protocol CameraDeviceSelecting: Sendable {
+    func selectDevice(id: String, ownerID: String?) throws -> CameraState
+}
+
+public protocol CameraSessionStarting: Sendable {
+    func startSession(ownerID: String, permissionState: PermissionState) throws -> CameraState
+}
+
+public protocol CameraSessionStopping: Sendable {
+    func stopSession(ownerID: String) throws -> CameraState
+}
+
+public protocol CameraPhotoCapturing: Sendable {
+    func capturePhoto(ownerID: String) throws -> CapturedPhotoArtifact
+}
+
+public enum CameraDeviceSelectionError: Error, Sendable, Equatable {
+    case ownershipConflict(currentOwnerID: String)
+    case unavailableDevice(id: String)
+}
+
+public enum CameraSessionLifecycleError: Error, Sendable, Equatable {
+    case ownershipConflict(currentOwnerID: String)
+    case permissionRequired(status: PermissionState)
+    case missingActiveDevice
+    case alreadyRunning
+    case alreadyStopped
+    case missingOwner
+}
+
+public struct CapturedPhotoArtifact: Sendable, Equatable {
+    public var localPath: String
+    public var capturedAt: Date
+    public var deviceID: String
+
+    public init(localPath: String, capturedAt: Date, deviceID: String) {
+        self.localPath = localPath
+        self.capturedAt = capturedAt
+        self.deviceID = deviceID
+    }
+}
+
+public enum CameraPhotoCaptureError: Error, Sendable, Equatable {
+    case ownershipConflict(currentOwnerID: String)
+    case sessionNotRunning
+    case missingOwner
+    case missingActiveDevice
+    case unavailableDevice(id: String)
+    case captureFailed(message: String)
+}
+
+public protocol CameraStillPhotoProducing: Sendable {
+    func capturePhotoData(deviceID: String) throws -> Data
+}
+
+public protocol PhotoArtifactStoring: Sendable {
+    func storePhotoData(_ data: Data, deviceID: String, capturedAt: Date) throws -> URL
 }
 
 public struct AVFoundationCameraPermissionStatusProvider: CameraPermissionStatusProviding {
@@ -82,6 +163,34 @@ public struct AVFoundationCameraPermissionStatusProvider: CameraPermissionStatus
 
     public func currentPermissionState() -> PermissionState {
         PermissionState(authorizationStatus: AVCaptureDevice.authorizationStatus(for: .video))
+    }
+}
+
+public struct AVFoundationCameraPermissionRequester: CameraPermissionRequesting {
+    public init() {}
+
+    public func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void) {
+        let currentStatus = AVCaptureDevice.authorizationStatus(for: .video)
+        guard currentStatus == .notDetermined else {
+            completion(
+                PermissionRequestResult(
+                    status: PermissionState(authorizationStatus: currentStatus),
+                    prompted: false
+                )
+            )
+            return
+        }
+
+        AVCaptureDevice.requestAccess(for: .video) { _ in
+            completion(
+                PermissionRequestResult(
+                    status: PermissionState(
+                        authorizationStatus: AVCaptureDevice.authorizationStatus(for: .video)
+                    ),
+                    prompted: true
+                )
+            )
+        }
     }
 }
 
@@ -107,6 +216,309 @@ public struct AVFoundationCameraDeviceListing: CameraDeviceListing {
             }
 
             return $0.name < $1.name
+        }
+    }
+}
+
+public struct DefaultPhotoArtifactStore: PhotoArtifactStoring {
+    public var baseDirectoryURL: URL
+
+    public init(baseDirectoryURL: URL? = nil) {
+        self.baseDirectoryURL = baseDirectoryURL ?? Self.defaultBaseDirectoryURL()
+    }
+
+    public func storePhotoData(_ data: Data, deviceID: String, capturedAt: Date) throws -> URL {
+        try FileManager.default.createDirectory(
+            at: baseDirectoryURL,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        let fileURL = baseDirectoryURL.appendingPathComponent(
+            "capture-\(Self.filenameTimestamp(from: capturedAt))-\(UUID().uuidString.lowercased()).jpg",
+            isDirectory: false
+        )
+        try data.write(to: fileURL, options: .atomic)
+        return fileURL
+    }
+
+    private static func defaultBaseDirectoryURL() -> URL {
+        let applicationSupportURL =
+            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first ??
+            URL(fileURLWithPath: NSHomeDirectory())
+                .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return applicationSupportURL
+            .appendingPathComponent("CameraBridge", isDirectory: true)
+            .appendingPathComponent("Captures", isDirectory: true)
+    }
+
+    private static func filenameTimestamp(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd'T'HHmmssSSS'Z'"
+        return formatter.string(from: date)
+    }
+}
+
+public struct UnimplementedStillPhotoProducer: CameraStillPhotoProducing {
+    public init() {}
+
+    public func capturePhotoData(deviceID: String) throws -> Data {
+        throw CameraPhotoCaptureError.captureFailed(message: "Still photo capture is not configured")
+    }
+}
+
+public struct AVFoundationStillPhotoProducer: CameraStillPhotoProducing {
+    public var timeout: TimeInterval
+
+    public init(timeout: TimeInterval = 10) {
+        self.timeout = timeout
+    }
+
+    public func capturePhotoData(deviceID: String) throws -> Data {
+        guard let device = discoverDevice(id: deviceID) else {
+            throw CameraPhotoCaptureError.unavailableDevice(id: deviceID)
+        }
+
+        let session = AVCaptureSession()
+        session.beginConfiguration()
+        session.sessionPreset = .photo
+
+        let input: AVCaptureDeviceInput
+        do {
+            input = try AVCaptureDeviceInput(device: device)
+        } catch {
+            throw CameraPhotoCaptureError.captureFailed(message: "Unable to create AVCaptureDeviceInput")
+        }
+
+        guard session.canAddInput(input) else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Unable to add camera input to capture session")
+        }
+
+        let output = AVCapturePhotoOutput()
+        guard session.canAddOutput(output) else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Unable to add photo output to capture session")
+        }
+
+        session.addInput(input)
+        session.addOutput(output)
+        session.commitConfiguration()
+        session.startRunning()
+        defer { session.stopRunning() }
+
+        let delegate = StillPhotoCaptureDelegate()
+        let settings: AVCapturePhotoSettings
+        if output.availablePhotoCodecTypes.contains(.jpeg) {
+            settings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.jpeg])
+        } else {
+            settings = AVCapturePhotoSettings()
+        }
+
+        output.capturePhoto(with: settings, delegate: delegate)
+        return try delegate.waitForPhotoData(timeout: timeout)
+    }
+
+    private func discoverDevice(id: String) -> AVCaptureDevice? {
+        AVCaptureDevice.DiscoverySession(
+            deviceTypes: [
+                .builtInWideAngleCamera,
+                .continuityCamera,
+                .deskViewCamera,
+                .external,
+            ],
+            mediaType: .video,
+            position: .unspecified
+        )
+        .devices
+        .first(where: { $0.uniqueID == id })
+    }
+}
+
+public struct DefaultCameraStateProvider: CameraStateProviding {
+    public var state: CameraState
+
+    public init(state: CameraState = CameraState()) {
+        self.state = state
+    }
+
+    public func currentCameraState() -> CameraState {
+        state
+    }
+}
+
+public final class DefaultCameraSessionController: CameraStateProviding, CameraDeviceListing, CameraDeviceSelecting, CameraSessionStarting, CameraSessionStopping, CameraPhotoCapturing, @unchecked Sendable {
+    private let deviceListing: any CameraDeviceListing
+    private let photoProducer: any CameraStillPhotoProducing
+    private let artifactStore: any PhotoArtifactStoring
+    private let now: @Sendable () -> Date
+    private let stateLock = NSLock()
+    private var state: CameraState
+
+    public init(
+        deviceListing: any CameraDeviceListing,
+        photoProducer: any CameraStillPhotoProducing = UnimplementedStillPhotoProducer(),
+        artifactStore: any PhotoArtifactStoring = DefaultPhotoArtifactStore(),
+        now: @escaping @Sendable () -> Date = { Date() },
+        initialState: CameraState = CameraState()
+    ) {
+        self.deviceListing = deviceListing
+        self.photoProducer = photoProducer
+        self.artifactStore = artifactStore
+        self.now = now
+        self.state = initialState
+    }
+
+    public func currentCameraState() -> CameraState {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return state
+    }
+
+    public func availableDevices() -> [CameraDevice] {
+        deviceListing.availableDevices()
+    }
+
+    public func selectDevice(id: String, ownerID: String?) throws -> CameraState {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        if let currentOwnerID = state.currentOwnerID, currentOwnerID != ownerID {
+            let message = "Session is owned by \(currentOwnerID)"
+            state.lastError = CameraStateError(message: message)
+            throw CameraDeviceSelectionError.ownershipConflict(currentOwnerID: currentOwnerID)
+        }
+
+        guard deviceListing.availableDevices().contains(where: { $0.id == id }) else {
+            let message = "Requested device is unavailable: \(id)"
+            state.lastError = CameraStateError(message: message)
+            throw CameraDeviceSelectionError.unavailableDevice(id: id)
+        }
+
+        state.activeDeviceID = id
+        state.lastError = nil
+        return state
+    }
+
+    public func startSession(ownerID: String, permissionState: PermissionState) throws -> CameraState {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        state.permissionState = permissionState
+
+        if let currentOwnerID = state.currentOwnerID, currentOwnerID != ownerID {
+            let message = "Session is owned by \(currentOwnerID)"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.ownershipConflict(currentOwnerID: currentOwnerID)
+        }
+
+        guard permissionState == .authorized else {
+            let message = "Camera permission is \(permissionState.rawValue)"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.permissionRequired(status: permissionState)
+        }
+
+        guard state.activeDeviceID != nil else {
+            let message = "Cannot start session without an active device"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.missingActiveDevice
+        }
+
+        guard state.sessionState != .running else {
+            let message = "Session is already running"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.alreadyRunning
+        }
+
+        state.sessionState = .running
+        state.currentOwnerID = ownerID
+        state.lastError = nil
+        return state
+    }
+
+    public func stopSession(ownerID: String) throws -> CameraState {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        guard state.sessionState == .running else {
+            let message = "Session is already stopped"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.alreadyStopped
+        }
+
+        guard let currentOwnerID = state.currentOwnerID else {
+            let message = "Running session has no owner"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.missingOwner
+        }
+
+        guard currentOwnerID == ownerID else {
+            let message = "Session is owned by \(currentOwnerID)"
+            state.lastError = CameraStateError(message: message)
+            throw CameraSessionLifecycleError.ownershipConflict(currentOwnerID: currentOwnerID)
+        }
+
+        state.sessionState = .stopped
+        state.previewState = .stopped
+        state.currentOwnerID = nil
+        state.lastError = nil
+        return state
+    }
+
+    public func capturePhoto(ownerID: String) throws -> CapturedPhotoArtifact {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        guard state.sessionState == .running else {
+            let error = CameraPhotoCaptureError.sessionNotRunning
+            state.lastError = CameraStateError(message: error.message)
+            throw error
+        }
+
+        guard let currentOwnerID = state.currentOwnerID else {
+            let error = CameraPhotoCaptureError.missingOwner
+            state.lastError = CameraStateError(message: error.message)
+            throw error
+        }
+
+        guard currentOwnerID == ownerID else {
+            let error = CameraPhotoCaptureError.ownershipConflict(currentOwnerID: currentOwnerID)
+            state.lastError = CameraStateError(message: error.message)
+            throw error
+        }
+
+        guard let activeDeviceID = state.activeDeviceID else {
+            let error = CameraPhotoCaptureError.missingActiveDevice
+            state.lastError = CameraStateError(message: error.message)
+            throw error
+        }
+
+        let capturedAt = now()
+
+        do {
+            let data = try photoProducer.capturePhotoData(deviceID: activeDeviceID)
+            let fileURL = try artifactStore.storePhotoData(
+                data,
+                deviceID: activeDeviceID,
+                capturedAt: capturedAt
+            )
+            let artifact = CapturedPhotoArtifact(
+                localPath: fileURL.path,
+                capturedAt: capturedAt,
+                deviceID: activeDeviceID
+            )
+            state.lastError = nil
+            return artifact
+        } catch let error as CameraPhotoCaptureError {
+            state.lastError = CameraStateError(message: error.message)
+            throw error
+        } catch {
+            let captureError = CameraPhotoCaptureError.captureFailed(
+                message: error.localizedDescription
+            )
+            state.lastError = CameraStateError(message: captureError.message)
+            throw captureError
         }
     }
 }
@@ -150,5 +562,77 @@ private extension CameraDevice {
             name: device.localizedName,
             position: CameraDevicePosition(position: device.position)
         )
+    }
+}
+
+private extension CameraPhotoCaptureError {
+    var message: String {
+        switch self {
+        case .ownershipConflict(let currentOwnerID):
+            return "Session is owned by \(currentOwnerID)"
+        case .sessionNotRunning:
+            return "Session is not running"
+        case .missingOwner:
+            return "Running session has no owner"
+        case .missingActiveDevice:
+            return "Cannot capture photo without an active device"
+        case .unavailableDevice(let id):
+            return "Requested device is unavailable: \(id)"
+        case .captureFailed(let message):
+            return message
+        }
+    }
+}
+
+private final class StillPhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate, @unchecked Sendable {
+    private let lock = NSLock()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var result: Result<Data, CameraPhotoCaptureError>?
+
+    func photoOutput(
+        _ output: AVCapturePhotoOutput,
+        didFinishProcessingPhoto photo: AVCapturePhoto,
+        error: Error?
+    ) {
+        if let error {
+            complete(with: .failure(.captureFailed(message: error.localizedDescription)))
+            return
+        }
+
+        guard let data = photo.fileDataRepresentation() else {
+            complete(with: .failure(.captureFailed(message: "AVFoundation did not produce photo data")))
+            return
+        }
+
+        complete(with: .success(data))
+    }
+
+    func waitForPhotoData(timeout: TimeInterval) throws -> Data {
+        let waitResult = semaphore.wait(timeout: .now() + timeout)
+        guard waitResult == .success else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Photo capture timed out")
+        }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let result else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Photo capture finished without a result")
+        }
+
+        return try result.get()
+    }
+
+    private func complete(with result: Result<Data, CameraPhotoCaptureError>) {
+        lock.lock()
+        let shouldSignal = self.result == nil
+        if shouldSignal {
+            self.result = result
+        }
+        lock.unlock()
+
+        if shouldSignal {
+            semaphore.signal()
+        }
     }
 }

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -14,17 +14,16 @@ func routerReturnsNotFoundForUnknownRoute() {
     let response = router.response(for: HTTPRequest(method: .get, path: "/missing"))
 
     #expect(response.statusCode == 404)
-    #expect(String(decoding: response.body, as: UTF8.self) == #"{ "error": { "code": "not_found", "message": "Route not found" } }"#)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"not_found","message":"Route not found"}}"#
+    )
 }
 
 @Test
 func routerReturnsHealthResponseForHealthRoute() {
-    let router = CameraBridgeRouter(
-        routes: CameraBridgeRoutes.current(
-            permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
-            deviceListing: FixedDeviceListing(devices: [])
-        )
-    )
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController)
     let response = router.response(for: HTTPRequest(method: .get, path: "/health"))
 
     #expect(response.statusCode == 200)
@@ -34,14 +33,10 @@ func routerReturnsHealthResponseForHealthRoute() {
 @Test
 func localHTTPServerReturnsHealthResponse() async throws {
     let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController()
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
-                deviceListing: FixedDeviceListing(devices: [])
-            )
-        )
+        router: makeRouter(sessionController: sessionController)
     )
 
     defer { server.stop() }
@@ -58,14 +53,10 @@ func localHTTPServerReturnsHealthResponse() async throws {
 @Test
 func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
     let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController()
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
-                deviceListing: FixedDeviceListing(devices: [])
-            )
-        )
+        router: makeRouter(sessionController: sessionController)
     )
 
     defer { server.stop() }
@@ -77,17 +68,16 @@ func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
     let httpResponse = try #require(response as? HTTPURLResponse)
 
     #expect(httpResponse.statusCode == 404)
-    #expect(String(decoding: data, as: UTF8.self) == #"{ "error": { "code": "not_found", "message": "Route not found" } }"#)
+    #expect(
+        String(decoding: data, as: UTF8.self) ==
+        #"{"error":{"code":"not_found","message":"Route not found"}}"#
+    )
 }
 
 @Test(arguments: PermissionState.allCases)
 func routerReturnsPermissionStatusForProviderState(_ state: PermissionState) {
-    let router = CameraBridgeRouter(
-        routes: CameraBridgeRoutes.current(
-            permissionStatusProvider: FixedPermissionStatusProvider(state: state),
-            deviceListing: FixedDeviceListing(devices: [])
-        )
-    )
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController, permissionState: state)
     let response = router.response(for: HTTPRequest(method: .get, path: "/v1/permissions"))
 
     #expect(response.statusCode == 200)
@@ -97,14 +87,10 @@ func routerReturnsPermissionStatusForProviderState(_ state: PermissionState) {
 @Test
 func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
     let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController()
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted),
-                deviceListing: FixedDeviceListing(devices: [])
-            )
-        )
+        router: makeRouter(sessionController: sessionController, permissionState: .restricted)
     )
 
     defer { server.stop() }
@@ -119,17 +105,71 @@ func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
 }
 
 @Test
+func routerRejectsPermissionRequestWithoutBearerToken() {
+    let requester = RecordingPermissionRequester(result: .init(status: .authorized, prompted: true))
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController, permissionRequester: requester)
+    let response = router.response(for: HTTPRequest(method: .post, path: "/v1/permissions/request"))
+
+    #expect(response.statusCode == 401)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"unauthorized","message":"Bearer token missing or invalid"}}"#
+    )
+    #expect(requester.requestCount == 0)
+}
+
+@Test
+func routerReturnsPermissionRequestResultForAuthorizedRequest() {
+    let requester = RecordingPermissionRequester(result: .init(status: .authorized, prompted: true))
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController, permissionRequester: requester)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/permissions/request",
+            headers: ["Authorization": "Bearer test-token"]
+        )
+    )
+
+    #expect(response.statusCode == 200)
+    #expect(String(decoding: response.body, as: UTF8.self) == #"{"prompted":true,"status":"authorized"}"#)
+    #expect(requester.requestCount == 1)
+}
+
+@Test
+func localHTTPServerReturnsPermissionRequestResultForAuthorizedRequest() async throws {
+    let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController()
+    let server = LocalHTTPServer(
+        configuration: .init(host: "127.0.0.1", port: port),
+        router: makeRouter(
+            sessionController: sessionController,
+            permissionRequester: FixedPermissionRequester(result: .init(status: .denied, prompted: true))
+        )
+    )
+
+    defer { server.stop() }
+
+    let boundPort = try server.start()
+    var request = URLRequest(url: try #require(URL(string: "http://127.0.0.1:\(boundPort)/v1/permissions/request")))
+    request.httpMethod = "POST"
+    request.setValue("Bearer test-token", forHTTPHeaderField: "Authorization")
+    let (data, response) = try await URLSession.shared.data(for: request)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+
+    #expect(httpResponse.statusCode == 200)
+    #expect(String(decoding: data, as: UTF8.self) == #"{"prompted":true,"status":"denied"}"#)
+}
+
+@Test
 func routerReturnsDeviceListForDeviceRoute() {
     let devices = [
         CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
         CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
     ]
-    let router = CameraBridgeRouter(
-        routes: CameraBridgeRoutes.current(
-            permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
-            deviceListing: FixedDeviceListing(devices: devices)
-        )
-    )
+    let sessionController = makeSessionController(devices: devices)
+    let router = makeRouter(sessionController: sessionController)
     let response = router.response(for: HTTPRequest(method: .get, path: "/v1/devices"))
 
     #expect(response.statusCode == 200)
@@ -146,14 +186,10 @@ func localHTTPServerReturnsDeviceListWithoutAuth() async throws {
         CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
         CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
     ]
+    let sessionController = makeSessionController(devices: devices)
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: CameraBridgeRouter(
-            routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized),
-                deviceListing: FixedDeviceListing(devices: devices)
-            )
-        )
+        router: makeRouter(sessionController: sessionController)
     )
 
     defer { server.stop() }
@@ -170,11 +206,677 @@ func localHTTPServerReturnsDeviceListWithoutAuth() async throws {
     )
 }
 
+@Test
+func routerReturnsSessionStateForSessionRoute() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: CameraStateError(message: "session failed")
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(for: HTTPRequest(method: .get, path: "/v1/session"))
+
+    #expect(response.statusCode == 200)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"active_device_id":"camera-1","last_error":"session failed","owner_id":"client-1","state":"running"}"#
+    )
+}
+
+@Test
+func localHTTPServerReturnsSessionStateWithoutAuth() async throws {
+    let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .restricted,
+            sessionState: .stopped,
+            previewState: .stopped,
+            activeDeviceID: nil,
+            currentOwnerID: nil,
+            lastError: nil
+        )
+    )
+    let server = LocalHTTPServer(
+        configuration: .init(host: "127.0.0.1", port: port),
+        router: makeRouter(sessionController: sessionController, permissionState: .restricted)
+    )
+
+    defer { server.stop() }
+
+    let boundPort = try server.start()
+    let url = try #require(URL(string: "http://127.0.0.1:\(boundPort)/v1/session"))
+    let (data, response) = try await URLSession.shared.data(from: url)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+
+    #expect(httpResponse.statusCode == 200)
+    #expect(
+        String(decoding: data, as: UTF8.self) ==
+        #"{"active_device_id":null,"last_error":null,"owner_id":null,"state":"stopped"}"#
+    )
+}
+
+@Test
+func routerRejectsSessionStartWithoutBearerToken() {
+    let sessionController = makeSessionController(
+        state: CameraState(activeDeviceID: "camera-1")
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/start",
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 401)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"unauthorized","message":"Bearer token missing or invalid"}}"#
+    )
+}
+
+@Test
+func routerRejectsSessionStartWithoutOwnerID() {
+    let sessionController = makeSessionController(
+        state: CameraState(activeDeviceID: "camera-1")
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/start",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":" "}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 400)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_request","message":"owner_id is required"}}"#
+    )
+}
+
+@Test
+func routerRejectsSessionStartWithoutSelectedDevice() {
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/start",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_state","message":"Cannot start session without an active device"}}"#
+    )
+}
+
+@Test
+func routerRejectsSessionStartWithoutAuthorizedPermission() {
+    let sessionController = makeSessionController(
+        state: CameraState(activeDeviceID: "camera-1")
+    )
+    let router = makeRouter(sessionController: sessionController, permissionState: .denied)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/start",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_state","message":"Camera permission is denied"}}"#
+    )
+}
+
+@Test
+func routerReturnsRunningSessionForAuthorizedSessionStart() {
+    let sessionController = makeSessionController(
+        state: CameraState(activeDeviceID: "camera-1")
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/start",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 200)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"active_device_id":"camera-1","last_error":null,"owner_id":"client-1","state":"running"}"#
+    )
+    #expect(sessionController.currentCameraState().sessionState == .running)
+    #expect(sessionController.currentCameraState().currentOwnerID == "client-1")
+}
+
+@Test
+func routerRejectsSessionStopWithoutBearerToken() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/stop",
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 401)
+}
+
+@Test
+func routerRejectsSessionStopWhenAlreadyStopped() {
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/stop",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_state","message":"Session is already stopped"}}"#
+    )
+}
+
+@Test
+func routerRejectsSessionStopForOwnerMismatch() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/stop",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-2"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"ownership_conflict","message":"Session is owned by client-1"}}"#
+    )
+}
+
+@Test
+func routerReturnsStoppedSessionForAuthorizedSessionStop() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .running,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/stop",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 200)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"active_device_id":"camera-1","last_error":null,"owner_id":null,"state":"stopped"}"#
+    )
+    #expect(sessionController.currentCameraState().sessionState == .stopped)
+    #expect(sessionController.currentCameraState().currentOwnerID == nil)
+}
+
+@Test
+func routerRejectsDeviceSelectionWithoutBearerToken() {
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/select-device",
+            body: Data(#"{"device_id":"camera-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 401)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"unauthorized","message":"Bearer token missing or invalid"}}"#
+    )
+    #expect(sessionController.currentCameraState().activeDeviceID == nil)
+}
+
+@Test
+func routerRejectsDeviceSelectionWithMalformedRequestBody() {
+    let sessionController = makeSessionController()
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/select-device",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data("not-json".utf8)
+        )
+    )
+
+    #expect(response.statusCode == 400)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_request","message":"Request body must be valid JSON"}}"#
+    )
+}
+
+@Test
+func routerRejectsDeviceSelectionForUnknownDevice() {
+    let sessionController = makeSessionController(
+        state: CameraState(activeDeviceID: "camera-1"),
+        devices: [CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front)]
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/select-device",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"device_id":"camera-2"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_state","message":"Requested device is unavailable: camera-2"}}"#
+    )
+    #expect(sessionController.currentCameraState().activeDeviceID == "camera-1")
+}
+
+@Test
+func routerRejectsDeviceSelectionForOwnerMismatch() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        ),
+        devices: [
+            CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
+        ]
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/select-device",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"device_id":"camera-2","owner_id":"client-2"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"ownership_conflict","message":"Session is owned by client-1"}}"#
+    )
+    #expect(sessionController.currentCameraState().activeDeviceID == "camera-1")
+}
+
+@Test
+func routerReturnsUpdatedSessionStateForAuthorizedDeviceSelection() {
+    let sessionController = makeSessionController(
+        devices: [
+            CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
+        ]
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/select-device",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"device_id":"camera-2"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 200)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"active_device_id":"camera-2","last_error":null,"owner_id":null,"state":"stopped"}"#
+    )
+    #expect(sessionController.currentCameraState().activeDeviceID == "camera-2")
+}
+
+@Test
+func routerRejectsPhotoCaptureWithoutBearerToken() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/capture/photo",
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 401)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"unauthorized","message":"Bearer token missing or invalid"}}"#
+    )
+}
+
+@Test
+func routerRejectsPhotoCaptureWhenSessionIsStopped() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .stopped,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/capture/photo",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_state","message":"Session is not running"}}"#
+    )
+}
+
+@Test
+func routerRejectsPhotoCaptureForOwnerMismatch() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/capture/photo",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-2"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"ownership_conflict","message":"Session is owned by client-1"}}"#
+    )
+}
+
+@Test
+func routerReturnsPhotoCaptureMetadataForAuthorizedOwner() throws {
+    let directoryURL = makeTemporaryDirectory()
+    let capturedAt = Date(timeIntervalSince1970: 1_710_000_000.123)
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        ),
+        photoProducer: FixedStillPhotoProducer(data: Data([0x01, 0x02, 0x03])),
+        artifactStore: DefaultPhotoArtifactStore(baseDirectoryURL: directoryURL),
+        now: { capturedAt }
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/capture/photo",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 200)
+
+    let payload = try #require(
+        JSONSerialization.jsonObject(with: response.body) as? [String: String]
+    )
+    let localPath = try #require(payload["local_path"])
+    #expect(payload["device_id"] == "camera-1")
+    #expect(payload["captured_at"] == "2024-03-09T16:00:00.123Z")
+    #expect(localPath.hasPrefix(directoryURL.path))
+    #expect(localPath.hasSuffix(".jpg"))
+    #expect(FileManager.default.fileExists(atPath: localPath))
+}
+
+@Test
+func localHTTPServerReturnsUpdatedSessionStateForAuthorizedDeviceSelection() async throws {
+    let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController(
+        devices: [
+            CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
+        ]
+    )
+    let server = LocalHTTPServer(
+        configuration: .init(host: "127.0.0.1", port: port),
+        router: makeRouter(sessionController: sessionController)
+    )
+
+    defer { server.stop() }
+
+    let boundPort = try server.start()
+    var request = URLRequest(
+        url: try #require(URL(string: "http://127.0.0.1:\(boundPort)/v1/session/select-device"))
+    )
+    request.httpMethod = "POST"
+    request.httpBody = Data(#"{"device_id":"camera-2"}"#.utf8)
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("Bearer test-token", forHTTPHeaderField: "Authorization")
+    let (data, response) = try await URLSession.shared.data(for: request)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+
+    #expect(httpResponse.statusCode == 200)
+    #expect(
+        String(decoding: data, as: UTF8.self) ==
+        #"{"active_device_id":"camera-2","last_error":null,"owner_id":null,"state":"stopped"}"#
+    )
+    #expect(sessionController.currentCameraState().activeDeviceID == "camera-2")
+}
+
+@Test
+func localHTTPServerSupportsSessionStartThenStop() async throws {
+    let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController(
+        state: CameraState(activeDeviceID: "camera-1")
+    )
+    let server = LocalHTTPServer(
+        configuration: .init(host: "127.0.0.1", port: port),
+        router: makeRouter(sessionController: sessionController)
+    )
+
+    defer { server.stop() }
+
+    let boundPort = try server.start()
+
+    var startRequest = URLRequest(
+        url: try #require(URL(string: "http://127.0.0.1:\(boundPort)/v1/session/start"))
+    )
+    startRequest.httpMethod = "POST"
+    startRequest.httpBody = Data(#"{"owner_id":"client-1"}"#.utf8)
+    startRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    startRequest.setValue("Bearer test-token", forHTTPHeaderField: "Authorization")
+    let (startData, startResponse) = try await URLSession.shared.data(for: startRequest)
+    let startHTTPResponse = try #require(startResponse as? HTTPURLResponse)
+
+    #expect(startHTTPResponse.statusCode == 200)
+    #expect(
+        String(decoding: startData, as: UTF8.self) ==
+        #"{"active_device_id":"camera-1","last_error":null,"owner_id":"client-1","state":"running"}"#
+    )
+
+    var stopRequest = URLRequest(
+        url: try #require(URL(string: "http://127.0.0.1:\(boundPort)/v1/session/stop"))
+    )
+    stopRequest.httpMethod = "POST"
+    stopRequest.httpBody = Data(#"{"owner_id":"client-1"}"#.utf8)
+    stopRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    stopRequest.setValue("Bearer test-token", forHTTPHeaderField: "Authorization")
+    let (stopData, stopResponse) = try await URLSession.shared.data(for: stopRequest)
+    let stopHTTPResponse = try #require(stopResponse as? HTTPURLResponse)
+
+    #expect(stopHTTPResponse.statusCode == 200)
+    #expect(
+        String(decoding: stopData, as: UTF8.self) ==
+        #"{"active_device_id":"camera-1","last_error":null,"owner_id":null,"state":"stopped"}"#
+    )
+}
+
+private func makeRouter(
+    sessionController: DefaultCameraSessionController,
+    permissionState: PermissionState = .authorized,
+    permissionRequester: any CameraPermissionRequesting = FixedPermissionRequester(
+        result: .init(status: .authorized, prompted: false)
+    ),
+    bearerToken: String = "test-token"
+) -> CameraBridgeRouter {
+    CameraBridgeRouter(
+        routes: CameraBridgeRoutes.current(
+            permissionStatusProvider: FixedPermissionStatusProvider(state: permissionState),
+            permissionRequester: permissionRequester,
+            deviceListing: sessionController,
+            cameraStateProvider: sessionController,
+            deviceSelector: sessionController,
+            sessionStarter: sessionController,
+            sessionStopper: sessionController,
+            photoCapturer: sessionController,
+            authorizer: StaticBearerTokenAuthorizer(bearerToken: bearerToken)
+        )
+    )
+}
+
+private func makeSessionController(
+    state: CameraState = CameraState(),
+    devices: [CameraDevice] = [
+        CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+    ],
+    photoProducer: any CameraStillPhotoProducing = UnimplementedStillPhotoProducer(),
+    artifactStore: any PhotoArtifactStoring = DefaultPhotoArtifactStore(
+        baseDirectoryURL: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("CameraBridgeAPITests", isDirectory: true)
+    ),
+    now: @escaping @Sendable () -> Date = { Date() }
+) -> DefaultCameraSessionController {
+    DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(devices: devices),
+        photoProducer: photoProducer,
+        artifactStore: artifactStore,
+        now: now,
+        initialState: state
+    )
+}
+
 private struct FixedPermissionStatusProvider: CameraPermissionStatusProviding {
     let state: PermissionState
 
     func currentPermissionState() -> PermissionState {
         state
+    }
+}
+
+private struct FixedPermissionRequester: CameraPermissionRequesting {
+    let result: PermissionRequestResult
+
+    func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void) {
+        completion(result)
+    }
+}
+
+private final class RecordingPermissionRequester: CameraPermissionRequesting, @unchecked Sendable {
+    private(set) var requestCount = 0
+    let result: PermissionRequestResult
+
+    init(result: PermissionRequestResult) {
+        self.result = result
+    }
+
+    func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void) {
+        requestCount += 1
+        completion(result)
     }
 }
 
@@ -184,6 +886,25 @@ private struct FixedDeviceListing: CameraDeviceListing {
     func availableDevices() -> [CameraDevice] {
         devices
     }
+}
+
+private struct FixedStillPhotoProducer: CameraStillPhotoProducing {
+    let data: Data
+
+    func capturePhotoData(deviceID: String) throws -> Data {
+        data
+    }
+}
+
+private func makeTemporaryDirectory() -> URL {
+    let directoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("CameraBridgeAPITests-\(UUID().uuidString)", isDirectory: true)
+    try! FileManager.default.createDirectory(
+        at: directoryURL,
+        withIntermediateDirectories: true,
+        attributes: nil
+    )
+    return directoryURL
 }
 
 private func reserveEphemeralPort() throws -> UInt16 {

--- a/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
+++ b/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
@@ -1,6 +1,7 @@
+import AVFoundation
+import Foundation
 import Testing
 @testable import CameraBridgeCore
-import AVFoundation
 
 @Test
 func coreModuleNameMatchesTarget() {
@@ -15,6 +16,7 @@ func cameraStateDefaultsMatchEarlySlice() {
     #expect(state.sessionState == .stopped)
     #expect(state.previewState == .stopped)
     #expect(state.activeDeviceID == nil)
+    #expect(state.currentOwnerID == nil)
     #expect(state.lastError == nil)
 }
 
@@ -24,6 +26,12 @@ func permissionStateRawValuesMatchAPIVocabulary() {
     #expect(PermissionState.restricted.rawValue == "restricted")
     #expect(PermissionState.denied.rawValue == "denied")
     #expect(PermissionState.authorized.rawValue == "authorized")
+}
+
+@Test
+func sessionStateRawValuesMatchAPIVocabulary() {
+    #expect(SessionState.stopped.rawValue == "stopped")
+    #expect(SessionState.running.rawValue == "running")
 }
 
 @Test
@@ -41,6 +49,7 @@ func cameraStateRetainsExplicitValues() {
         sessionState: .running,
         previewState: .running,
         activeDeviceID: "camera-1",
+        currentOwnerID: "client-1",
         lastError: error
     )
 
@@ -48,6 +57,7 @@ func cameraStateRetainsExplicitValues() {
     #expect(state.sessionState == .running)
     #expect(state.previewState == .running)
     #expect(state.activeDeviceID == "camera-1")
+    #expect(state.currentOwnerID == "client-1")
     #expect(state.lastError == error)
 }
 
@@ -73,4 +83,442 @@ func cameraDevicePositionMapsAVFoundationPositionValues() {
     #expect(CameraDevicePosition(position: .front) == .front)
     #expect(CameraDevicePosition(position: .back) == .back)
     #expect(CameraDevicePosition(position: .unspecified) == .external)
+}
+
+@Test
+func defaultCameraStateProviderReturnsConfiguredState() {
+    let state = CameraState(
+        permissionState: .authorized,
+        sessionState: .running,
+        previewState: .stopped,
+        activeDeviceID: "camera-1",
+        currentOwnerID: "client-1",
+        lastError: CameraStateError(message: "session failed")
+    )
+    let provider = DefaultCameraStateProvider(state: state)
+
+    #expect(provider.currentCameraState() == state)
+}
+
+@Test
+func defaultCameraSessionControllerSelectsAvailableDevice() throws {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+                CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
+            ]
+        )
+    )
+
+    let state = try controller.selectDevice(id: "camera-2", ownerID: nil)
+
+    #expect(state.activeDeviceID == "camera-2")
+    #expect(state.currentOwnerID == nil)
+    #expect(state.lastError == nil)
+    #expect(controller.currentCameraState().activeDeviceID == "camera-2")
+}
+
+@Test
+func defaultCameraSessionControllerRejectsUnavailableDevice() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        initialState: CameraState(activeDeviceID: "camera-1")
+    )
+
+    do {
+        _ = try controller.selectDevice(id: "missing-camera", ownerID: nil)
+        Issue.record("Expected unavailable device selection to fail")
+    } catch let error as CameraDeviceSelectionError {
+        #expect(error == .unavailableDevice(id: "missing-camera"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    let state = controller.currentCameraState()
+    #expect(state.activeDeviceID == "camera-1")
+    #expect(state.lastError == CameraStateError(message: "Requested device is unavailable: missing-camera"))
+}
+
+@Test
+func defaultCameraSessionControllerRejectsMismatchedOwner() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.selectDevice(id: "camera-1", ownerID: "client-2")
+        Issue.record("Expected owner mismatch to fail")
+    } catch let error as CameraDeviceSelectionError {
+        #expect(error == .ownershipConflict(currentOwnerID: "client-1"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    let state = controller.currentCameraState()
+    #expect(state.activeDeviceID == "camera-1")
+    #expect(state.currentOwnerID == "client-1")
+    #expect(state.lastError == CameraStateError(message: "Session is owned by client-1"))
+}
+
+@Test
+func defaultCameraSessionControllerStartsSessionWithSelectedDeviceAndOwner() throws {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        initialState: CameraState(
+            permissionState: .notDetermined,
+            sessionState: .stopped,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: nil,
+            lastError: nil
+        )
+    )
+
+    let state = try controller.startSession(ownerID: "client-1", permissionState: .authorized)
+
+    #expect(state.permissionState == .authorized)
+    #expect(state.sessionState == .running)
+    #expect(state.activeDeviceID == "camera-1")
+    #expect(state.currentOwnerID == "client-1")
+    #expect(state.lastError == nil)
+}
+
+@Test
+func defaultCameraSessionControllerRejectsStartWithoutActiveDevice() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        )
+    )
+
+    do {
+        _ = try controller.startSession(ownerID: "client-1", permissionState: .authorized)
+        Issue.record("Expected session start without device to fail")
+    } catch let error as CameraSessionLifecycleError {
+        #expect(error == .missingActiveDevice)
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    let state = controller.currentCameraState()
+    #expect(state.sessionState == .stopped)
+    #expect(state.currentOwnerID == nil)
+    #expect(state.lastError == CameraStateError(message: "Cannot start session without an active device"))
+}
+
+@Test
+func defaultCameraSessionControllerRejectsStartWithoutAuthorizedPermission() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        initialState: CameraState(activeDeviceID: "camera-1")
+    )
+
+    do {
+        _ = try controller.startSession(ownerID: "client-1", permissionState: .denied)
+        Issue.record("Expected session start without permission to fail")
+    } catch let error as CameraSessionLifecycleError {
+        #expect(error == .permissionRequired(status: .denied))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    let state = controller.currentCameraState()
+    #expect(state.permissionState == .denied)
+    #expect(state.sessionState == .stopped)
+    #expect(state.lastError == CameraStateError(message: "Camera permission is denied"))
+}
+
+@Test
+func defaultCameraSessionControllerRejectsStartForOwnerConflict() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .stopped,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.startSession(ownerID: "client-2", permissionState: .authorized)
+        Issue.record("Expected owner conflict on start")
+    } catch let error as CameraSessionLifecycleError {
+        #expect(error == .ownershipConflict(currentOwnerID: "client-1"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(controller.currentCameraState().lastError == CameraStateError(message: "Session is owned by client-1"))
+}
+
+@Test
+func defaultCameraSessionControllerStopsRunningSessionAndReleasesOwner() throws {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .running,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    let state = try controller.stopSession(ownerID: "client-1")
+
+    #expect(state.sessionState == .stopped)
+    #expect(state.previewState == .stopped)
+    #expect(state.activeDeviceID == "camera-1")
+    #expect(state.currentOwnerID == nil)
+    #expect(state.lastError == nil)
+}
+
+@Test
+func defaultCameraSessionControllerRejectsStopWhenAlreadyStopped() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(devices: [])
+    )
+
+    do {
+        _ = try controller.stopSession(ownerID: "client-1")
+        Issue.record("Expected stop on stopped session to fail")
+    } catch let error as CameraSessionLifecycleError {
+        #expect(error == .alreadyStopped)
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(controller.currentCameraState().lastError == CameraStateError(message: "Session is already stopped"))
+}
+
+@Test
+func defaultCameraSessionControllerRejectsStopForOwnerMismatch() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(devices: []),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.stopSession(ownerID: "client-2")
+        Issue.record("Expected owner conflict on stop")
+    } catch let error as CameraSessionLifecycleError {
+        #expect(error == .ownershipConflict(currentOwnerID: "client-1"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(controller.currentCameraState().lastError == CameraStateError(message: "Session is owned by client-1"))
+}
+
+@Test
+func defaultPhotoArtifactStoreWritesPhotoDataToConfiguredDirectory() throws {
+    let directoryURL = makeTemporaryDirectory()
+    let store = DefaultPhotoArtifactStore(baseDirectoryURL: directoryURL)
+    let capturedAt = Date(timeIntervalSince1970: 1_710_000_000.123)
+    let data = Data([0xFF, 0xD8, 0xFF, 0xD9])
+
+    let fileURL = try store.storePhotoData(data, deviceID: "camera-1", capturedAt: capturedAt)
+
+    #expect(fileURL.path.hasPrefix(directoryURL.path))
+    #expect(fileURL.pathExtension == "jpg")
+    #expect(try Data(contentsOf: fileURL) == data)
+}
+
+@Test
+func defaultCameraSessionControllerCapturesPhotoForRunningOwnedSession() throws {
+    let directoryURL = makeTemporaryDirectory()
+    let capturedAt = Date(timeIntervalSince1970: 1_710_000_000.123)
+    let expectedData = Data([0x01, 0x02, 0x03, 0x04])
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front)]
+        ),
+        photoProducer: FixedStillPhotoProducer(data: expectedData),
+        artifactStore: DefaultPhotoArtifactStore(baseDirectoryURL: directoryURL),
+        now: { capturedAt },
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    let artifact = try controller.capturePhoto(ownerID: "client-1")
+
+    #expect(artifact.deviceID == "camera-1")
+    #expect(artifact.capturedAt == capturedAt)
+    #expect(artifact.localPath.hasPrefix(directoryURL.path))
+    #expect(try Data(contentsOf: URL(fileURLWithPath: artifact.localPath)) == expectedData)
+    #expect(controller.currentCameraState().lastError == nil)
+}
+
+@Test
+func defaultCameraSessionControllerRejectsCaptureWhenSessionIsStopped() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front)]
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .stopped,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.capturePhoto(ownerID: "client-1")
+        Issue.record("Expected photo capture on stopped session to fail")
+    } catch let error as CameraPhotoCaptureError {
+        #expect(error == .sessionNotRunning)
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(controller.currentCameraState().lastError == CameraStateError(message: "Session is not running"))
+}
+
+@Test
+func defaultCameraSessionControllerRejectsCaptureForOwnerMismatch() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front)]
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.capturePhoto(ownerID: "client-2")
+        Issue.record("Expected photo capture owner mismatch to fail")
+    } catch let error as CameraPhotoCaptureError {
+        #expect(error == .ownershipConflict(currentOwnerID: "client-1"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(controller.currentCameraState().lastError == CameraStateError(message: "Session is owned by client-1"))
+}
+
+@Test
+func defaultCameraSessionControllerRetainsCaptureFailureAsLastError() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front)]
+        ),
+        photoProducer: FailingStillPhotoProducer(
+            error: .captureFailed(message: "AVFoundation timed out")
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.capturePhoto(ownerID: "client-1")
+        Issue.record("Expected photo capture failure to surface producer error")
+    } catch let error as CameraPhotoCaptureError {
+        #expect(error == .captureFailed(message: "AVFoundation timed out"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(controller.currentCameraState().lastError == CameraStateError(message: "AVFoundation timed out"))
+}
+
+private struct FixedDeviceListing: CameraDeviceListing {
+    let devices: [CameraDevice]
+
+    func availableDevices() -> [CameraDevice] {
+        devices
+    }
+}
+
+private struct FixedStillPhotoProducer: CameraStillPhotoProducing {
+    let data: Data
+
+    func capturePhotoData(deviceID: String) throws -> Data {
+        data
+    }
+}
+
+private struct FailingStillPhotoProducer: CameraStillPhotoProducing {
+    let error: CameraPhotoCaptureError
+
+    func capturePhotoData(deviceID: String) throws -> Data {
+        throw error
+    }
+}
+
+private func makeTemporaryDirectory() -> URL {
+    let directoryURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("CameraBridgeCoreTests-\(UUID().uuidString)", isDirectory: true)
+    try! FileManager.default.createDirectory(
+        at: directoryURL,
+        withIntermediateDirectories: true,
+        attributes: nil
+    )
+    return directoryURL
 }


### PR DESCRIPTION
## Summary
- consolidate the validated backend camera flow into one clean branch on top of current `main`
- land permission request, session state, device selection, session start and stop, and still photo capture together
- replace the stale stacked backend PR chain with one tested integration slice

## Files Changed
- `README.md`
- `apps/camd/Sources/camd/CameraBridgeDaemon.swift`
- `docs/api/v1.md`
- `packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift`
- `packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift`
- `tests/CameraBridgeAPITests/CameraBridgeAPITests.swift`
- `tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift`

## How Tested
- `swift test`

## Manual Verification Notes
- this consolidation branch is built from the previously validated integration path that exercised permission request, device selection, session start, and real still-photo capture on local hardware
- later app-owned validation also succeeded on top of this backend surface through the packaged app path

## Deferred
- preview transport
- richer app UX and onboarding polish
- additional example clients beyond the minimal docs/example slice

Supersedes the stale backend stack in #31, #32, #33, #34, and #35.