### PR TITLE
Make camd own default auth token bootstrap

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,10 @@ let package = Package(
             name: "CameraBridgeClientSwift",
             targets: ["CameraBridgeClientSwift"]
         ),
+        .library(
+            name: "CameraBridgeSupport",
+            targets: ["CameraBridgeSupport"]
+        ),
         .executable(
             name: "camd",
             targets: ["camd"]
@@ -43,14 +47,18 @@ let package = Package(
             dependencies: ["CameraBridgeAPI"],
             path: "packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift"
         ),
+        .target(
+            name: "CameraBridgeSupport",
+            path: "packages/CameraBridgeSupport/Sources/CameraBridgeSupport"
+        ),
         .executableTarget(
             name: "camd",
-            dependencies: ["CameraBridgeAPI", "CameraBridgeCore"],
+            dependencies: ["CameraBridgeAPI", "CameraBridgeCore", "CameraBridgeSupport"],
             path: "apps/camd/Sources/camd"
         ),
         .executableTarget(
             name: "CameraBridgeApp",
-            dependencies: ["CameraBridgeClientSwift"],
+            dependencies: ["CameraBridgeClientSwift", "CameraBridgeSupport"],
             path: "apps/CameraBridgeApp/Sources/CameraBridgeApp"
         ),
         .testTarget(
@@ -69,9 +77,19 @@ let package = Package(
             path: "tests/CameraBridgeClientSwiftTests"
         ),
         .testTarget(
+            name: "CameraBridgeSupportTests",
+            dependencies: ["CameraBridgeSupport"],
+            path: "tests/CameraBridgeSupportTests"
+        ),
+        .testTarget(
             name: "CameraBridgeAppTests",
             dependencies: ["CameraBridgeApp"],
             path: "tests/CameraBridgeAppTests"
+        ),
+        .testTarget(
+            name: "CameraBridgeDaemonTests",
+            dependencies: ["camd"],
+            path: "tests/CameraBridgeDaemonTests"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ CameraBridge v1 keeps the trust model intentionally narrow:
 
 - read-only localhost endpoints may remain unauthenticated in the early v1 slices
 - planned mutating endpoints use a bearer token or equivalent local secret
+- when `camd` starts without `CAMERABRIDGE_AUTH_TOKEN`, it loads or creates the local bearer token at `~/Library/Application Support/CameraBridge/auth-token`
 - v1 does not add separate session `claim` or `release` endpoints
 - successful `POST /v1/session/start` establishes implicit session ownership
 - session ownership is released by `POST /v1/session/stop` or when the session ends

--- a/apps/CameraBridgeApp/README.md
+++ b/apps/CameraBridgeApp/README.md
@@ -31,11 +31,13 @@ Launch the packaged app from Finder or with:
 open "$(swift build --show-bin-path)/CameraBridgeApp.app"
 ```
 
-When the app starts the service itself, it persists the local bearer token at:
+When the app starts the bundled service, `camd` loads or creates the local bearer token at:
 
 ```text
 ~/Library/Application Support/CameraBridge/auth-token
 ```
+
+The app then reads that same token file for its protected localhost API requests.
 
 ## Manual Verification
 

--- a/apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift
+++ b/apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift
@@ -1,4 +1,5 @@
 import CameraBridgeClientSwift
+import CameraBridgeSupport
 import Foundation
 
 @MainActor
@@ -150,19 +151,16 @@ final class CameraBridgeAppModel {
 
     init(
         client: (any CameraBridgeAppClient)? = nil,
-        authTokenStore: any CameraBridgeAuthTokenStoring = DefaultCameraBridgeAuthTokenStore(),
+        authTokenStore: any CameraBridgeAuthTokenReading = DefaultCameraBridgeAuthTokenStore(),
         serviceLauncher: (any CameraBridgeServiceLaunching)? = nil
     ) {
         let resolvedClient = client ?? CameraBridgeClient(
             tokenProvider: {
-                try? authTokenStore.loadOrCreateToken()
+                try? authTokenStore.loadToken()
             }
         )
         self.client = resolvedClient
-        self.serviceLauncher = serviceLauncher ?? LocalCameraBridgeServiceLauncher(
-            client: resolvedClient,
-            authTokenStore: authTokenStore
-        )
+        self.serviceLauncher = serviceLauncher ?? LocalCameraBridgeServiceLauncher(client: resolvedClient)
     }
 
     func start() {
@@ -305,9 +303,11 @@ final class CameraBridgeAppModel {
     }
 }
 
-protocol CameraBridgeAuthTokenStoring {
-    func loadOrCreateToken() throws -> String
+protocol CameraBridgeAuthTokenReading {
+    func loadToken() throws -> String?
 }
+
+extension DefaultCameraBridgeAuthTokenStore: CameraBridgeAuthTokenReading {}
 
 protocol CameraBridgeAppClient {
     func serviceIsRunning() async -> Bool
@@ -316,58 +316,6 @@ protocol CameraBridgeAppClient {
 }
 
 extension CameraBridgeClient: CameraBridgeAppClient {}
-
-enum CameraBridgeAuthTokenError: LocalizedError {
-    case invalidTokenFile
-    case supportDirectoryUnavailable
-
-    var errorDescription: String? {
-        switch self {
-        case .invalidTokenFile:
-            return "Stored auth token is invalid"
-        case .supportDirectoryUnavailable:
-            return "CameraBridge support directory is unavailable"
-        }
-    }
-}
-
-struct DefaultCameraBridgeAuthTokenStore: CameraBridgeAuthTokenStoring {
-    private let fileManager = FileManager.default
-
-    func loadOrCreateToken() throws -> String {
-        let tokenURL = try authTokenURL()
-        try fileManager.createDirectory(
-            at: tokenURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-
-        if fileManager.fileExists(atPath: tokenURL.path) {
-            let token = try String(contentsOf: tokenURL, encoding: .utf8)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !token.isEmpty else {
-                throw CameraBridgeAuthTokenError.invalidTokenFile
-            }
-            return token
-        }
-
-        let token = UUID().uuidString.lowercased()
-        try Data(token.utf8).write(to: tokenURL, options: .atomic)
-        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tokenURL.path)
-        return token
-    }
-
-    private func authTokenURL() throws -> URL {
-        guard let applicationSupportURL =
-            fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-        else {
-            throw CameraBridgeAuthTokenError.supportDirectoryUnavailable
-        }
-
-        return applicationSupportURL
-            .appendingPathComponent("CameraBridge", isDirectory: true)
-            .appendingPathComponent("auth-token", isDirectory: false)
-    }
-}
 
 @MainActor
 protocol CameraBridgeServiceLaunching {
@@ -393,15 +341,11 @@ enum CameraBridgeServiceLaunchError: LocalizedError {
 
 @MainActor
 final class LocalCameraBridgeServiceLauncher: CameraBridgeServiceLaunching {
-    private static let authTokenEnvironmentVariable = "CAMERABRIDGE_AUTH_TOKEN"
-
     private let client: any CameraBridgeAppClient
-    private let authTokenStore: any CameraBridgeAuthTokenStoring
     private var process: Process?
 
-    init(client: any CameraBridgeAppClient, authTokenStore: any CameraBridgeAuthTokenStoring) {
+    init(client: any CameraBridgeAppClient) {
         self.client = client
-        self.authTokenStore = authTokenStore
     }
 
     func startIfNeeded() async throws {
@@ -410,17 +354,12 @@ final class LocalCameraBridgeServiceLauncher: CameraBridgeServiceLaunching {
         }
 
         let daemonURL = try bundledDaemonURL()
-        let token = try authTokenStore.loadOrCreateToken()
         let logHandle = try makeLogHandle()
 
         let process = Process()
         process.executableURL = daemonURL
         process.standardOutput = logHandle
         process.standardError = logHandle
-
-        var environment = ProcessInfo.processInfo.environment
-        environment[Self.authTokenEnvironmentVariable] = token
-        process.environment = environment
 
         try process.run()
         self.process = process

--- a/apps/camd/README.md
+++ b/apps/camd/README.md
@@ -1,3 +1,11 @@
 # camd
 
-`camd` will host process startup, configuration bootstrap, dependency wiring, and logging for the local CameraBridge service.
+`camd` hosts process startup, configuration bootstrap, dependency wiring, and logging for the local CameraBridge service.
+
+When `camd` starts without `CAMERABRIDGE_AUTH_TOKEN`, it loads or creates the local bearer token at:
+
+```text
+~/Library/Application Support/CameraBridge/auth-token
+```
+
+This is the default local token contract used by both direct daemon startup and the packaged app launcher.

--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -1,5 +1,6 @@
 import CameraBridgeAPI
 import CameraBridgeCore
+import CameraBridgeSupport
 import Foundation
 
 struct ServerConfiguration: Sendable, Equatable {
@@ -20,6 +21,19 @@ struct ServerConfiguration: Sendable, Equatable {
         self.port = port
         self.authToken = authToken
     }
+
+    func resolvedAuthToken(
+        authTokenStore: DefaultCameraBridgeAuthTokenStore = DefaultCameraBridgeAuthTokenStore()
+    ) throws -> String {
+        if let authToken {
+            let trimmedToken = authToken.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedToken.isEmpty {
+                return trimmedToken
+            }
+        }
+
+        return try authTokenStore.loadOrCreateToken()
+    }
 }
 
 struct CameraBridgeDaemon {
@@ -36,13 +50,14 @@ struct CameraBridgeDaemon {
         self.logger = logger
     }
 
-    private func defaultRouter() -> CameraBridgeRouter {
+    private func defaultRouter() throws -> CameraBridgeRouter {
         let deviceListing = AVFoundationCameraDeviceListing()
         let sessionController = DefaultCameraSessionController(
             deviceListing: deviceListing,
             photoProducer: AVFoundationStillPhotoProducer(),
             artifactStore: DefaultPhotoArtifactStore()
         )
+        let authToken = try configuration.resolvedAuthToken()
         return CameraBridgeRouter(
             routes: CameraBridgeRoutes.current(
                 permissionController: sessionController,
@@ -52,15 +67,15 @@ struct CameraBridgeDaemon {
                 sessionStarter: sessionController,
                 sessionStopper: sessionController,
                 photoCapturer: sessionController,
-                authorizer: StaticBearerTokenAuthorizer(bearerToken: configuration.authToken)
+                authorizer: StaticBearerTokenAuthorizer(bearerToken: authToken)
             )
         )
     }
 
-    func makeServer(router: CameraBridgeRouter? = nil) -> LocalHTTPServer {
+    func makeServer(router: CameraBridgeRouter? = nil) throws -> LocalHTTPServer {
         LocalHTTPServer(
             configuration: .init(host: configuration.host, port: configuration.port),
-            router: router ?? defaultRouter(),
+            router: try (router ?? defaultRouter()),
             logger: logger
         )
     }
@@ -68,7 +83,7 @@ struct CameraBridgeDaemon {
     @discardableResult
     func start(router: CameraBridgeRouter? = nil) throws -> LocalHTTPServer {
         logger("starting camd on \(configuration.host):\(configuration.port)")
-        let server = makeServer(router: router)
+        let server = try makeServer(router: router)
         let port = try server.start()
         logger("camd ready on \(configuration.host):\(port)")
         return server

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -51,11 +51,13 @@ From the menu bar app:
 3. click `Request Camera Access` if permission is still undecided
 4. confirm the app shows `Permission: authorized`
 
-When the app starts the service, it stores the local bearer token at:
+When `camd` starts without `CAMERABRIDGE_AUTH_TOKEN`, it loads or creates the local bearer token at:
 
 ```text
 ~/Library/Application Support/CameraBridge/auth-token
 ```
+
+The packaged app uses that same daemon-owned token contract when it launches the bundled service.
 
 The packaged app starts `camd` as a localhost-only service intended to be reachable from other local clients at `127.0.0.1:8731`.
 

--- a/packages/CameraBridgeSupport/Sources/CameraBridgeSupport/CameraBridgeSupport.swift
+++ b/packages/CameraBridgeSupport/Sources/CameraBridgeSupport/CameraBridgeSupport.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+public enum CameraBridgeSupportModule {
+    public static let name = "CameraBridgeSupport"
+}
+
+public enum CameraBridgeAuthTokenError: LocalizedError, Equatable {
+    case invalidTokenFile
+    case supportDirectoryUnavailable
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidTokenFile:
+            return "Stored auth token is invalid"
+        case .supportDirectoryUnavailable:
+            return "CameraBridge support directory is unavailable"
+        }
+    }
+}
+
+public struct DefaultCameraBridgeAuthTokenStore {
+    public var baseDirectoryURL: URL?
+
+    private let fileManager: FileManager
+
+    public init(fileManager: FileManager = .default, baseDirectoryURL: URL? = nil) {
+        self.fileManager = fileManager
+        self.baseDirectoryURL = baseDirectoryURL
+    }
+
+    public func loadToken() throws -> String? {
+        let tokenURL = try authTokenURL()
+        guard fileManager.fileExists(atPath: tokenURL.path) else {
+            return nil
+        }
+
+        return try normalizedToken(from: tokenURL)
+    }
+
+    public func loadOrCreateToken() throws -> String {
+        let tokenURL = try authTokenURL()
+        try fileManager.createDirectory(
+            at: tokenURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        if fileManager.fileExists(atPath: tokenURL.path) {
+            return try normalizedToken(from: tokenURL)
+        }
+
+        let token = UUID().uuidString.lowercased()
+        try Data(token.utf8).write(to: tokenURL, options: .atomic)
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tokenURL.path)
+        return token
+    }
+
+    public func authTokenURL() throws -> URL {
+        try supportDirectoryURL()
+            .appendingPathComponent("auth-token", isDirectory: false)
+    }
+
+    private func supportDirectoryURL() throws -> URL {
+        if let baseDirectoryURL {
+            return baseDirectoryURL
+        }
+
+        guard let applicationSupportURL =
+            fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        else {
+            throw CameraBridgeAuthTokenError.supportDirectoryUnavailable
+        }
+
+        return applicationSupportURL
+            .appendingPathComponent("CameraBridge", isDirectory: true)
+    }
+
+    private func normalizedToken(from tokenURL: URL) throws -> String {
+        let token = try String(contentsOf: tokenURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else {
+            throw CameraBridgeAuthTokenError.invalidTokenFile
+        }
+        return token
+    }
+}

--- a/tests/CameraBridgeDaemonTests/CameraBridgeDaemonTests.swift
+++ b/tests/CameraBridgeDaemonTests/CameraBridgeDaemonTests.swift
@@ -1,0 +1,37 @@
+import CameraBridgeSupport
+import Foundation
+import Testing
+@testable import camd
+
+@Test
+func serverConfigurationResolvedAuthTokenPrefersExplicitConfiguration() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let configuration = ServerConfiguration(authToken: " explicit-token \n")
+    let store = DefaultCameraBridgeAuthTokenStore(baseDirectoryURL: directoryURL)
+
+    let token = try configuration.resolvedAuthToken(authTokenStore: store)
+
+    #expect(token == "explicit-token")
+}
+
+@Test
+func serverConfigurationResolvedAuthTokenLoadsOrCreatesStoredTokenWhenMissing() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let configuration = ServerConfiguration(authToken: nil)
+    let store = DefaultCameraBridgeAuthTokenStore(baseDirectoryURL: directoryURL)
+
+    let createdToken = try configuration.resolvedAuthToken(authTokenStore: store)
+    let reloadedToken = try store.loadToken()
+
+    #expect(!createdToken.isEmpty)
+    #expect(reloadedToken == createdToken)
+}
+
+private func makeTemporaryDirectoryURL() -> URL {
+    FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+}

--- a/tests/CameraBridgeSupportTests/CameraBridgeSupportTests.swift
+++ b/tests/CameraBridgeSupportTests/CameraBridgeSupportTests.swift
@@ -1,0 +1,52 @@
+import CameraBridgeSupport
+import Foundation
+import Testing
+
+@Test
+func authTokenStoreReturnsNilWhenTokenFileIsMissing() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let store = DefaultCameraBridgeAuthTokenStore(baseDirectoryURL: directoryURL)
+
+    #expect(try store.loadToken() == nil)
+}
+
+@Test
+func authTokenStoreCreatesAndReloadsTokenFromApplicationSupportDirectory() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let store = DefaultCameraBridgeAuthTokenStore(baseDirectoryURL: directoryURL)
+
+    let createdToken = try store.loadOrCreateToken()
+    let tokenURL = try store.authTokenURL()
+    let reloadedToken = try store.loadToken()
+
+    #expect(!createdToken.isEmpty)
+    #expect(reloadedToken == createdToken)
+    #expect(FileManager.default.fileExists(atPath: tokenURL.path))
+}
+
+@Test
+func authTokenStoreRejectsWhitespaceOnlyTokenFiles() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let store = DefaultCameraBridgeAuthTokenStore(baseDirectoryURL: directoryURL)
+    let tokenURL = try store.authTokenURL()
+    try FileManager.default.createDirectory(
+        at: tokenURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try Data(" \n".utf8).write(to: tokenURL, options: .atomic)
+
+    #expect(throws: CameraBridgeAuthTokenError.invalidTokenFile) {
+        _ = try store.loadToken()
+    }
+}
+
+private func makeTemporaryDirectoryURL() -> URL {
+    FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+}


### PR DESCRIPTION
## Summary
- add a shared local auth token store used by both camd and the app
- make camd load or create the Application Support token when no environment override is provided
- switch the app from token creation to token reading and document the daemon-owned contract

## Files Changed
- Package.swift
- packages/CameraBridgeSupport/Sources/CameraBridgeSupport/CameraBridgeSupport.swift
- apps/camd/Sources/camd/CameraBridgeDaemon.swift
- apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift
- tests/CameraBridgeSupportTests/CameraBridgeSupportTests.swift
- tests/CameraBridgeDaemonTests/CameraBridgeDaemonTests.swift
- README.md
- docs/quick-start.md
- apps/CameraBridgeApp/README.md
- apps/camd/README.md

## How It Was Tested
- swift test

## Intentionally Deferred
- broader roadmap and repo docs truth-pass work tracked separately in #49
- manual real-hardware release validation tracked separately in #50

Closes #48