### PR TITLE
Add client photo capture method

### DIFF
--- a/packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
+++ b/packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
@@ -60,6 +60,18 @@ public struct CameraBridgeSessionSnapshot: Sendable, Equatable {
     }
 }
 
+public struct CameraBridgeCapturedPhotoArtifact: Sendable, Equatable {
+    public var localPath: String
+    public var capturedAt: Date
+    public var deviceID: String
+
+    public init(localPath: String, capturedAt: Date, deviceID: String) {
+        self.localPath = localPath
+        self.capturedAt = capturedAt
+        self.deviceID = deviceID
+    }
+}
+
 public struct CameraBridgeHealthResponse: Sendable, Equatable, Decodable {
     public var status: String
 
@@ -196,6 +208,24 @@ public struct CameraBridgeClient {
         return try makeSessionSnapshot(from: response)
     }
 
+    public func capturePhoto(ownerID: String) async throws -> CameraBridgeCapturedPhotoArtifact {
+        let response: PhotoCaptureResponse = try await send(
+            method: "POST",
+            path: "/v1/capture/photo",
+            requiresAuthorization: true,
+            requestBody: SessionOwnerRequest(ownerID: ownerID)
+        )
+        guard let capturedAt = iso8601DateFormatter.date(from: response.capturedAt) else {
+            throw CameraBridgeClientError.invalidResponse
+        }
+
+        return CameraBridgeCapturedPhotoArtifact(
+            localPath: response.localPath,
+            capturedAt: capturedAt,
+            deviceID: response.deviceID
+        )
+    }
+
     private func send<Response: Decodable>(
         method: String,
         path: String,
@@ -308,6 +338,18 @@ private struct SessionStateResponse: Decodable {
     }
 }
 
+private struct PhotoCaptureResponse: Decodable {
+    var localPath: String
+    var capturedAt: String
+    var deviceID: String
+
+    enum CodingKeys: String, CodingKey {
+        case localPath = "local_path"
+        case capturedAt = "captured_at"
+        case deviceID = "device_id"
+    }
+}
+
 private struct APIErrorResponse: Decodable {
     var error: APIError
 }
@@ -316,3 +358,9 @@ private struct APIError: Decodable {
     var code: String
     var message: String
 }
+
+private let iso8601DateFormatter: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter
+}()

--- a/tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift
+++ b/tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift
@@ -291,6 +291,59 @@ func stopSessionSurfacesAPIErrorDetails() async {
     }
 }
 
+@Test
+func capturePhotoSendsBearerTokenAndParsesArtifactMetadata() async throws {
+    let capturedAt = makeFractionalSecondISO8601Formatter().date(from: "2024-03-09T16:00:00.123Z")!
+    let recorder = RequestRecorder()
+    let client = CameraBridgeClient(
+        tokenProvider: { "test-token" },
+        transport: { request in
+            await recorder.record(request)
+            return (
+                Data(#"{"local_path":"/tmp/capture.jpg","captured_at":"2024-03-09T16:00:00.123Z","device_id":"camera-1"}"#.utf8),
+                makeHTTPResponse(for: request, statusCode: 200)
+            )
+        }
+    )
+
+    let artifact = try await client.capturePhoto(ownerID: "client-1")
+    let recordedRequest = await recorder.currentRequest()
+
+    #expect(artifact == .init(
+        localPath: "/tmp/capture.jpg",
+        capturedAt: capturedAt,
+        deviceID: "camera-1"
+    ))
+    #expect(recordedRequest?.method == "POST")
+    #expect(recordedRequest?.url == "http://127.0.0.1:8731/v1/capture/photo")
+    #expect(recordedRequest?.authorization == "Bearer test-token")
+    #expect(recordedRequest?.contentType == "application/json")
+    #expect(recordedRequest?.body == Data(#"{"owner_id":"client-1"}"#.utf8))
+}
+
+@Test
+func capturePhotoSurfacesInvalidTimestampResponse() async {
+    let client = CameraBridgeClient(
+        tokenProvider: { "test-token" },
+        transport: { request in
+            (
+                Data(#"{"local_path":"/tmp/capture.jpg","captured_at":"not-a-date","device_id":"camera-1"}"#.utf8),
+                makeHTTPResponse(for: request, statusCode: 200)
+            )
+        }
+    )
+
+    await #expect(throws: CameraBridgeClientError.invalidResponse) {
+        _ = try await client.capturePhoto(ownerID: "client-1")
+    }
+}
+
 private func makeHTTPResponse(for request: URLRequest, statusCode: Int) -> HTTPURLResponse {
     HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+}
+
+private func makeFractionalSecondISO8601Formatter() -> ISO8601DateFormatter {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter
 }


### PR DESCRIPTION
## Summary
- add a typed Swift client artifact model for still photo capture metadata
- expose a capturePhoto(ownerID:) method for POST /v1/capture/photo
- add request-shape and timestamp-parsing tests for the new capture path

## Files Changed
- packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
- tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift

## How It Was Tested
- swift test

## Intentionally Deferred
- client README refresh remains tracked in #59

Closes #58