### PR TITLE
Add client session control methods

### DIFF
--- a/packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
+++ b/packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
@@ -163,16 +163,37 @@ public struct CameraBridgeClient {
             path: "/v1/session",
             requiresAuthorization: false
         )
-        guard let state = CameraBridgeSessionState(rawValue: response.state) else {
-            throw CameraBridgeClientError.invalidStatus(response.state)
-        }
+        return try makeSessionSnapshot(from: response)
+    }
 
-        return CameraBridgeSessionSnapshot(
-            state: state,
-            activeDeviceID: response.activeDeviceID,
-            ownerID: response.ownerID,
-            lastError: response.lastError
+    public func selectDevice(deviceID: String, ownerID: String?) async throws -> CameraBridgeSessionSnapshot {
+        let response: SessionStateResponse = try await send(
+            method: "POST",
+            path: "/v1/session/select-device",
+            requiresAuthorization: true,
+            requestBody: DeviceSelectionRequest(deviceID: deviceID, ownerID: ownerID)
         )
+        return try makeSessionSnapshot(from: response)
+    }
+
+    public func startSession(ownerID: String) async throws -> CameraBridgeSessionSnapshot {
+        let response: SessionStateResponse = try await send(
+            method: "POST",
+            path: "/v1/session/start",
+            requiresAuthorization: true,
+            requestBody: SessionOwnerRequest(ownerID: ownerID)
+        )
+        return try makeSessionSnapshot(from: response)
+    }
+
+    public func stopSession(ownerID: String) async throws -> CameraBridgeSessionSnapshot {
+        let response: SessionStateResponse = try await send(
+            method: "POST",
+            path: "/v1/session/stop",
+            requiresAuthorization: true,
+            requestBody: SessionOwnerRequest(ownerID: ownerID)
+        )
+        return try makeSessionSnapshot(from: response)
     }
 
     private func send<Response: Decodable>(
@@ -219,9 +240,40 @@ public struct CameraBridgeClient {
 
         return try JSONDecoder().decode(Response.self, from: data)
     }
+
+    private func makeSessionSnapshot(from response: SessionStateResponse) throws -> CameraBridgeSessionSnapshot {
+        guard let state = CameraBridgeSessionState(rawValue: response.state) else {
+            throw CameraBridgeClientError.invalidStatus(response.state)
+        }
+
+        return CameraBridgeSessionSnapshot(
+            state: state,
+            activeDeviceID: response.activeDeviceID,
+            ownerID: response.ownerID,
+            lastError: response.lastError
+        )
+    }
 }
 
 private struct EmptyRequest: Encodable {}
+
+private struct SessionOwnerRequest: Encodable {
+    var ownerID: String
+
+    enum CodingKeys: String, CodingKey {
+        case ownerID = "owner_id"
+    }
+}
+
+private struct DeviceSelectionRequest: Encodable {
+    var deviceID: String
+    var ownerID: String?
+
+    enum CodingKeys: String, CodingKey {
+        case deviceID = "device_id"
+        case ownerID = "owner_id"
+    }
+}
 
 private struct PermissionStatusResponse: Decodable {
     var status: String

--- a/tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift
+++ b/tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift
@@ -180,6 +180,117 @@ func sessionStateSurfacesInvalidSessionState() async {
     }
 }
 
+@Test
+func selectDeviceSendsBearerTokenAndSelectionPayload() async throws {
+    let recorder = RequestRecorder()
+    let client = CameraBridgeClient(
+        tokenProvider: { "test-token" },
+        transport: { request in
+            await recorder.record(request)
+            return (
+                Data(#"{"state":"stopped","active_device_id":"camera-1","owner_id":"client-1","last_error":null}"#.utf8),
+                makeHTTPResponse(for: request, statusCode: 200)
+            )
+        }
+    )
+
+    let snapshot = try await client.selectDevice(deviceID: "camera-1", ownerID: "client-1")
+    let recordedRequest = await recorder.currentRequest()
+
+    #expect(snapshot == .init(
+        state: .stopped,
+        activeDeviceID: "camera-1",
+        ownerID: "client-1",
+        lastError: nil
+    ))
+    #expect(recordedRequest?.method == "POST")
+    #expect(recordedRequest?.url == "http://127.0.0.1:8731/v1/session/select-device")
+    #expect(recordedRequest?.authorization == "Bearer test-token")
+    #expect(recordedRequest?.contentType == "application/json")
+    #expect(recordedRequest?.body == Data(#"{"device_id":"camera-1","owner_id":"client-1"}"#.utf8))
+}
+
+@Test
+func startSessionSendsBearerTokenAndOwnerPayload() async throws {
+    let recorder = RequestRecorder()
+    let client = CameraBridgeClient(
+        tokenProvider: { "test-token" },
+        transport: { request in
+            await recorder.record(request)
+            return (
+                Data(#"{"state":"running","active_device_id":"camera-1","owner_id":"client-1","last_error":null}"#.utf8),
+                makeHTTPResponse(for: request, statusCode: 200)
+            )
+        }
+    )
+
+    let snapshot = try await client.startSession(ownerID: "client-1")
+    let recordedRequest = await recorder.currentRequest()
+
+    #expect(snapshot == .init(
+        state: .running,
+        activeDeviceID: "camera-1",
+        ownerID: "client-1",
+        lastError: nil
+    ))
+    #expect(recordedRequest?.method == "POST")
+    #expect(recordedRequest?.url == "http://127.0.0.1:8731/v1/session/start")
+    #expect(recordedRequest?.authorization == "Bearer test-token")
+    #expect(recordedRequest?.contentType == "application/json")
+    #expect(recordedRequest?.body == Data(#"{"owner_id":"client-1"}"#.utf8))
+}
+
+@Test
+func stopSessionSendsBearerTokenAndOwnerPayload() async throws {
+    let recorder = RequestRecorder()
+    let client = CameraBridgeClient(
+        tokenProvider: { "test-token" },
+        transport: { request in
+            await recorder.record(request)
+            return (
+                Data(#"{"state":"stopped","active_device_id":"camera-1","owner_id":null,"last_error":null}"#.utf8),
+                makeHTTPResponse(for: request, statusCode: 200)
+            )
+        }
+    )
+
+    let snapshot = try await client.stopSession(ownerID: "client-1")
+    let recordedRequest = await recorder.currentRequest()
+
+    #expect(snapshot == .init(
+        state: .stopped,
+        activeDeviceID: "camera-1",
+        ownerID: nil,
+        lastError: nil
+    ))
+    #expect(recordedRequest?.method == "POST")
+    #expect(recordedRequest?.url == "http://127.0.0.1:8731/v1/session/stop")
+    #expect(recordedRequest?.authorization == "Bearer test-token")
+    #expect(recordedRequest?.contentType == "application/json")
+    #expect(recordedRequest?.body == Data(#"{"owner_id":"client-1"}"#.utf8))
+}
+
+@Test
+func stopSessionSurfacesAPIErrorDetails() async {
+    let client = CameraBridgeClient(
+        tokenProvider: { "test-token" },
+        transport: { request in
+            (
+                Data(#"{"error":{"code":"ownership_conflict","message":"Session is owned by client-2"}}"#.utf8),
+                makeHTTPResponse(for: request, statusCode: 409)
+            )
+        }
+    )
+
+    await #expect(throws: CameraBridgeClientError.requestFailed(
+        statusCode: 409,
+        code: "ownership_conflict",
+        message: "Session is owned by client-2"
+    )) {
+        _ = try await client.stopSession(ownerID: "client-1")
+    }
+}
+
 private func makeHTTPResponse(for request: URLRequest, statusCode: Int) -> HTTPURLResponse {
     HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
 }


### PR DESCRIPTION
## Summary
- add Swift client methods for device selection and session start/stop
- reuse the typed session snapshot model for the mutating session responses
- add request-shape and API-error tests for the new control methods

## Files Changed
- packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
- tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift

## How It Was Tested
- swift test

## Intentionally Deferred
- still photo capture remains tracked in #58
- client README refresh remains tracked in #59

Closes #57