### PR TITLE
Polish CameraBridgeApp onboarding shell

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -68,5 +68,10 @@ let package = Package(
             dependencies: ["CameraBridgeClientSwift"],
             path: "tests/CameraBridgeClientSwiftTests"
         ),
+        .testTarget(
+            name: "CameraBridgeAppTests",
+            dependencies: ["CameraBridgeApp"],
+            path: "tests/CameraBridgeAppTests"
+        ),
     ]
 )

--- a/apps/CameraBridgeApp/README.md
+++ b/apps/CameraBridgeApp/README.md
@@ -2,6 +2,15 @@
 
 `CameraBridgeApp` is reserved for the macOS menu bar application, onboarding flow, and service status UI.
 
+The app remains a thin client of the localhost CameraBridge service. Its menu bar shell is limited to:
+
+- service running or stopped visibility
+- camera permission visibility
+- onboarding guidance for the next user action
+- starting the bundled `camd` service
+- requesting camera access through the public API
+- quitting the app
+
 ## Local Packaging
 
 Package a local `.app` bundle with:
@@ -27,3 +36,21 @@ When the app starts the service itself, it persists the local bearer token at:
 ```text
 ~/Library/Application Support/CameraBridge/auth-token
 ```
+
+## Manual Verification
+
+Use the packaged app bundle for manual verification:
+
+1. Run `apps/CameraBridgeApp/scripts/package-app.sh`.
+2. Launch `CameraBridgeApp.app` from Finder or with `open "$(swift build --show-bin-path)/CameraBridgeApp.app"`.
+3. Confirm the menu shows:
+   - a clear service status row
+   - a clear permission status row
+   - a guidance row describing the next onboarding step
+4. With the service stopped, confirm `Start CameraBridge Service` is enabled and permission request is disabled.
+5. After starting the service, confirm the menu updates to show the running state.
+6. With permission not yet granted, confirm `Request Camera Access` is enabled and the guidance text points the user to that action.
+7. After granting permission, confirm the menu reports that CameraBridge is ready.
+8. If service launch or permission request fails, confirm the last error row appears with readable wording.
+
+Capture screenshots of the refined menu states when practical for PR notes.

--- a/apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift
+++ b/apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift
@@ -12,13 +12,13 @@ final class CameraBridgeAppModel {
         var title: String {
             switch self {
             case .stopped:
-                return "stopped"
+                return "Stopped"
             case .starting:
-                return "starting"
+                return "Starting"
             case .running:
-                return "running"
+                return "Running"
             case .failed:
-                return "failed"
+                return "Needs Attention"
             }
         }
 
@@ -42,17 +42,17 @@ final class CameraBridgeAppModel {
         var title: String {
             switch self {
             case .unavailable:
-                return "unavailable"
+                return "Unavailable"
             case .checking:
-                return "checking"
+                return "Requesting Access"
             case .notDetermined:
-                return "not determined"
+                return "Not Determined"
             case .restricted:
-                return "restricted"
+                return "Restricted"
             case .denied:
-                return "denied"
+                return "Denied"
             case .authorized:
-                return "authorized"
+                return "Authorized"
             }
         }
 
@@ -80,6 +80,48 @@ final class CameraBridgeAppModel {
         permissionDisplay.title
     }
 
+    var statusSummaryTitle: String {
+        switch (serviceStatus, permissionDisplay) {
+        case (.starting, _):
+            return "CameraBridge is starting"
+        case (.stopped, _):
+            return "Local service is stopped"
+        case (.failed, _):
+            return "CameraBridge needs attention"
+        case (.running, .checking):
+            return "Waiting for camera access"
+        case (.running, .notDetermined):
+            return "Camera access setup is incomplete"
+        case (.running, .restricted), (.running, .denied):
+            return "Camera access is unavailable"
+        case (.running, .authorized):
+            return "CameraBridge is ready"
+        case (.running, .unavailable):
+            return "Service is running"
+        }
+    }
+
+    var guidanceMessage: String {
+        switch (serviceStatus, permissionDisplay) {
+        case (.starting, _):
+            return "Waiting for the local CameraBridge service to respond."
+        case (.stopped, _), (.failed, _):
+            return "Start the local service to check camera permissions and finish onboarding."
+        case (.running, .checking):
+            return "Respond to the macOS camera permission prompt if it appears."
+        case (.running, .notDetermined):
+            return "Request camera access to complete the app-owned onboarding flow."
+        case (.running, .restricted):
+            return "Camera access is restricted on this Mac and cannot be granted from CameraBridge."
+        case (.running, .denied):
+            return "Camera access was denied. Re-enable it in System Settings > Privacy & Security > Camera."
+        case (.running, .authorized):
+            return "The service is running and camera access is available."
+        case (.running, .unavailable):
+            return "The service is running, but permission status could not be loaded."
+        }
+    }
+
     var lastErrorMessage: String? {
         lastError
     }
@@ -103,11 +145,11 @@ final class CameraBridgeAppModel {
     private var isRequestInFlight = false
     private var refreshTimer: Timer?
 
-    private let client: CameraBridgeClient
+    private let client: any CameraBridgeAppClient
     private let serviceLauncher: any CameraBridgeServiceLaunching
 
     init(
-        client: CameraBridgeClient? = nil,
+        client: (any CameraBridgeAppClient)? = nil,
         authTokenStore: any CameraBridgeAuthTokenStoring = DefaultCameraBridgeAuthTokenStore(),
         serviceLauncher: (any CameraBridgeServiceLaunching)? = nil
     ) {
@@ -139,20 +181,32 @@ final class CameraBridgeAppModel {
 
     func refresh() {
         Task { @MainActor in
-            await refreshState()
+            await refreshNow()
         }
     }
 
     func startService() {
         Task { @MainActor in
-            await performStartService()
+            await startServiceNow()
         }
     }
 
     func requestCameraAccess() {
         Task { @MainActor in
-            await performRequestCameraAccess()
+            await requestCameraAccessNow()
         }
+    }
+
+    func refreshNow() async {
+        await refreshState()
+    }
+
+    func startServiceNow() async {
+        await performStartService()
+    }
+
+    func requestCameraAccessNow() async {
+        await performRequestCameraAccess()
     }
 
     private func publishChange() {
@@ -255,6 +309,14 @@ protocol CameraBridgeAuthTokenStoring {
     func loadOrCreateToken() throws -> String
 }
 
+protocol CameraBridgeAppClient {
+    func serviceIsRunning() async -> Bool
+    func permissionStatus() async throws -> CameraBridgePermissionStatus
+    func requestPermission() async throws -> CameraBridgePermissionRequestResult
+}
+
+extension CameraBridgeClient: CameraBridgeAppClient {}
+
 enum CameraBridgeAuthTokenError: LocalizedError {
     case invalidTokenFile
     case supportDirectoryUnavailable
@@ -333,11 +395,11 @@ enum CameraBridgeServiceLaunchError: LocalizedError {
 final class LocalCameraBridgeServiceLauncher: CameraBridgeServiceLaunching {
     private static let authTokenEnvironmentVariable = "CAMERABRIDGE_AUTH_TOKEN"
 
-    private let client: CameraBridgeClient
+    private let client: any CameraBridgeAppClient
     private let authTokenStore: any CameraBridgeAuthTokenStoring
     private var process: Process?
 
-    init(client: CameraBridgeClient, authTokenStore: any CameraBridgeAuthTokenStoring) {
+    init(client: any CameraBridgeAppClient, authTokenStore: any CameraBridgeAuthTokenStoring) {
         self.client = client
         self.authTokenStore = authTokenStore
     }

--- a/apps/CameraBridgeApp/Sources/CameraBridgeApp/main.swift
+++ b/apps/CameraBridgeApp/Sources/CameraBridgeApp/main.swift
@@ -52,17 +52,23 @@ final class CameraBridgeStatusBarDelegate: NSObject, NSApplicationDelegate {
     private func makeMenu() -> NSMenu {
         let menu = NSMenu()
 
+        menu.addItem(disabledItem(title: "CameraBridge"))
+        menu.addItem(disabledItem(title: model.statusSummaryTitle))
+        menu.addItem(.separator())
+
         menu.addItem(disabledItem(title: "Service: \(model.serviceStatusTitle)"))
         menu.addItem(disabledItem(title: "Permission: \(model.permissionStatusTitle)"))
+        menu.addItem(disabledItem(title: model.guidanceMessage))
 
         if let lastError = model.lastErrorMessage {
+            menu.addItem(.separator())
             menu.addItem(disabledItem(title: "Last error: \(lastError)"))
         }
 
         menu.addItem(.separator())
 
         let startServiceItem = NSMenuItem(
-            title: "Start Service",
+            title: "Start CameraBridge Service",
             action: #selector(startService(_:)),
             keyEquivalent: ""
         )

--- a/tests/CameraBridgeAppTests/CameraBridgeAppModelTests.swift
+++ b/tests/CameraBridgeAppTests/CameraBridgeAppModelTests.swift
@@ -1,0 +1,224 @@
+import CameraBridgeClientSwift
+import Foundation
+import Testing
+@testable import CameraBridgeApp
+
+@Test
+@MainActor
+func stoppedServiceStateShowsStartGuidance() async {
+    let client = FakeCameraBridgeAppClient()
+    await client.setServiceIsRunning(false)
+    let model = CameraBridgeAppModel(client: client, serviceLauncher: FakeServiceLauncher())
+
+    await model.refreshNow()
+
+    #expect(model.statusSummaryTitle == "Local service is stopped")
+    #expect(model.serviceStatusTitle == "Stopped")
+    #expect(model.permissionStatusTitle == "Unavailable")
+    #expect(model.guidanceMessage == "Start the local service to check camera permissions and finish onboarding.")
+    #expect(model.canStartService)
+    #expect(!model.canRequestCameraAccess)
+    #expect(model.lastErrorMessage == nil)
+}
+
+@Test(arguments: [
+    (
+        CameraBridgePermissionStatus.notDetermined,
+        "Camera access setup is incomplete",
+        "Request camera access to complete the app-owned onboarding flow."
+    ),
+    (
+        CameraBridgePermissionStatus.restricted,
+        "Camera access is unavailable",
+        "Camera access is restricted on this Mac and cannot be granted from CameraBridge."
+    ),
+    (
+        CameraBridgePermissionStatus.denied,
+        "Camera access is unavailable",
+        "Camera access was denied. Re-enable it in System Settings > Privacy & Security > Camera."
+    ),
+    (
+        CameraBridgePermissionStatus.authorized,
+        "CameraBridge is ready",
+        "The service is running and camera access is available."
+    ),
+])
+@MainActor
+func runningServiceShowsPermissionSpecificGuidance(
+    permissionStatus: CameraBridgePermissionStatus,
+    expectedSummary: String,
+    expectedGuidance: String
+) async {
+    let client = FakeCameraBridgeAppClient()
+    await client.setServiceIsRunning(true)
+    await client.setPermissionStatus(.success(permissionStatus))
+    let model = CameraBridgeAppModel(client: client, serviceLauncher: FakeServiceLauncher())
+
+    await model.refreshNow()
+
+    #expect(model.serviceStatusTitle == "Running")
+    #expect(model.permissionStatusTitle == permissionStatusTitle(permissionStatus))
+    #expect(model.statusSummaryTitle == expectedSummary)
+    #expect(model.guidanceMessage == expectedGuidance)
+}
+
+@Test
+@MainActor
+func startServiceFailureShowsErrorState() async {
+    let client = FakeCameraBridgeAppClient()
+    await client.setServiceIsRunning(false)
+    let launcher = FakeServiceLauncher()
+    launcher.error = CameraBridgeServiceLaunchError.failedToStartService
+    let model = CameraBridgeAppModel(client: client, serviceLauncher: launcher)
+
+    await model.startServiceNow()
+
+    #expect(model.serviceStatusTitle == "Needs Attention")
+    #expect(model.guidanceMessage == "Start the local service to check camera permissions and finish onboarding.")
+    #expect(model.lastErrorMessage == "Service did not become healthy after launch")
+    #expect(model.canStartService)
+}
+
+@Test
+@MainActor
+func permissionRequestFailureShowsErrorAndKeepsActionAvailable() async {
+    let client = FakeCameraBridgeAppClient()
+    await client.setServiceIsRunning(true)
+    await client.setPermissionStatus(.success(.notDetermined))
+    await client.setRequestPermissionResult(.failure(CameraBridgeClientError.requestFailed(
+        statusCode: 401,
+        code: "unauthorized",
+        message: "Bearer token missing or invalid"
+    )))
+    let model = CameraBridgeAppModel(client: client, serviceLauncher: FakeServiceLauncher())
+
+    await model.refreshNow()
+    await model.requestCameraAccessNow()
+
+    #expect(model.permissionStatusTitle == "Unavailable")
+    #expect(model.statusSummaryTitle == "Service is running")
+    #expect(model.guidanceMessage == "The service is running, but permission status could not be loaded.")
+    #expect(model.lastErrorMessage == "Bearer token missing or invalid")
+    #expect(model.canRequestCameraAccess)
+}
+
+@Test
+@MainActor
+func startServiceDisablesActionWhileLaunchIsInFlight() async {
+    let client = FakeCameraBridgeAppClient()
+    await client.setServiceIsRunning(false)
+    let launcher = FakeServiceLauncher()
+    let model = CameraBridgeAppModel(client: client, serviceLauncher: launcher)
+
+    let task = Task {
+        await model.startServiceNow()
+    }
+    await Task.yield()
+
+    #expect(model.serviceStatusTitle == "Starting")
+    #expect(model.statusSummaryTitle == "CameraBridge is starting")
+    #expect(!model.canStartService)
+
+    await client.setServiceIsRunning(true)
+    await client.setPermissionStatus(.success(.authorized))
+    launcher.finish()
+    await task.value
+
+    #expect(model.serviceStatusTitle == "Running")
+    #expect(model.canRequestCameraAccess)
+}
+
+@Test
+@MainActor
+func permissionRequestDisablesActionWhilePromptIsInFlight() async {
+    let client = FakeCameraBridgeAppClient()
+    await client.setServiceIsRunning(true)
+    await client.setPermissionStatus(.success(.notDetermined))
+    let model = CameraBridgeAppModel(client: client, serviceLauncher: FakeServiceLauncher())
+
+    await model.refreshNow()
+    let task = Task {
+        await model.requestCameraAccessNow()
+    }
+    await Task.yield()
+
+    #expect(model.permissionStatusTitle == "Requesting Access")
+    #expect(model.statusSummaryTitle == "Waiting for camera access")
+    #expect(!model.canRequestCameraAccess)
+
+    await client.setRequestPermissionResult(.success(.init(status: .authorized, prompted: true)))
+    await client.setPermissionStatus(.success(.authorized))
+    await task.value
+
+    #expect(model.permissionStatusTitle == "Authorized")
+    #expect(model.statusSummaryTitle == "CameraBridge is ready")
+    #expect(model.canRequestCameraAccess)
+}
+
+private func permissionStatusTitle(_ status: CameraBridgePermissionStatus) -> String {
+    switch status {
+    case .notDetermined:
+        return "Not Determined"
+    case .restricted:
+        return "Restricted"
+    case .denied:
+        return "Denied"
+    case .authorized:
+        return "Authorized"
+    }
+}
+
+private actor FakeCameraBridgeAppClient: CameraBridgeAppClient {
+    private var isRunning = false
+    private var permissionStatusResult: Result<CameraBridgePermissionStatus, Error> = .success(.notDetermined)
+    private var requestPermissionResult: Result<CameraBridgePermissionRequestResult, Error>?
+
+    func setServiceIsRunning(_ value: Bool) {
+        isRunning = value
+    }
+
+    func setPermissionStatus(_ result: Result<CameraBridgePermissionStatus, Error>) {
+        permissionStatusResult = result
+    }
+
+    func setRequestPermissionResult(_ result: Result<CameraBridgePermissionRequestResult, Error>) {
+        requestPermissionResult = result
+    }
+
+    func serviceIsRunning() async -> Bool {
+        isRunning
+    }
+
+    func permissionStatus() async throws -> CameraBridgePermissionStatus {
+        try permissionStatusResult.get()
+    }
+
+    func requestPermission() async throws -> CameraBridgePermissionRequestResult {
+        while requestPermissionResult == nil {
+            await Task.yield()
+        }
+
+        return try requestPermissionResult!.get()
+    }
+}
+
+@MainActor
+private final class FakeServiceLauncher: CameraBridgeServiceLaunching {
+    var error: Error?
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func startIfNeeded() async throws {
+        if let error {
+            throw error
+        }
+
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func finish() {
+        continuation?.resume()
+        continuation = nil
+    }
+}


### PR DESCRIPTION
## Summary
- polish the `CameraBridgeApp` menu bar shell with clearer service, permission, and onboarding guidance copy
- reorganize the status menu into summary, status, guidance, error, and action sections without expanding app scope
- add `CameraBridgeAppTests` coverage for app-model presentation states and action gating
- document the refined shell behavior and manual verification steps in the app README

## Files Changed
- `Package.swift`
- `apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift`
- `apps/CameraBridgeApp/Sources/CameraBridgeApp/main.swift`
- `apps/CameraBridgeApp/README.md`
- `tests/CameraBridgeAppTests/CameraBridgeAppModelTests.swift`

## How It Was Tested
- `swift test`
- packaged `CameraBridgeApp.app` locally with `apps/CameraBridgeApp/scripts/package-app.sh`
- launched the packaged app bundle
- manually verified the app could start the service, request camera permission, and reach the ready state from the menu bar shell

## Deferred
- no new backend endpoints
- no app capture or session controls
- no launch-at-login or URL scheme work
- localhost connectivity mismatch from terminal clients after app-launched `camd` was split into a follow-up issue