### PR TITLE
Use core-owned permission control in API routes

### DIFF
--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -45,8 +45,7 @@ struct CameraBridgeDaemon {
         )
         return CameraBridgeRouter(
             routes: CameraBridgeRoutes.current(
-                permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
-                permissionRequester: AVFoundationCameraPermissionRequester(),
+                permissionController: sessionController,
                 deviceListing: sessionController,
                 cameraStateProvider: sessionController,
                 deviceSelector: sessionController,

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -133,8 +133,7 @@ public struct CameraBridgeRouter: Sendable {
 
 public enum CameraBridgeRoutes {
     public static func current(
-        permissionStatusProvider: any CameraPermissionStatusProviding,
-        permissionRequester: any CameraPermissionRequesting,
+        permissionController: any CameraPermissionControlling,
         deviceListing: any CameraDeviceListing,
         cameraStateProvider: any CameraStateProviding,
         deviceSelector: any CameraDeviceSelecting,
@@ -145,13 +144,13 @@ public enum CameraBridgeRoutes {
     ) -> [HTTPRoute] {
         [
             health(),
-            permissionStatus(provider: permissionStatusProvider),
-            permissionRequest(requester: permissionRequester, authorizer: authorizer),
+            permissionStatus(controller: permissionController),
+            permissionRequest(controller: permissionController, authorizer: authorizer),
             devices(deviceListing: deviceListing),
             sessionState(provider: cameraStateProvider),
             sessionStart(
                 starter: sessionStarter,
-                permissionStatusProvider: permissionStatusProvider,
+                permissionController: permissionController,
                 authorizer: authorizer
             ),
             sessionStop(stopper: sessionStopper, authorizer: authorizer),
@@ -166,17 +165,17 @@ public enum CameraBridgeRoutes {
         }
     }
 
-    public static func permissionStatus(provider: any CameraPermissionStatusProviding) -> HTTPRoute {
+    public static func permissionStatus(controller: any CameraPermissionStatusProviding) -> HTTPRoute {
         HTTPRoute(method: .get, path: "/v1/permissions") { _ in
             .json(
                 statusCode: 200,
-                body: #"{ "status": "\#(provider.currentPermissionState().rawValue)" }"#
+                body: #"{ "status": "\#(controller.currentPermissionState().rawValue)" }"#
             )
         }
     }
 
     public static func permissionRequest(
-        requester: any CameraPermissionRequesting,
+        controller: any CameraPermissionRequesting,
         authorizer: any BearerTokenAuthorizing
     ) -> HTTPRoute {
         HTTPRoute(method: .post, path: "/v1/permissions/request") { request in
@@ -187,7 +186,7 @@ public enum CameraBridgeRoutes {
             let semaphore = DispatchSemaphore(value: 0)
             let resultBox = PermissionRequestResultBox()
 
-            requester.requestPermission { permissionResult in
+            controller.requestPermission { permissionResult in
                 resultBox.result = permissionResult
                 semaphore.signal()
             }
@@ -220,7 +219,7 @@ public enum CameraBridgeRoutes {
 
     public static func sessionStart(
         starter: any CameraSessionStarting,
-        permissionStatusProvider: any CameraPermissionStatusProviding,
+        permissionController: any CameraPermissionStatusProviding,
         authorizer: any BearerTokenAuthorizing
     ) -> HTTPRoute {
         HTTPRoute(method: .post, path: "/v1/session/start") { request in
@@ -243,7 +242,7 @@ public enum CameraBridgeRoutes {
             do {
                 let state = try starter.startSession(
                     ownerID: ownerID,
-                    permissionState: permissionStatusProvider.currentPermissionState()
+                    permissionState: permissionController.currentPermissionState()
                 )
                 return .json(statusCode: 200, body: SessionStateResponse(state: state))
             } catch let error as CameraSessionLifecycleError {

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -110,8 +110,10 @@ func localHTTPServerStillReturnsNotFoundForUnknownRoute() async throws {
 
 @Test(arguments: PermissionState.allCases)
 func routerReturnsPermissionStatusForProviderState(_ state: PermissionState) {
-    let sessionController = makeSessionController()
-    let router = makeRouter(sessionController: sessionController, permissionState: state)
+    let sessionController = makeSessionController(
+        permissionStatusProvider: FixedPermissionStatusProvider(state: state)
+    )
+    let router = makeRouter(sessionController: sessionController)
     let response = router.response(for: HTTPRequest(method: .get, path: "/v1/permissions"))
 
     #expect(response.statusCode == 200)
@@ -121,10 +123,12 @@ func routerReturnsPermissionStatusForProviderState(_ state: PermissionState) {
 @Test
 func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
     let port = try reserveEphemeralPort()
-    let sessionController = makeSessionController()
+    let sessionController = makeSessionController(
+        permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted)
+    )
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: makeRouter(sessionController: sessionController, permissionState: .restricted)
+        router: makeRouter(sessionController: sessionController)
     )
 
     defer { server.stop() }
@@ -141,8 +145,8 @@ func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
 @Test
 func routerRejectsPermissionRequestWithoutBearerToken() {
     let requester = RecordingPermissionRequester(result: .init(status: .authorized, prompted: true))
-    let sessionController = makeSessionController()
-    let router = makeRouter(sessionController: sessionController, permissionRequester: requester)
+    let sessionController = makeSessionController(permissionRequester: requester)
+    let router = makeRouter(sessionController: sessionController)
     let response = router.response(for: HTTPRequest(method: .post, path: "/v1/permissions/request"))
 
     #expect(response.statusCode == 401)
@@ -156,8 +160,8 @@ func routerRejectsPermissionRequestWithoutBearerToken() {
 @Test
 func routerReturnsPermissionRequestResultForAuthorizedRequest() {
     let requester = RecordingPermissionRequester(result: .init(status: .authorized, prompted: true))
-    let sessionController = makeSessionController()
-    let router = makeRouter(sessionController: sessionController, permissionRequester: requester)
+    let sessionController = makeSessionController(permissionRequester: requester)
+    let router = makeRouter(sessionController: sessionController)
     let response = router.response(
         for: HTTPRequest(
             method: .post,
@@ -174,13 +178,12 @@ func routerReturnsPermissionRequestResultForAuthorizedRequest() {
 @Test
 func localHTTPServerReturnsPermissionRequestResultForAuthorizedRequest() async throws {
     let port = try reserveEphemeralPort()
-    let sessionController = makeSessionController()
+    let sessionController = makeSessionController(
+        permissionRequester: FixedPermissionRequester(result: .init(status: .denied, prompted: true))
+    )
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: makeRouter(
-            sessionController: sessionController,
-            permissionRequester: FixedPermissionRequester(result: .init(status: .denied, prompted: true))
-        )
+        router: makeRouter(sessionController: sessionController)
     )
 
     defer { server.stop() }
@@ -273,11 +276,12 @@ func localHTTPServerReturnsSessionStateWithoutAuth() async throws {
             activeDeviceID: nil,
             currentOwnerID: nil,
             lastError: nil
-        )
+        ),
+        permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted)
     )
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
-        router: makeRouter(sessionController: sessionController, permissionState: .restricted)
+        router: makeRouter(sessionController: sessionController)
     )
 
     defer { server.stop() }
@@ -360,9 +364,10 @@ func routerRejectsSessionStartWithoutSelectedDevice() {
 @Test
 func routerRejectsSessionStartWithoutAuthorizedPermission() {
     let sessionController = makeSessionController(
-        state: CameraState(activeDeviceID: "camera-1")
+        state: CameraState(activeDeviceID: "camera-1"),
+        permissionStatusProvider: FixedPermissionStatusProvider(state: .denied)
     )
-    let router = makeRouter(sessionController: sessionController, permissionState: .denied)
+    let router = makeRouter(sessionController: sessionController)
     let response = router.response(
         for: HTTPRequest(
             method: .post,
@@ -842,16 +847,11 @@ func localHTTPServerSupportsSessionStartThenStop() async throws {
 
 private func makeRouter(
     sessionController: DefaultCameraSessionController,
-    permissionState: PermissionState = .authorized,
-    permissionRequester: any CameraPermissionRequesting = FixedPermissionRequester(
-        result: .init(status: .authorized, prompted: false)
-    ),
     bearerToken: String = "test-token"
 ) -> CameraBridgeRouter {
     CameraBridgeRouter(
         routes: CameraBridgeRoutes.current(
-            permissionStatusProvider: FixedPermissionStatusProvider(state: permissionState),
-            permissionRequester: permissionRequester,
+            permissionController: sessionController,
             deviceListing: sessionController,
             cameraStateProvider: sessionController,
             deviceSelector: sessionController,
@@ -868,6 +868,10 @@ private func makeSessionController(
     devices: [CameraDevice] = [
         CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
     ],
+    permissionStatusProvider: any CameraPermissionStatusProviding = FixedPermissionStatusProvider(state: .authorized),
+    permissionRequester: any CameraPermissionRequesting = FixedPermissionRequester(
+        result: .init(status: .authorized, prompted: false)
+    ),
     photoProducer: any CameraStillPhotoProducing = UnimplementedStillPhotoProducer(),
     artifactStore: any PhotoArtifactStoring = DefaultPhotoArtifactStore(
         baseDirectoryURL: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -876,6 +880,8 @@ private func makeSessionController(
     now: @escaping @Sendable () -> Date = { Date() }
 ) -> DefaultCameraSessionController {
     DefaultCameraSessionController(
+        permissionStatusProvider: permissionStatusProvider,
+        permissionRequester: permissionRequester,
         deviceListing: FixedDeviceListing(devices: devices),
         photoProducer: photoProducer,
         artifactStore: artifactStore,


### PR DESCRIPTION
## Summary

Refactor `CameraBridgeRoutes` to consume a single Core-owned permission controller instead of separate permission status and permission request dependencies. This aligns the API and daemon wiring with the new `DefaultCameraSessionController` contract and updates the API tests to inject permission behavior through the session controller path.

## Issue

Closes #53

## Files Changed

- `packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift`
- `apps/camd/Sources/camd/CameraBridgeDaemon.swift`
- `tests/CameraBridgeAPITests/CameraBridgeAPITests.swift`

## Testing

- [ ] `swift build`
- [x] `swift test`
- [ ] Manual verification completed
- [ ] Not run, explained below

Testing notes:
Updated API tests to drive permission state and permission requests through `DefaultCameraSessionController`, matching daemon wiring.

## Deferred

- Extra regression-focused permission coverage remains in #54
- Docs updates remain in #55

## AGENTS.md Check

- [x] Scope stayed focused on one issue
- [x] Unrelated files were not changed without cause
- [ ] Docs were updated if public behavior changed
