### PR TITLE
Define core-owned permission control contract

### DIFF
--- a/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
+++ b/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
@@ -91,6 +91,8 @@ public protocol CameraPermissionRequesting: Sendable {
     func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void)
 }
 
+public protocol CameraPermissionControlling: CameraPermissionStatusProviding, CameraPermissionRequesting {}
+
 public protocol CameraStateProviding: Sendable {
     func currentCameraState() -> CameraState
 }
@@ -348,7 +350,9 @@ public struct DefaultCameraStateProvider: CameraStateProviding {
     }
 }
 
-public final class DefaultCameraSessionController: CameraStateProviding, CameraDeviceListing, CameraDeviceSelecting, CameraSessionStarting, CameraSessionStopping, CameraPhotoCapturing, @unchecked Sendable {
+public final class DefaultCameraSessionController: CameraPermissionControlling, CameraStateProviding, CameraDeviceListing, CameraDeviceSelecting, CameraSessionStarting, CameraSessionStopping, CameraPhotoCapturing, @unchecked Sendable {
+    private let permissionStatusProvider: any CameraPermissionStatusProviding
+    private let permissionRequester: any CameraPermissionRequesting
     private let deviceListing: any CameraDeviceListing
     private let photoProducer: any CameraStillPhotoProducing
     private let artifactStore: any PhotoArtifactStoring
@@ -357,12 +361,16 @@ public final class DefaultCameraSessionController: CameraStateProviding, CameraD
     private var state: CameraState
 
     public init(
+        permissionStatusProvider: any CameraPermissionStatusProviding = AVFoundationCameraPermissionStatusProvider(),
+        permissionRequester: any CameraPermissionRequesting = AVFoundationCameraPermissionRequester(),
         deviceListing: any CameraDeviceListing,
         photoProducer: any CameraStillPhotoProducing = UnimplementedStillPhotoProducer(),
         artifactStore: any PhotoArtifactStoring = DefaultPhotoArtifactStore(),
         now: @escaping @Sendable () -> Date = { Date() },
         initialState: CameraState = CameraState()
     ) {
+        self.permissionStatusProvider = permissionStatusProvider
+        self.permissionRequester = permissionRequester
         self.deviceListing = deviceListing
         self.photoProducer = photoProducer
         self.artifactStore = artifactStore
@@ -370,10 +378,51 @@ public final class DefaultCameraSessionController: CameraStateProviding, CameraD
         self.state = initialState
     }
 
+    public convenience init(
+        deviceListing: any CameraDeviceListing,
+        photoProducer: any CameraStillPhotoProducing = UnimplementedStillPhotoProducer(),
+        artifactStore: any PhotoArtifactStoring = DefaultPhotoArtifactStore(),
+        now: @escaping @Sendable () -> Date = { Date() },
+        initialState: CameraState = CameraState()
+    ) {
+        self.init(
+            permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
+            permissionRequester: AVFoundationCameraPermissionRequester(),
+            deviceListing: deviceListing,
+            photoProducer: photoProducer,
+            artifactStore: artifactStore,
+            now: now,
+            initialState: initialState
+        )
+    }
+
     public func currentCameraState() -> CameraState {
         stateLock.lock()
         defer { stateLock.unlock() }
         return state
+    }
+
+    public func currentPermissionState() -> PermissionState {
+        let permissionState = permissionStatusProvider.currentPermissionState()
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        state.permissionState = permissionState
+        return permissionState
+    }
+
+    public func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void) {
+        permissionRequester.requestPermission { [weak self] result in
+            guard let self else {
+                completion(result)
+                return
+            }
+
+            self.stateLock.lock()
+            self.state.permissionState = result.status
+            self.state.lastError = nil
+            self.stateLock.unlock()
+            completion(result)
+        }
     }
 
     public func availableDevices() -> [CameraDevice] {

--- a/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
+++ b/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Dispatch
 import Foundation
 import Testing
 @testable import CameraBridgeCore
@@ -98,6 +99,43 @@ func defaultCameraStateProviderReturnsConfiguredState() {
     let provider = DefaultCameraStateProvider(state: state)
 
     #expect(provider.currentCameraState() == state)
+}
+
+@Test
+func defaultCameraSessionControllerSyncsPermissionStateFromProvider() {
+    let controller = DefaultCameraSessionController(
+        permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted),
+        permissionRequester: FixedPermissionRequester(result: .init(status: .authorized, prompted: false)),
+        deviceListing: FixedDeviceListing(devices: [])
+    )
+
+    let permissionState = controller.currentPermissionState()
+
+    #expect(permissionState == .restricted)
+    #expect(controller.currentCameraState().permissionState == .restricted)
+}
+
+@Test
+func defaultCameraSessionControllerUpdatesPermissionStateWhenRequestingPermission() {
+    let controller = DefaultCameraSessionController(
+        permissionStatusProvider: FixedPermissionStatusProvider(state: .notDetermined),
+        permissionRequester: FixedPermissionRequester(result: .init(status: .authorized, prompted: true)),
+        deviceListing: FixedDeviceListing(devices: []),
+        initialState: CameraState(lastError: CameraStateError(message: "stale error"))
+    )
+    let semaphore = DispatchSemaphore(value: 0)
+    let expectedResult = PermissionRequestResult(status: .authorized, prompted: true)
+    let resultBox = PermissionRequestResultBox()
+
+    controller.requestPermission { result in
+        resultBox.result = result
+        semaphore.signal()
+    }
+
+    #expect(semaphore.wait(timeout: .now() + 1) == .success)
+    #expect(resultBox.result == expectedResult)
+    #expect(controller.currentCameraState().permissionState == .authorized)
+    #expect(controller.currentCameraState().lastError == nil)
 }
 
 @Test
@@ -494,6 +532,26 @@ private struct FixedDeviceListing: CameraDeviceListing {
     func availableDevices() -> [CameraDevice] {
         devices
     }
+}
+
+private struct FixedPermissionStatusProvider: CameraPermissionStatusProviding {
+    let state: PermissionState
+
+    func currentPermissionState() -> PermissionState {
+        state
+    }
+}
+
+private struct FixedPermissionRequester: CameraPermissionRequesting {
+    let result: PermissionRequestResult
+
+    func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void) {
+        completion(result)
+    }
+}
+
+private final class PermissionRequestResultBox: @unchecked Sendable {
+    var result: PermissionRequestResult?
 }
 
 private struct FixedStillPhotoProducer: CameraStillPhotoProducing {


### PR DESCRIPTION
## Summary

Define a Core-owned permission control contract on `DefaultCameraSessionController` so permission reads and permission requests can live behind one Core surface. This keeps the existing initializer shape intact for current callers while making the controller itself conform to the new contract and sync `CameraState.permissionState` as permission operations occur.

## Issue

Closes #52

## Files Changed

- `packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift`
- `tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift`

## Testing

- [ ] `swift build`
- [x] `swift test`
- [ ] Manual verification completed
- [ ] Not run, explained below

Testing notes:
Added focused Core tests for permission-state synchronization from the injected provider and permission-request state updates.

## Deferred

- API route rewiring remains in #53
- Additional regression coverage beyond the Core contract remains in #54
- Docs updates remain in #55

## AGENTS.md Check

- [x] Scope stayed focused on one issue
- [x] Unrelated files were not changed without cause
- [ ] Docs were updated if public behavior changed
