### PR TITLE
Document core-owned permission ownership

### DIFF
--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -79,6 +79,7 @@ Status: `current`
 
 - auth: none for the early read-only slice
 - response: `200 OK`
+- returns the current permission state from the Core-owned permission controller
 
 ```json
 {
@@ -102,9 +103,11 @@ Status: `current`
 
 Behavior:
 
+- uses the same Core-owned permission controller exposed by `GET /v1/permissions`
 - requests camera permission through the macOS system prompt only when the status is `not_determined`
 - when permission has already been decided, returns the current state without prompting again
 - does not create or transfer session ownership
+- updates the shared permission state later consumed by `POST /v1/session/start`
 
 Successful response: `200 OK`
 
@@ -189,6 +192,7 @@ Request fields:
 Behavior:
 
 - requires camera permission state `authorized`
+- reads that permission precondition from the same Core-owned permission path exposed by the permission endpoints
 - requires a previously selected `active_device_id`
 - does not implicitly pick or change the active device
 - successful start sets `state` to `running` and `owner_id` to the provided caller identity

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -64,6 +64,8 @@ A single, centralized representation of:
 - last error
 
 This state lives in `CameraBridgeCore` and is the source of truth.
+Permission reads, permission requests, and permission-dependent session
+preconditions must all flow through this Core-owned state path.
 
 ---
 
@@ -103,6 +105,7 @@ Must never be inferred implicitly.
 - AVFoundation integration
 - domain models
 - state management
+- permission status and request coordination
 
 No HTTP, no UI.
 
@@ -113,8 +116,9 @@ No HTTP, no UI.
 - HTTP interface
 - request/response models
 - auth validation
+- translation of HTTP permission routes into Core-owned permission operations
 
-No AVFoundation logic.
+No AVFoundation logic and no parallel permission state.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify in the architecture docs that permission reads, requests, and session-start preconditions flow through CameraBridgeCore
- document in the API spec that the permission endpoints and session-start checks share the same Core-owned permission path

## Files Changed
- docs/architecture-overview.md
- docs/api/v1.md

## How It Was Tested
- manual review against the merged #52, #53, and #54 implementation slices

## Intentionally Deferred
- broader roadmap and README truth pass tracked separately in #49

Closes #55