### PR TITLE
Add permission flow regression coverage

### DIFF
--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -160,7 +160,10 @@ func routerRejectsPermissionRequestWithoutBearerToken() {
 @Test
 func routerReturnsPermissionRequestResultForAuthorizedRequest() {
     let requester = RecordingPermissionRequester(result: .init(status: .authorized, prompted: true))
-    let sessionController = makeSessionController(permissionRequester: requester)
+    let sessionController = makeSessionController(
+        state: CameraState(permissionState: .denied),
+        permissionRequester: requester
+    )
     let router = makeRouter(sessionController: sessionController)
     let response = router.response(
         for: HTTPRequest(
@@ -173,6 +176,7 @@ func routerReturnsPermissionRequestResultForAuthorizedRequest() {
     #expect(response.statusCode == 200)
     #expect(String(decoding: response.body, as: UTF8.self) == #"{"prompted":true,"status":"authorized"}"#)
     #expect(requester.requestCount == 1)
+    #expect(sessionController.currentCameraState().permissionState == .authorized)
 }
 
 @Test
@@ -197,6 +201,7 @@ func localHTTPServerReturnsPermissionRequestResultForAuthorizedRequest() async t
 
     #expect(httpResponse.statusCode == 200)
     #expect(String(decoding: data, as: UTF8.self) == #"{"prompted":true,"status":"denied"}"#)
+    #expect(sessionController.currentCameraState().permissionState == .denied)
 }
 
 @Test
@@ -364,7 +369,7 @@ func routerRejectsSessionStartWithoutSelectedDevice() {
 @Test
 func routerRejectsSessionStartWithoutAuthorizedPermission() {
     let sessionController = makeSessionController(
-        state: CameraState(activeDeviceID: "camera-1"),
+        state: CameraState(permissionState: .authorized, activeDeviceID: "camera-1"),
         permissionStatusProvider: FixedPermissionStatusProvider(state: .denied)
     )
     let router = makeRouter(sessionController: sessionController)
@@ -382,6 +387,21 @@ func routerRejectsSessionStartWithoutAuthorizedPermission() {
         String(decoding: response.body, as: UTF8.self) ==
         #"{"error":{"code":"invalid_state","message":"Camera permission is denied"}}"#
     )
+}
+
+@Test
+func routerReturnsPermissionStatusAndSyncsSessionStateFromController() {
+    let sessionController = makeSessionController(
+        state: CameraState(permissionState: .authorized),
+        permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted)
+    )
+    let router = makeRouter(sessionController: sessionController)
+
+    let response = router.response(for: HTTPRequest(method: .get, path: "/v1/permissions"))
+
+    #expect(response.statusCode == 200)
+    #expect(String(decoding: response.body, as: UTF8.self) == #"{ "status": "restricted" }"#)
+    #expect(sessionController.currentCameraState().permissionState == .restricted)
 }
 
 @Test

--- a/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
+++ b/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
@@ -106,7 +106,8 @@ func defaultCameraSessionControllerSyncsPermissionStateFromProvider() {
     let controller = DefaultCameraSessionController(
         permissionStatusProvider: FixedPermissionStatusProvider(state: .restricted),
         permissionRequester: FixedPermissionRequester(result: .init(status: .authorized, prompted: false)),
-        deviceListing: FixedDeviceListing(devices: [])
+        deviceListing: FixedDeviceListing(devices: []),
+        initialState: CameraState(permissionState: .authorized)
     )
 
     let permissionState = controller.currentPermissionState()
@@ -121,7 +122,10 @@ func defaultCameraSessionControllerUpdatesPermissionStateWhenRequestingPermissio
         permissionStatusProvider: FixedPermissionStatusProvider(state: .notDetermined),
         permissionRequester: FixedPermissionRequester(result: .init(status: .authorized, prompted: true)),
         deviceListing: FixedDeviceListing(devices: []),
-        initialState: CameraState(lastError: CameraStateError(message: "stale error"))
+        initialState: CameraState(
+            permissionState: .denied,
+            lastError: CameraStateError(message: "stale error")
+        )
     )
     let semaphore = DispatchSemaphore(value: 0)
     let expectedResult = PermissionRequestResult(status: .authorized, prompted: true)


### PR DESCRIPTION
## Summary

Add regression coverage that locks the consolidated permission path in both Core and API tests. The new assertions verify that permission reads and permission requests overwrite stale stored state and that session start behavior follows the controller-provided permission source rather than relying on previously cached state.

## Issue

Closes #54

## Files Changed

- `tests/CameraBridgeAPITests/CameraBridgeAPITests.swift`
- `tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift`

## Testing

- [ ] `swift build`
- [x] `swift test`
- [ ] Manual verification completed
- [ ] Not run, explained below

Testing notes:
Added regression assertions for stale permission-state overwrite on read, request-driven state updates, and session-start behavior under provider/controller mismatch.

## Deferred

- Docs updates remain in #55

## AGENTS.md Check

- [x] Scope stayed focused on one issue
- [x] Unrelated files were not changed without cause
- [ ] Docs were updated if public behavior changed
