### PR TITLE
Align docs with shipped v1 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 CameraBridge is a local macOS camera service that exposes AVFoundation over a localhost API.
 
-This repository is intentionally scaffolded with strict package boundaries:
+This repository is organized with strict package boundaries:
 
 - `apps/camd` for the daemon and CLI entrypoint
 - `apps/CameraBridgeApp` for the macOS menu bar app
@@ -12,24 +12,24 @@ This repository is intentionally scaffolded with strict package boundaries:
 - `docs/` for RFCs and API documentation
 - `examples/` for small example clients
 
-The repository currently includes early daemon and API slices for health,
-permission status and request, device listing and selection, session state,
-basic session lifecycle control, and still photo capture with local artifact
-metadata, plus a minimal menu bar app shell, with the remaining v1 surface
-defined in the docs. Preview transport, example clients, and fuller onboarding
-UI are still in progress.
+The repository currently ships the v1 localhost service for health, permission
+status and request, device listing and selection, session state, session
+lifecycle control, and still photo capture with local artifact metadata. It
+also includes the minimal menu bar app shell, the Python first-capture example,
+and the core v1 docs. Preview transport and broader client surfaces remain
+deferred work.
 
 ## v1 Auth And Ownership
 
 CameraBridge v1 keeps the trust model intentionally narrow:
 
 - read-only localhost endpoints may remain unauthenticated in the early v1 slices
-- planned mutating endpoints use a bearer token or equivalent local secret
+- mutating endpoints use a bearer token or equivalent local secret
 - when `camd` starts without `CAMERABRIDGE_AUTH_TOKEN`, it loads or creates the local bearer token at `~/Library/Application Support/CameraBridge/auth-token`
 - v1 does not add separate session `claim` or `release` endpoints
 - successful `POST /v1/session/start` establishes implicit session ownership
 - session ownership is released by `POST /v1/session/stop` or when the session ends
-- ownership-conflict and invalid-state failures are explicit parts of the planned contract
+- ownership-conflict and invalid-state failures are explicit parts of the current contract
 
 ## Docs
 

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -1,6 +1,6 @@
 # CameraBridge API v1
 
-This document defines the early CameraBridge API contract for the v1 service slice.
+This document defines the current CameraBridge API contract for the shipped v1 service slice.
 
 ## Status Labels
 
@@ -26,11 +26,11 @@ This document defines the early CameraBridge API contract for the v1 service sli
 }
 ```
 
-## Planned Auth And Ownership Model
+## Auth And Ownership Model
 
 - `GET /health` remains unauthenticated
 - read-only `/v1/...` endpoints may remain unauthenticated in the early localhost-only slices
-- all planned mutating endpoints require a bearer token or equivalent local secret
+- mutating endpoints require a bearer token or equivalent local secret
 - v1 does not add separate `claim` or `release` endpoints
 - successful `POST /v1/session/start` establishes implicit session ownership
 - successful `POST /v1/session/stop` releases implicit session ownership
@@ -38,7 +38,7 @@ This document defines the early CameraBridge API contract for the v1 service sli
 - `POST /v1/permissions/request` is token-protected but does not create or transfer session ownership
 - successful `POST /v1/session/select-device` does not create or transfer session ownership
 
-High-level planned error categories for mutating endpoints:
+Current error categories for mutating endpoints:
 
 - `unauthorized`: bearer token missing or invalid
 - `ownership_conflict`: another client already owns the active session

--- a/docs/roadmap/v1.md
+++ b/docs/roadmap/v1.md
@@ -105,18 +105,16 @@ If this flow works reliably, v1 is successful.
 - first-run onboarding
 - permission status visibility
 - basic service status (running / stopped)
-- custom URL scheme for app activation and onboarding only:
-  - `camerabridge://open` launches or focuses the CameraBridge app
-  - `camerabridge://request-permissions` opens the app and surfaces the permission flow
+- custom URL scheme is deferred until after v1
 
 ---
 
 ### Documentation
 
 - README with quick start
-- API reference (partial, v1 endpoints only)
-- install guide
-- minimal examples (JS or Python)
+- API reference for the shipped v1 endpoints
+- quick-start guide
+- minimal Python example for the first-capture flow
 
 ---
 
@@ -173,7 +171,7 @@ v1 must maintain:
 
 ## 6. Milestones
 
-### Milestone 1 - First Useful Loop
+### Milestone 1 - First Useful Loop (Shipped)
 
 - daemon starts
 - `/health` works
@@ -182,7 +180,7 @@ v1 must maintain:
 
 ---
 
-### Milestone 2 - Camera Control
+### Milestone 2 - Camera Control (Shipped)
 
 - permission request
 - session start/stop
@@ -190,18 +188,19 @@ v1 must maintain:
 
 ---
 
-### Milestone 3 - Capture
+### Milestone 3 - Capture (Shipped)
 
 - still image capture
 - artifact storage + metadata
 
 ---
 
-### Milestone 4 - Usability
+### Milestone 4 - Usability (Partially Shipped)
 
 - menu bar app
 - onboarding flow
-- basic docs and examples
+- basic docs and Python example
+- custom URL scheme remains deferred
 
 ---
 

--- a/packages/CameraBridgeAPI/README.md
+++ b/packages/CameraBridgeAPI/README.md
@@ -1,3 +1,16 @@
 # CameraBridgeAPI
 
-`CameraBridgeAPI` will translate localhost HTTP requests into core operations and serialize responses without owning camera state.
+`CameraBridgeAPI` translates localhost HTTP requests into Core operations and
+serializes responses without owning camera state.
+
+The current v1 surface includes:
+
+- `GET /health`
+- `GET /v1/permissions`
+- `POST /v1/permissions/request`
+- `GET /v1/devices`
+- `GET /v1/session`
+- `POST /v1/session/start`
+- `POST /v1/session/stop`
+- `POST /v1/session/select-device`
+- `POST /v1/capture/photo`

--- a/packages/CameraBridgeClientSwift/README.md
+++ b/packages/CameraBridgeClientSwift/README.md
@@ -2,13 +2,15 @@
 
 `CameraBridgeClientSwift` is the small Swift client currently used by `CameraBridgeApp`.
 
-Current onboarding-focused surface:
+Current app-focused surface:
 
 - `health()` to confirm the local daemon is reachable
 - `permissionStatus()` for `GET /v1/permissions`
 - `requestPermission()` for `POST /v1/permissions/request`
 - `serviceIsRunning()` convenience check for the app shell
 
-This package is intentionally narrow in the current slice. It does not yet expose session or capture helpers.
+This package is intentionally narrow in the current slice. Session and capture
+helpers are tracked separately and are not part of the shipped client surface
+yet.
 
 For the current repo-level setup and first capture flow, see [docs/quick-start.md](../../docs/quick-start.md).

--- a/packages/CameraBridgeCore/README.md
+++ b/packages/CameraBridgeCore/README.md
@@ -1,3 +1,11 @@
 # CameraBridgeCore
 
-`CameraBridgeCore` will own camera permissions, device discovery, session lifecycle, capture pipeline coordination, and domain models.
+`CameraBridgeCore` owns the camera-facing domain model for CameraBridge:
+
+- permission status and permission requests
+- device discovery and selection
+- session lifecycle state
+- still capture coordination
+- artifact storage metadata
+
+It does not know about HTTP, app UI, or site/docs tooling.


### PR DESCRIPTION
## Summary
- update the roadmap to mark shipped milestones, keep Milestone 4 partial, and explicitly defer the custom URL scheme
- refresh the top-level and package READMEs so they describe the current shipped surface instead of scaffold-era intent
- tighten the API contract intro language so auth and ownership are described as the current v1 behavior

## Files Changed
- README.md
- docs/api/v1.md
- docs/roadmap/v1.md
- packages/CameraBridgeCore/README.md
- packages/CameraBridgeAPI/README.md
- packages/CameraBridgeClientSwift/README.md

## How It Was Tested
- manual doc review against the current implementation on main

## Intentionally Deferred
- manual hardware release validation remains tracked in #50
- Swift client surface expansion remains tracked in #51

Closes #49