### PR TITLE
Enforce localhost bind contract for camd

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -57,6 +57,8 @@ When the app starts the service, it stores the local bearer token at:
 ~/Library/Application Support/CameraBridge/auth-token
 ```
 
+The packaged app starts `camd` as a localhost-only service intended to be reachable from other local clients at `127.0.0.1:8731`.
+
 Camera captures are stored under:
 
 ```text

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -469,7 +469,10 @@ public final class LocalHTTPServer: @unchecked Sendable {
             throw HTTPServerError.invalidPort(configuration.port)
         }
 
-        let listener = try NWListener(using: .tcp, on: port)
+        let localEndpoint = try resolvedLocalEndpoint(port: port)
+        let parameters = NWParameters.tcp
+        parameters.requiredLocalEndpoint = localEndpoint
+        let listener = try NWListener(using: parameters)
         let readySemaphore = DispatchSemaphore(value: 0)
         var startError: Error?
 
@@ -563,10 +566,35 @@ public final class LocalHTTPServer: @unchecked Sendable {
             connection.cancel()
         })
     }
+
+    private func resolvedLocalEndpoint(port: NWEndpoint.Port) throws -> NWEndpoint {
+        guard let host = resolvedLoopbackHost() else {
+            throw HTTPServerError.invalidHost(configuration.host)
+        }
+
+        return .hostPort(host: host, port: port)
+    }
+
+    private func resolvedLoopbackHost() -> NWEndpoint.Host? {
+        let normalizedHost = configuration.host.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        switch normalizedHost {
+        case "127.0.0.1":
+            return .ipv4(.loopback)
+        case "::1":
+            return .ipv6(.loopback)
+        case "localhost":
+            return .ipv4(.loopback)
+        default:
+            return nil
+        }
+    }
 }
 
 public enum HTTPServerError: Error, Sendable, Equatable {
     case invalidPort(UInt16)
+    case invalidHost(String)
 }
 
 private struct RouteKey: Hashable, Sendable {

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -51,6 +51,40 @@ func localHTTPServerReturnsHealthResponse() async throws {
 }
 
 @Test
+func localHTTPServerReturnsHealthResponseForLocalhostAlias() async throws {
+    let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController()
+    let server = LocalHTTPServer(
+        configuration: .init(host: "localhost", port: port),
+        router: makeRouter(sessionController: sessionController)
+    )
+
+    defer { server.stop() }
+
+    let boundPort = try server.start()
+    let url = try #require(URL(string: "http://127.0.0.1:\(boundPort)/health"))
+    let (data, response) = try await URLSession.shared.data(from: url)
+    let httpResponse = try #require(response as? HTTPURLResponse)
+
+    #expect(httpResponse.statusCode == 200)
+    #expect(String(decoding: data, as: UTF8.self) == #"{ "status": "ok" }"#)
+}
+
+@Test
+func localHTTPServerRejectsInvalidHostConfiguration() throws {
+    let port = try reserveEphemeralPort()
+    let sessionController = makeSessionController()
+    let server = LocalHTTPServer(
+        configuration: .init(host: "camera-bridge.local", port: port),
+        router: makeRouter(sessionController: sessionController)
+    )
+
+    #expect(throws: HTTPServerError.invalidHost("camera-bridge.local")) {
+        _ = try server.start()
+    }
+}
+
+@Test
 func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
     let port = try reserveEphemeralPort()
     let sessionController = makeSessionController()


### PR DESCRIPTION
## Summary
- make `LocalHTTPServer` enforce the configured loopback host instead of ignoring it during listener startup
- fail fast for unsupported host values with an explicit `invalidHost` server error
- add API/server tests for `127.0.0.1`, `localhost`, and invalid-host startup behavior
- clarify in quick start that the packaged app starts a localhost-only daemon intended to be reachable at `127.0.0.1:8731`

## Files Changed
- `packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift`
- `tests/CameraBridgeAPITests/CameraBridgeAPITests.swift`
- `docs/quick-start.md`

## How It Was Tested
- `swift test --filter CameraBridgeAPITests`
- `swift test`
- packaged `CameraBridgeApp.app` locally and launched it
- manually started the service from the menu bar app
- verified an unsandboxed terminal client could reach `http://127.0.0.1:8731/health` and `http://127.0.0.1:8731/v1/permissions`
- confirmed the bundled `camd` process was listening on `127.0.0.1:8731`

## Deferred
- no endpoint contract changes
- no auth or ownership changes
- no broader networking/config redesign beyond enforcing the existing localhost bind contract