### PR TITLE
Refresh Swift client README

### DIFF
--- a/packages/CameraBridgeClientSwift/README.md
+++ b/packages/CameraBridgeClientSwift/README.md
@@ -2,15 +2,33 @@
 
 `CameraBridgeClientSwift` is the small Swift client currently used by `CameraBridgeApp`.
 
-Current app-focused surface:
+Current shipped surface:
 
 - `health()` to confirm the local daemon is reachable
+- `serviceIsRunning()` convenience check for the app shell
 - `permissionStatus()` for `GET /v1/permissions`
 - `requestPermission()` for `POST /v1/permissions/request`
-- `serviceIsRunning()` convenience check for the app shell
+- `devices()` for `GET /v1/devices`
+- `sessionState()` for `GET /v1/session`
+- `selectDevice(deviceID:ownerID:)` for `POST /v1/session/select-device`
+- `startSession(ownerID:)` for `POST /v1/session/start`
+- `stopSession(ownerID:)` for `POST /v1/session/stop`
+- `capturePhoto(ownerID:)` for `POST /v1/capture/photo`
 
-This package is intentionally narrow in the current slice. Session and capture
-helpers are tracked separately and are not part of the shipped client surface
-yet.
+The client exposes typed models for:
+
+- permission status and permission request results
+- device inventory
+- session state snapshots
+- captured photo artifact metadata
+
+Protected endpoints use the same bearer-token contract as the daemon and app:
+
+```swift
+let client = CameraBridgeClient(tokenProvider: { try? String(contentsOfFile: tokenPath) })
+```
+
+The request and response contract for the full shipped client surface is
+covered by `swift test` in `tests/CameraBridgeClientSwiftTests`.
 
 For the current repo-level setup and first capture flow, see [docs/quick-start.md](../../docs/quick-start.md).

--- a/tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift
+++ b/tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift
@@ -207,7 +207,10 @@ func selectDeviceSendsBearerTokenAndSelectionPayload() async throws {
     #expect(recordedRequest?.url == "http://127.0.0.1:8731/v1/session/select-device")
     #expect(recordedRequest?.authorization == "Bearer test-token")
     #expect(recordedRequest?.contentType == "application/json")
-    #expect(recordedRequest?.body == Data(#"{"device_id":"camera-1","owner_id":"client-1"}"#.utf8))
+    #expect(try decodedJSONObject(recordedRequest?.body) == [
+        "device_id": "camera-1",
+        "owner_id": "client-1",
+    ])
 }
 
 @Test
@@ -340,6 +343,14 @@ func capturePhotoSurfacesInvalidTimestampResponse() async {
 
 private func makeHTTPResponse(for request: URLRequest, statusCode: Int) -> HTTPURLResponse {
     HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+}
+
+private func decodedJSONObject(_ data: Data?) throws -> [String: String] {
+    guard let data else {
+        return [:]
+    }
+    let object = try JSONSerialization.jsonObject(with: data)
+    return object as? [String: String] ?? [:]
 }
 
 private func makeFractionalSecondISO8601Formatter() -> ISO8601DateFormatter {


### PR DESCRIPTION
## Summary
- update the Swift client README to describe the full shipped client surface
- document the typed models and bearer-token usage expected by protected endpoints
- normalize the select-device request test to compare decoded JSON payloads instead of raw byte ordering

## Files Changed
- packages/CameraBridgeClientSwift/README.md
- tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift

## How It Was Tested
- swift test

## Intentionally Deferred
- no further client API expansion remains in the current issue stack

Closes #59