### PR TITLE
Add client device and session read methods

### DIFF
--- a/packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
+++ b/packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
@@ -18,6 +18,48 @@ public struct CameraBridgePermissionRequestResult: Sendable, Equatable {
     }
 }
 
+public enum CameraBridgeDevicePosition: String, Sendable, CaseIterable, Equatable {
+    case front
+    case back
+    case external
+}
+
+public struct CameraBridgeDevice: Sendable, Equatable {
+    public var id: String
+    public var name: String
+    public var position: CameraBridgeDevicePosition
+
+    public init(id: String, name: String, position: CameraBridgeDevicePosition) {
+        self.id = id
+        self.name = name
+        self.position = position
+    }
+}
+
+public enum CameraBridgeSessionState: String, Sendable, CaseIterable, Equatable {
+    case stopped
+    case running
+}
+
+public struct CameraBridgeSessionSnapshot: Sendable, Equatable {
+    public var state: CameraBridgeSessionState
+    public var activeDeviceID: String?
+    public var ownerID: String?
+    public var lastError: String?
+
+    public init(
+        state: CameraBridgeSessionState,
+        activeDeviceID: String?,
+        ownerID: String?,
+        lastError: String?
+    ) {
+        self.state = state
+        self.activeDeviceID = activeDeviceID
+        self.ownerID = ownerID
+        self.lastError = lastError
+    }
+}
+
 public struct CameraBridgeHealthResponse: Sendable, Equatable, Decodable {
     public var status: String
 
@@ -99,6 +141,40 @@ public struct CameraBridgeClient {
         return CameraBridgePermissionRequestResult(status: status, prompted: response.prompted)
     }
 
+    public func devices() async throws -> [CameraBridgeDevice] {
+        let response: DevicesResponse = try await send(
+            method: "GET",
+            path: "/v1/devices",
+            requiresAuthorization: false
+        )
+
+        return try response.devices.map { device in
+            guard let position = CameraBridgeDevicePosition(rawValue: device.position) else {
+                throw CameraBridgeClientError.invalidStatus(device.position)
+            }
+
+            return CameraBridgeDevice(id: device.id, name: device.name, position: position)
+        }
+    }
+
+    public func sessionState() async throws -> CameraBridgeSessionSnapshot {
+        let response: SessionStateResponse = try await send(
+            method: "GET",
+            path: "/v1/session",
+            requiresAuthorization: false
+        )
+        guard let state = CameraBridgeSessionState(rawValue: response.state) else {
+            throw CameraBridgeClientError.invalidStatus(response.state)
+        }
+
+        return CameraBridgeSessionSnapshot(
+            state: state,
+            activeDeviceID: response.activeDeviceID,
+            ownerID: response.ownerID,
+            lastError: response.lastError
+        )
+    }
+
     private func send<Response: Decodable>(
         method: String,
         path: String,
@@ -154,6 +230,30 @@ private struct PermissionStatusResponse: Decodable {
 private struct PermissionRequestResponse: Decodable {
     var status: String
     var prompted: Bool
+}
+
+private struct DevicesResponse: Decodable {
+    var devices: [DeviceResponse]
+}
+
+private struct DeviceResponse: Decodable {
+    var id: String
+    var name: String
+    var position: String
+}
+
+private struct SessionStateResponse: Decodable {
+    var state: String
+    var activeDeviceID: String?
+    var ownerID: String?
+    var lastError: String?
+
+    enum CodingKeys: String, CodingKey {
+        case state
+        case activeDeviceID = "active_device_id"
+        case ownerID = "owner_id"
+        case lastError = "last_error"
+    }
 }
 
 private struct APIErrorResponse: Decodable {

--- a/tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift
+++ b/tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift
@@ -97,6 +97,89 @@ func permissionRequestSurfacesAPIErrorDetails() async {
     }
 }
 
+@Test
+func devicesUsesReadOnlyRequestShapeAndParsesDevices() async throws {
+    let recorder = RequestRecorder()
+    let client = CameraBridgeClient(
+        transport: { request in
+            await recorder.record(request)
+            return (
+                Data(#"{"devices":[{"id":"camera-1","name":"Built-in Camera","position":"front"}]}"#.utf8),
+                makeHTTPResponse(for: request, statusCode: 200)
+            )
+        }
+    )
+
+    let devices = try await client.devices()
+    let recordedRequest = await recorder.currentRequest()
+
+    #expect(devices == [.init(id: "camera-1", name: "Built-in Camera", position: .front)])
+    #expect(recordedRequest?.method == "GET")
+    #expect(recordedRequest?.url == "http://127.0.0.1:8731/v1/devices")
+    #expect(recordedRequest?.authorization == nil)
+    #expect(recordedRequest?.body == nil)
+}
+
+@Test
+func devicesSurfacesInvalidDevicePosition() async {
+    let client = CameraBridgeClient(
+        transport: { request in
+            (
+                Data(#"{"devices":[{"id":"camera-1","name":"Built-in Camera","position":"sideways"}]}"#.utf8),
+                makeHTTPResponse(for: request, statusCode: 200)
+            )
+        }
+    )
+
+    await #expect(throws: CameraBridgeClientError.invalidStatus("sideways")) {
+        _ = try await client.devices()
+    }
+}
+
+@Test
+func sessionStateUsesReadOnlyRequestShapeAndParsesSessionSnapshot() async throws {
+    let recorder = RequestRecorder()
+    let client = CameraBridgeClient(
+        transport: { request in
+            await recorder.record(request)
+            return (
+                Data(#"{"state":"running","active_device_id":"camera-1","owner_id":"client-1","last_error":null}"#.utf8),
+                makeHTTPResponse(for: request, statusCode: 200)
+            )
+        }
+    )
+
+    let snapshot = try await client.sessionState()
+    let recordedRequest = await recorder.currentRequest()
+
+    #expect(snapshot == .init(
+        state: .running,
+        activeDeviceID: "camera-1",
+        ownerID: "client-1",
+        lastError: nil
+    ))
+    #expect(recordedRequest?.method == "GET")
+    #expect(recordedRequest?.url == "http://127.0.0.1:8731/v1/session")
+    #expect(recordedRequest?.authorization == nil)
+    #expect(recordedRequest?.body == nil)
+}
+
+@Test
+func sessionStateSurfacesInvalidSessionState() async {
+    let client = CameraBridgeClient(
+        transport: { request in
+            (
+                Data(#"{"state":"paused","active_device_id":null,"owner_id":null,"last_error":null}"#.utf8),
+                makeHTTPResponse(for: request, statusCode: 200)
+            )
+        }
+    )
+
+    await #expect(throws: CameraBridgeClientError.invalidStatus("paused")) {
+        _ = try await client.sessionState()
+    }
+}
+
 private func makeHTTPResponse(for request: URLRequest, statusCode: Int) -> HTTPURLResponse {
     HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
 }


### PR DESCRIPTION
## Summary
- add typed Swift client models for device inventory and session state
- expose read-side client methods for GET /v1/devices and GET /v1/session
- add request-shape and response-parsing tests, including invalid-status coverage

## Files Changed
- packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
- tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift

## How It Was Tested
- swift test

## Intentionally Deferred
- mutating session methods remain tracked in #57
- still photo capture remains tracked in #58
- client README refresh remains tracked in #59

Closes #56