### PR TITLE
Move camera permission prompting into CameraBridgeApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ The shortest successful path is:
 
 1. package and launch `CameraBridgeApp.app`
 2. click `Start Service`
-3. confirm `Permission: authorized`
-4. run the minimal Python example with a real device id from `GET /v1/devices`
+3. click `Request Camera Access` if permission is not already authorized
+4. confirm `Permission: authorized`
+5. run the minimal Python example with a real device id from `GET /v1/devices`
 
 ```bash
 python3 examples/python/capture_photo.py --device-id "YOUR_DEVICE_ID"

--- a/apps/CameraBridgeApp/README.md
+++ b/apps/CameraBridgeApp/README.md
@@ -8,8 +8,19 @@ The app remains a thin client of the localhost CameraBridge service. Its menu ba
 - camera permission visibility
 - onboarding guidance for the next user action
 - starting the bundled `camd` service
-- requesting camera access through the public API
+- requesting camera access directly from the app process
 - quitting the app
+
+`CameraBridgeApp` is the only supported camera-permission prompt initiator in v1.
+It reads and requests camera access through the app bundle, then syncs the
+observed permission state to:
+
+```text
+~/Library/Application Support/CameraBridge/permission-state
+```
+
+The bundled daemon reads that stored permission state for `/v1/permissions`,
+`/v1/permissions/request`, and session-start preconditions.
 
 ## Local Packaging
 
@@ -49,10 +60,10 @@ Use the packaged app bundle for manual verification:
    - a clear service status row
    - a clear permission status row
    - a guidance row describing the next onboarding step
-4. With the service stopped, confirm `Start CameraBridge Service` is enabled and permission request is disabled.
+4. With permission not yet granted, confirm `Request Camera Access` is enabled even before the service is started.
 5. After starting the service, confirm the menu updates to show the running state.
-6. With permission not yet granted, confirm `Request Camera Access` is enabled and the guidance text points the user to that action.
-7. After granting permission, confirm the menu reports that CameraBridge is ready.
+6. Confirm that clicking `Request Camera Access` prompts from `CameraBridgeApp`.
+7. After granting permission, confirm the menu reports that CameraBridge is ready and `~/Library/Application Support/CameraBridge/permission-state` contains `authorized`.
 8. If service launch or permission request fails, confirm the last error row appears with readable wording.
 
 Capture screenshots of the refined menu states when practical for PR notes.

--- a/apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift
+++ b/apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import CameraBridgeClientSwift
 import CameraBridgeSupport
 import Foundation
@@ -106,12 +107,18 @@ final class CameraBridgeAppModel {
         switch (serviceStatus, permissionDisplay) {
         case (.starting, _):
             return "Waiting for the local CameraBridge service to respond."
+        case (.stopped, .notDetermined), (.failed, .notDetermined):
+            return "Request camera access from CameraBridge, then start the local service to finish onboarding."
+        case (.stopped, .restricted), (.failed, .restricted):
+            return "Camera access is restricted on this Mac and cannot be granted from CameraBridge."
+        case (.stopped, .denied), (.failed, .denied):
+            return "Camera access was denied. Re-enable it in System Settings > Privacy & Security > Camera."
         case (.stopped, _), (.failed, _):
-            return "Start the local service to check camera permissions and finish onboarding."
+            return "Start the local service to finish onboarding."
         case (.running, .checking):
             return "Respond to the macOS camera permission prompt if it appears."
         case (.running, .notDetermined):
-            return "Request camera access to complete the app-owned onboarding flow."
+            return "Request camera access from CameraBridge to continue."
         case (.running, .restricted):
             return "Camera access is restricted on this Mac and cannot be granted from CameraBridge."
         case (.running, .denied):
@@ -137,7 +144,7 @@ final class CameraBridgeAppModel {
     }
 
     var canRequestCameraAccess: Bool {
-        serviceStatus.isRunning && !isRequestInFlight
+        !isRequestInFlight && (permissionDisplay == .notDetermined || permissionDisplay == .unavailable)
     }
 
     private var serviceStatus: ServiceStatus = .stopped
@@ -147,11 +154,15 @@ final class CameraBridgeAppModel {
     private var refreshTimer: Timer?
 
     private let client: any CameraBridgeAppClient
+    private let permissionController: any CameraBridgeAppPermissionControlling
+    private let permissionStateStore: any CameraBridgePermissionStateWriting
     private let serviceLauncher: any CameraBridgeServiceLaunching
 
     init(
         client: (any CameraBridgeAppClient)? = nil,
         authTokenStore: any CameraBridgeAuthTokenReading = DefaultCameraBridgeAuthTokenStore(),
+        permissionController: (any CameraBridgeAppPermissionControlling)? = nil,
+        permissionStateStore: any CameraBridgePermissionStateWriting = DefaultCameraBridgePermissionStateStore(),
         serviceLauncher: (any CameraBridgeServiceLaunching)? = nil
     ) {
         let resolvedClient = client ?? CameraBridgeClient(
@@ -160,6 +171,8 @@ final class CameraBridgeAppModel {
             }
         )
         self.client = resolvedClient
+        self.permissionController = permissionController ?? AVFoundationCameraBridgeAppPermissionController()
+        self.permissionStateStore = permissionStateStore
         self.serviceLauncher = serviceLauncher ?? LocalCameraBridgeServiceLauncher(client: resolvedClient)
     }
 
@@ -212,26 +225,13 @@ final class CameraBridgeAppModel {
     }
 
     private func refreshState() async {
+        let permissionStatus = permissionController.currentPermissionStatus()
+        let syncError = syncPermissionState(permissionStatus)
         let isRunning = await client.serviceIsRunning()
-        guard isRunning else {
-            serviceStatus = .stopped
-            permissionDisplay = .unavailable
-            publishChange()
-            return
-        }
-
-        do {
-            let permissionStatus = try await client.permissionStatus()
-            serviceStatus = .running
-            permissionDisplay = .init(permissionStatus: permissionStatus)
-            lastError = nil
-            publishChange()
-        } catch {
-            serviceStatus = .running
-            permissionDisplay = .unavailable
-            lastError = displayMessage(for: error)
-            publishChange()
-        }
+        serviceStatus = isRunning ? .running : .stopped
+        permissionDisplay = .init(permissionStatus: permissionStatus)
+        lastError = syncError.map(displayMessage(for:))
+        publishChange()
     }
 
     private func performStartService() async {
@@ -248,7 +248,9 @@ final class CameraBridgeAppModel {
             await refreshState()
         } catch {
             serviceStatus = .failed(displayMessage(for: error))
-            permissionDisplay = .unavailable
+            let permissionStatus = permissionController.currentPermissionStatus()
+            _ = syncPermissionState(permissionStatus)
+            permissionDisplay = .init(permissionStatus: permissionStatus)
             lastError = displayMessage(for: error)
             publishChange()
         }
@@ -256,10 +258,6 @@ final class CameraBridgeAppModel {
 
     private func performRequestCameraAccess() async {
         guard canRequestCameraAccess else {
-            if !serviceStatus.isRunning {
-                lastError = "Service is not running"
-                publishChange()
-            }
             return
         }
 
@@ -273,12 +271,22 @@ final class CameraBridgeAppModel {
             publishChange()
         }
 
+        let result = await permissionController.requestPermission()
+        if let syncError = syncPermissionState(result.status) {
+            permissionDisplay = .init(permissionStatus: result.status)
+            lastError = displayMessage(for: syncError)
+            return
+        }
+
+        await refreshState()
+    }
+
+    private func syncPermissionState(_ permissionStatus: CameraBridgePermissionStatus) -> Error? {
         do {
-            _ = try await client.requestPermission()
-            await refreshState()
+            try permissionStateStore.savePermissionState(.init(permissionStatus: permissionStatus))
+            return nil
         } catch {
-            permissionDisplay = .unavailable
-            lastError = displayMessage(for: error)
+            return error
         }
     }
 
@@ -297,6 +305,8 @@ final class CameraBridgeAppModel {
             return launchError.errorDescription ?? "Service failed to start"
         case let authTokenError as CameraBridgeAuthTokenError:
             return authTokenError.errorDescription ?? "Auth token setup failed"
+        case let permissionStateStoreError as CameraBridgePermissionStateStoreError:
+            return permissionStateStoreError.errorDescription ?? "Permission state sync failed"
         default:
             return error.localizedDescription
         }
@@ -311,11 +321,52 @@ extension DefaultCameraBridgeAuthTokenStore: CameraBridgeAuthTokenReading {}
 
 protocol CameraBridgeAppClient {
     func serviceIsRunning() async -> Bool
-    func permissionStatus() async throws -> CameraBridgePermissionStatus
-    func requestPermission() async throws -> CameraBridgePermissionRequestResult
 }
 
 extension CameraBridgeClient: CameraBridgeAppClient {}
+
+@MainActor
+protocol CameraBridgeAppPermissionControlling {
+    func currentPermissionStatus() -> CameraBridgePermissionStatus
+    func requestPermission() async -> CameraBridgePermissionRequestResult
+}
+
+struct AVFoundationCameraBridgeAppPermissionController: CameraBridgeAppPermissionControlling {
+    func currentPermissionStatus() -> CameraBridgePermissionStatus {
+        CameraBridgePermissionStatus(
+            authorizationStatus: AVCaptureDevice.authorizationStatus(for: .video)
+        )
+    }
+
+    func requestPermission() async -> CameraBridgePermissionRequestResult {
+        let currentStatus = AVCaptureDevice.authorizationStatus(for: .video)
+        guard currentStatus == .notDetermined else {
+            return .init(
+                status: CameraBridgePermissionStatus(authorizationStatus: currentStatus),
+                prompted: false
+            )
+        }
+
+        return await withCheckedContinuation { continuation in
+            AVCaptureDevice.requestAccess(for: .video) { _ in
+                continuation.resume(
+                    returning: .init(
+                        status: CameraBridgePermissionStatus(
+                            authorizationStatus: AVCaptureDevice.authorizationStatus(for: .video)
+                        ),
+                        prompted: true
+                    )
+                )
+            }
+        }
+    }
+}
+
+protocol CameraBridgePermissionStateWriting {
+    func savePermissionState(_ state: CameraBridgeStoredPermissionState) throws
+}
+
+extension DefaultCameraBridgePermissionStateStore: CameraBridgePermissionStateWriting {}
 
 @MainActor
 protocol CameraBridgeServiceLaunching {
@@ -415,5 +466,37 @@ final class LocalCameraBridgeServiceLauncher: CameraBridgeServiceLaunching {
         let handle = try FileHandle(forWritingTo: logURL)
         try handle.seekToEnd()
         return handle
+    }
+}
+
+private extension CameraBridgeStoredPermissionState {
+    init(permissionStatus: CameraBridgePermissionStatus) {
+        switch permissionStatus {
+        case .notDetermined:
+            self = .notDetermined
+        case .restricted:
+            self = .restricted
+        case .denied:
+            self = .denied
+        case .authorized:
+            self = .authorized
+        }
+    }
+}
+
+private extension CameraBridgePermissionStatus {
+    init(authorizationStatus: AVAuthorizationStatus) {
+        switch authorizationStatus {
+        case .notDetermined:
+            self = .notDetermined
+        case .restricted:
+            self = .restricted
+        case .denied:
+            self = .denied
+        case .authorized:
+            self = .authorized
+        @unknown default:
+            self = .denied
+        }
     }
 }

--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -52,7 +52,11 @@ struct CameraBridgeDaemon {
 
     private func defaultRouter() throws -> CameraBridgeRouter {
         let deviceListing = AVFoundationCameraDeviceListing()
+        let permissionStateStore = DefaultCameraBridgePermissionStateStore()
+        let permissionStatusProvider = StoredPermissionStatusProvider(permissionStateStore: permissionStateStore)
         let sessionController = DefaultCameraSessionController(
+            permissionStatusProvider: permissionStatusProvider,
+            permissionRequester: StoredPermissionRequester(permissionStatusProvider: permissionStatusProvider),
             deviceListing: deviceListing,
             photoProducer: AVFoundationStillPhotoProducer(),
             artifactStore: DefaultPhotoArtifactStore()
@@ -60,7 +64,7 @@ struct CameraBridgeDaemon {
         let authToken = try configuration.resolvedAuthToken()
         return CameraBridgeRouter(
             routes: CameraBridgeRoutes.current(
-                permissionController: sessionController,
+                permissionStatusProvider: sessionController,
                 deviceListing: sessionController,
                 cameraStateProvider: sessionController,
                 deviceSelector: sessionController,
@@ -87,5 +91,45 @@ struct CameraBridgeDaemon {
         let port = try server.start()
         logger("camd ready on \(configuration.host):\(port)")
         return server
+    }
+}
+
+struct StoredPermissionStatusProvider: CameraPermissionStatusProviding, @unchecked Sendable {
+    let permissionStateStore: DefaultCameraBridgePermissionStateStore
+
+    func currentPermissionState() -> PermissionState {
+        do {
+            return PermissionState(storedPermissionState: try permissionStateStore.loadPermissionState())
+        } catch {
+            return .notDetermined
+        }
+    }
+}
+
+struct StoredPermissionRequester: CameraPermissionRequesting {
+    let permissionStatusProvider: any CameraPermissionStatusProviding
+
+    func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void) {
+        completion(
+            PermissionRequestResult(
+                status: permissionStatusProvider.currentPermissionState(),
+                prompted: false
+            )
+        )
+    }
+}
+
+extension PermissionState {
+    init(storedPermissionState: CameraBridgeStoredPermissionState) {
+        switch storedPermissionState {
+        case .notDetermined:
+            self = .notDetermined
+        case .restricted:
+            self = .restricted
+        case .denied:
+            self = .denied
+        case .authorized:
+            self = .authorized
+        }
     }
 }

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -79,7 +79,7 @@ Status: `current`
 
 - auth: none for the early read-only slice
 - response: `200 OK`
-- returns the current permission state from the Core-owned permission controller
+- returns the current permission state from the app-synced permission store consumed by the Core-owned permission controller
 
 ```json
 {
@@ -103,17 +103,18 @@ Status: `current`
 
 Behavior:
 
-- uses the same Core-owned permission controller exposed by `GET /v1/permissions`
-- requests camera permission through the macOS system prompt only when the status is `not_determined`
-- when permission has already been decided, returns the current state without prompting again
+- uses the same stored permission state exposed by `GET /v1/permissions`
+- does not trigger the macOS system prompt from `camd`
+- when permission has already been decided, returns the current state with `prompted: false`
+- when permission is still `not_determined`, the caller must use `CameraBridgeApp` to request access
 - does not create or transfer session ownership
-- updates the shared permission state later consumed by `POST /v1/session/start`
+- returns the shared permission state later consumed by `POST /v1/session/start`
 
 Successful response: `200 OK`
 
 ```json
 {
-  "prompted": true,
+  "prompted": false,
   "status": "authorized"
 }
 ```
@@ -121,7 +122,18 @@ Successful response: `200 OK`
 Response fields:
 
 - `status`: resulting permission state
-- `prompted`: `true` if the system prompt was shown during the request
+- `prompted`: always `false` for daemon responses in v1
+
+Undecided permission response: `409 invalid_state`
+
+```json
+{
+  "error": {
+    "code": "invalid_state",
+    "message": "Camera permission must be requested from CameraBridgeApp"
+  }
+}
+```
 
 ### `GET /v1/devices`
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -137,6 +137,8 @@ No domain logic.
 - menu bar UI
 - onboarding
 - status display
+- app-owned camera permission prompting
+- permission-state sync to Application Support
 
 No backend logic.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -49,7 +49,8 @@ From the menu bar app:
 1. click `Start Service`
 2. confirm the app shows `Service: running`
 3. click `Request Camera Access` if permission is still undecided
-4. confirm the app shows `Permission: authorized`
+4. allow the macOS camera prompt shown by `CameraBridgeApp`
+5. confirm the app shows `Permission: authorized`
 
 When `camd` starts without `CAMERABRIDGE_AUTH_TOKEN`, it loads or creates the local bearer token at:
 
@@ -58,6 +59,15 @@ When `camd` starts without `CAMERABRIDGE_AUTH_TOKEN`, it loads or creates the lo
 ```
 
 The packaged app uses that same daemon-owned token contract when it launches the bundled service.
+
+`CameraBridgeApp` also writes the current permission state to:
+
+```text
+~/Library/Application Support/CameraBridge/permission-state
+```
+
+The daemon consumes that stored state for `/v1/permissions`,
+`/v1/permissions/request`, and the session-start permission precondition.
 
 The packaged app starts `camd` as a localhost-only service intended to be reachable from other local clients at `127.0.0.1:8731`.
 
@@ -74,8 +84,16 @@ Check the service health and current permission state:
 ```bash
 curl -s http://127.0.0.1:8731/health
 curl -s http://127.0.0.1:8731/v1/permissions
+curl -s -X POST http://127.0.0.1:8731/v1/permissions/request \
+  -H "Authorization: Bearer $(cat ~/Library/Application\\ Support/CameraBridge/auth-token)" \
+  -H 'Content-Type: application/json' \
+  -d '{}'
 curl -s http://127.0.0.1:8731/v1/devices
 ```
+
+If permission is already decided, `POST /v1/permissions/request` returns the
+stored state with `prompted: false`. If it returns `409 invalid_state`, go back
+to the menu bar app and request access there.
 
 The mutating endpoints use the bearer token from Application Support:
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -61,8 +61,9 @@ Expected checkpoints:
 
 Expected checkpoints:
 
-- the macOS permission prompt appears when status is `not_determined`
+- the macOS permission prompt appears from `CameraBridgeApp` when status is `not_determined`
 - the menu reaches `Permission: Authorized`
+- `~/Library/Application Support/CameraBridge/permission-state` contains `authorized`
 - failures are surfaced in the menu with readable text
 
 5. Verify the local API:
@@ -70,6 +71,11 @@ Expected checkpoints:
 ```bash
 curl -s http://127.0.0.1:8731/health
 curl -s http://127.0.0.1:8731/v1/permissions
+TOKEN="$(cat ~/Library/Application\ Support/CameraBridge/auth-token)"
+curl -s -X POST http://127.0.0.1:8731/v1/permissions/request \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{}'
 curl -s http://127.0.0.1:8731/v1/devices
 ```
 
@@ -77,6 +83,7 @@ Expected checkpoints:
 
 - `/health` returns `{"status":"ok"}`
 - `/v1/permissions` returns `authorized`
+- `/v1/permissions/request` returns `{"prompted":false,"status":"authorized"}`
 - `/v1/devices` returns at least one real camera device
 
 6. Run the first-capture example with a real device id:
@@ -110,6 +117,7 @@ Record any failure in these areas:
 - auth token file is missing or unreadable
 - permission prompt does not appear when expected
 - permission state does not update after the prompt
+- permission-state file is missing, invalid, or stale
 - device listing is empty despite connected hardware
 - session start or device selection fails unexpectedly
 - capture fails or no artifact is written
@@ -127,7 +135,9 @@ release:
 - [ ] Packaged `CameraBridgeApp.app` launched successfully
 - [ ] `camd` started from the app and reported healthy on `127.0.0.1:8731`
 - [ ] Auth token file existed at `~/Library/Application Support/CameraBridge/auth-token`
+- [ ] Permission-state file existed at `~/Library/Application Support/CameraBridge/permission-state`
 - [ ] Camera permission reached `authorized`
+- [ ] `POST /v1/permissions/request` returned `prompted:false` after authorization
 - [ ] `GET /v1/devices` returned the expected camera
 - [ ] Python first-capture example completed successfully
 - [ ] Capture artifact existed at the reported `local_path`
@@ -144,3 +154,18 @@ Fill this in during the manual run:
 - Camera device:
 - Result:
 - Notes:
+
+### Latest Recorded Run
+
+- Date: 2026-03-21
+- Machine: Mac17,3
+- macOS version: 26.3.1 (25D2128)
+- Camera device: Insta360 Link 2
+- Result: Passed
+- Notes:
+  - Packaged `CameraBridgeApp.app` wrote `~/Library/Application Support/CameraBridge/permission-state`
+  - `GET /health` returned `200 OK`
+  - `GET /v1/permissions` returned `authorized`
+  - `POST /v1/permissions/request` returned `{"prompted":false,"status":"authorized"}`
+  - `examples/python/capture_photo.py --device-id 0x1000002e1a4c04` completed successfully
+  - Capture artifact written to `~/Library/Application Support/CameraBridge/Captures/capture-20260321T194247439Z-e21df7e5-ca86-4529-982f-a4a511053f7e.jpg`

--- a/docs/roadmap/v1.md
+++ b/docs/roadmap/v1.md
@@ -53,7 +53,7 @@ If this flow works reliably, v1 is successful.
 #### Permissions
 
 - Read permission state
-- Request camera permission via system prompt
+- Request camera permission via `CameraBridgeApp`
 
 #### Device Discovery
 

--- a/packages/CameraBridgeAPI/README.md
+++ b/packages/CameraBridgeAPI/README.md
@@ -14,3 +14,7 @@ The current v1 surface includes:
 - `POST /v1/session/stop`
 - `POST /v1/session/select-device`
 - `POST /v1/capture/photo`
+
+`POST /v1/permissions/request` does not invoke the macOS permission prompt from
+the daemon. It returns the stored synced permission state and directs callers to
+`CameraBridgeApp` when permission is still undecided.

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -133,7 +133,7 @@ public struct CameraBridgeRouter: Sendable {
 
 public enum CameraBridgeRoutes {
     public static func current(
-        permissionController: any CameraPermissionControlling,
+        permissionStatusProvider: any CameraPermissionStatusProviding,
         deviceListing: any CameraDeviceListing,
         cameraStateProvider: any CameraStateProviding,
         deviceSelector: any CameraDeviceSelecting,
@@ -144,13 +144,13 @@ public enum CameraBridgeRoutes {
     ) -> [HTTPRoute] {
         [
             health(),
-            permissionStatus(controller: permissionController),
-            permissionRequest(controller: permissionController, authorizer: authorizer),
+            permissionStatus(controller: permissionStatusProvider),
+            permissionRequest(controller: permissionStatusProvider, authorizer: authorizer),
             devices(deviceListing: deviceListing),
             sessionState(provider: cameraStateProvider),
             sessionStart(
                 starter: sessionStarter,
-                permissionController: permissionController,
+                permissionController: permissionStatusProvider,
                 authorizer: authorizer
             ),
             sessionStop(stopper: sessionStopper, authorizer: authorizer),
@@ -175,7 +175,7 @@ public enum CameraBridgeRoutes {
     }
 
     public static func permissionRequest(
-        controller: any CameraPermissionRequesting,
+        controller: any CameraPermissionStatusProviding,
         authorizer: any BearerTokenAuthorizing
     ) -> HTTPRoute {
         HTTPRoute(method: .post, path: "/v1/permissions/request") { request in
@@ -183,20 +183,19 @@ public enum CameraBridgeRoutes {
                 return .unauthorized()
             }
 
-            let semaphore = DispatchSemaphore(value: 0)
-            let resultBox = PermissionRequestResultBox()
-
-            controller.requestPermission { permissionResult in
-                resultBox.result = permissionResult
-                semaphore.signal()
+            let currentPermissionState = controller.currentPermissionState()
+            guard currentPermissionState != .notDetermined else {
+                return .error(
+                    statusCode: 409,
+                    code: "invalid_state",
+                    message: "Camera permission must be requested from CameraBridgeApp"
+                )
             }
-
-            semaphore.wait()
 
             return .json(
                 statusCode: 200,
                 body: PermissionRequestResponse(
-                    result: resultBox.result ?? .init(status: .denied, prompted: false)
+                    result: .init(status: currentPermissionState, prompted: false)
                 )
             )
         }
@@ -734,10 +733,6 @@ private struct PermissionRequestResponse: Encodable, Equatable {
         self.status = result.status.rawValue
         self.prompted = result.prompted
     }
-}
-
-private final class PermissionRequestResultBox: @unchecked Sendable {
-    var result: PermissionRequestResult?
 }
 
 private struct DevicesResponse: Encodable, Equatable {

--- a/packages/CameraBridgeClientSwift/README.md
+++ b/packages/CameraBridgeClientSwift/README.md
@@ -31,4 +31,9 @@ let client = CameraBridgeClient(tokenProvider: { try? String(contentsOfFile: tok
 The request and response contract for the full shipped client surface is
 covered by `swift test` in `tests/CameraBridgeClientSwiftTests`.
 
+`requestPermission()` no longer triggers a macOS prompt from `camd`. It returns
+the daemon's stored permission state with `prompted: false`, or surfaces the
+`409 invalid_state` response that tells callers to use `CameraBridgeApp` when
+permission is still `not_determined`.
+
 For the current repo-level setup and first capture flow, see [docs/quick-start.md](../../docs/quick-start.md).

--- a/packages/CameraBridgeSupport/Sources/CameraBridgeSupport/CameraBridgeSupport.swift
+++ b/packages/CameraBridgeSupport/Sources/CameraBridgeSupport/CameraBridgeSupport.swift
@@ -18,6 +18,27 @@ public enum CameraBridgeAuthTokenError: LocalizedError, Equatable {
     }
 }
 
+public enum CameraBridgeStoredPermissionState: String, Sendable, CaseIterable, Equatable {
+    case notDetermined = "not_determined"
+    case restricted
+    case denied
+    case authorized
+}
+
+public enum CameraBridgePermissionStateStoreError: LocalizedError, Equatable {
+    case invalidPermissionStateFile
+    case supportDirectoryUnavailable
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidPermissionStateFile:
+            return "Stored permission state is invalid"
+        case .supportDirectoryUnavailable:
+            return "CameraBridge support directory is unavailable"
+        }
+    }
+}
+
 public struct DefaultCameraBridgeAuthTokenStore {
     public var baseDirectoryURL: URL?
 
@@ -81,5 +102,60 @@ public struct DefaultCameraBridgeAuthTokenStore {
             throw CameraBridgeAuthTokenError.invalidTokenFile
         }
         return token
+    }
+}
+
+public struct DefaultCameraBridgePermissionStateStore {
+    public var baseDirectoryURL: URL?
+
+    private let fileManager: FileManager
+
+    public init(fileManager: FileManager = .default, baseDirectoryURL: URL? = nil) {
+        self.fileManager = fileManager
+        self.baseDirectoryURL = baseDirectoryURL
+    }
+
+    public func loadPermissionState() throws -> CameraBridgeStoredPermissionState {
+        let permissionStateURL = try permissionStateURL()
+        guard fileManager.fileExists(atPath: permissionStateURL.path) else {
+            return .notDetermined
+        }
+
+        let rawValue = try String(contentsOf: permissionStateURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let state = CameraBridgeStoredPermissionState(rawValue: rawValue) else {
+            throw CameraBridgePermissionStateStoreError.invalidPermissionStateFile
+        }
+
+        return state
+    }
+
+    public func savePermissionState(_ state: CameraBridgeStoredPermissionState) throws {
+        let permissionStateURL = try permissionStateURL()
+        try fileManager.createDirectory(
+            at: permissionStateURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(state.rawValue.utf8).write(to: permissionStateURL, options: .atomic)
+    }
+
+    public func permissionStateURL() throws -> URL {
+        try supportDirectoryURL()
+            .appendingPathComponent("permission-state", isDirectory: false)
+    }
+
+    private func supportDirectoryURL() throws -> URL {
+        if let baseDirectoryURL {
+            return baseDirectoryURL
+        }
+
+        guard let applicationSupportURL =
+            fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        else {
+            throw CameraBridgePermissionStateStoreError.supportDirectoryUnavailable
+        }
+
+        return applicationSupportURL
+            .appendingPathComponent("CameraBridge", isDirectory: true)
     }
 }

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -144,8 +144,9 @@ func localHTTPServerReturnsPermissionStatusWithoutAuth() async throws {
 
 @Test
 func routerRejectsPermissionRequestWithoutBearerToken() {
-    let requester = RecordingPermissionRequester(result: .init(status: .authorized, prompted: true))
-    let sessionController = makeSessionController(permissionRequester: requester)
+    let sessionController = makeSessionController(
+        permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized)
+    )
     let router = makeRouter(sessionController: sessionController)
     let response = router.response(for: HTTPRequest(method: .post, path: "/v1/permissions/request"))
 
@@ -154,15 +155,35 @@ func routerRejectsPermissionRequestWithoutBearerToken() {
         String(decoding: response.body, as: UTF8.self) ==
         #"{"error":{"code":"unauthorized","message":"Bearer token missing or invalid"}}"#
     )
-    #expect(requester.requestCount == 0)
 }
 
 @Test
-func routerReturnsPermissionRequestResultForAuthorizedRequest() {
-    let requester = RecordingPermissionRequester(result: .init(status: .authorized, prompted: true))
+func routerRejectsPermissionRequestWhenPromptMustComeFromApp() {
     let sessionController = makeSessionController(
         state: CameraState(permissionState: .denied),
-        permissionRequester: requester
+        permissionStatusProvider: FixedPermissionStatusProvider(state: .notDetermined)
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/permissions/request",
+            headers: ["Authorization": "Bearer test-token"]
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_state","message":"Camera permission must be requested from CameraBridgeApp"}}"#
+    )
+    #expect(sessionController.currentCameraState().permissionState == .notDetermined)
+}
+
+@Test
+func routerReturnsStoredPermissionRequestResultForAuthorizedRequest() {
+    let sessionController = makeSessionController(
+        permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized)
     )
     let router = makeRouter(sessionController: sessionController)
     let response = router.response(
@@ -174,16 +195,15 @@ func routerReturnsPermissionRequestResultForAuthorizedRequest() {
     )
 
     #expect(response.statusCode == 200)
-    #expect(String(decoding: response.body, as: UTF8.self) == #"{"prompted":true,"status":"authorized"}"#)
-    #expect(requester.requestCount == 1)
+    #expect(String(decoding: response.body, as: UTF8.self) == #"{"prompted":false,"status":"authorized"}"#)
     #expect(sessionController.currentCameraState().permissionState == .authorized)
 }
 
 @Test
-func localHTTPServerReturnsPermissionRequestResultForAuthorizedRequest() async throws {
+func localHTTPServerReturnsStoredPermissionRequestResultForAuthorizedRequest() async throws {
     let port = try reserveEphemeralPort()
     let sessionController = makeSessionController(
-        permissionRequester: FixedPermissionRequester(result: .init(status: .denied, prompted: true))
+        permissionStatusProvider: FixedPermissionStatusProvider(state: .denied)
     )
     let server = LocalHTTPServer(
         configuration: .init(host: "127.0.0.1", port: port),
@@ -200,7 +220,7 @@ func localHTTPServerReturnsPermissionRequestResultForAuthorizedRequest() async t
     let httpResponse = try #require(response as? HTTPURLResponse)
 
     #expect(httpResponse.statusCode == 200)
-    #expect(String(decoding: data, as: UTF8.self) == #"{"prompted":true,"status":"denied"}"#)
+    #expect(String(decoding: data, as: UTF8.self) == #"{"prompted":false,"status":"denied"}"#)
     #expect(sessionController.currentCameraState().permissionState == .denied)
 }
 
@@ -871,7 +891,7 @@ private func makeRouter(
 ) -> CameraBridgeRouter {
     CameraBridgeRouter(
         routes: CameraBridgeRoutes.current(
-            permissionController: sessionController,
+            permissionStatusProvider: sessionController,
             deviceListing: sessionController,
             cameraStateProvider: sessionController,
             deviceSelector: sessionController,
@@ -922,20 +942,6 @@ private struct FixedPermissionRequester: CameraPermissionRequesting {
     let result: PermissionRequestResult
 
     func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void) {
-        completion(result)
-    }
-}
-
-private final class RecordingPermissionRequester: CameraPermissionRequesting, @unchecked Sendable {
-    private(set) var requestCount = 0
-    let result: PermissionRequestResult
-
-    init(result: PermissionRequestResult) {
-        self.result = result
-    }
-
-    func requestPermission(completion: @escaping @Sendable (PermissionRequestResult) -> Void) {
-        requestCount += 1
         completion(result)
     }
 }

--- a/tests/CameraBridgeAppTests/CameraBridgeAppModelTests.swift
+++ b/tests/CameraBridgeAppTests/CameraBridgeAppModelTests.swift
@@ -1,31 +1,43 @@
 import CameraBridgeClientSwift
+import CameraBridgeSupport
 import Foundation
 import Testing
 @testable import CameraBridgeApp
 
 @Test
 @MainActor
-func stoppedServiceStateShowsStartGuidance() async {
+func stoppedServiceStateShowsLocalPermissionGuidance() async {
     let client = FakeCameraBridgeAppClient()
     await client.setServiceIsRunning(false)
-    let model = CameraBridgeAppModel(client: client, serviceLauncher: FakeServiceLauncher())
+    let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .notDetermined)
+    let permissionStateStore = FakePermissionStateStore()
+    let model = CameraBridgeAppModel(
+        client: client,
+        permissionController: permissionController,
+        permissionStateStore: permissionStateStore,
+        serviceLauncher: FakeServiceLauncher()
+    )
 
     await model.refreshNow()
 
     #expect(model.statusSummaryTitle == "Local service is stopped")
     #expect(model.serviceStatusTitle == "Stopped")
-    #expect(model.permissionStatusTitle == "Unavailable")
-    #expect(model.guidanceMessage == "Start the local service to check camera permissions and finish onboarding.")
+    #expect(model.permissionStatusTitle == "Not Determined")
+    #expect(
+        model.guidanceMessage ==
+        "Request camera access from CameraBridge, then start the local service to finish onboarding."
+    )
     #expect(model.canStartService)
-    #expect(!model.canRequestCameraAccess)
+    #expect(model.canRequestCameraAccess)
     #expect(model.lastErrorMessage == nil)
+    #expect(permissionStateStore.savedStates == [.notDetermined])
 }
 
 @Test(arguments: [
     (
         CameraBridgePermissionStatus.notDetermined,
         "Camera access setup is incomplete",
-        "Request camera access to complete the app-owned onboarding flow."
+        "Request camera access from CameraBridge to continue."
     ),
     (
         CameraBridgePermissionStatus.restricted,
@@ -44,15 +56,21 @@ func stoppedServiceStateShowsStartGuidance() async {
     ),
 ])
 @MainActor
-func runningServiceShowsPermissionSpecificGuidance(
+func runningServiceShowsAppLocalPermissionGuidance(
     permissionStatus: CameraBridgePermissionStatus,
     expectedSummary: String,
     expectedGuidance: String
 ) async {
     let client = FakeCameraBridgeAppClient()
     await client.setServiceIsRunning(true)
-    await client.setPermissionStatus(.success(permissionStatus))
-    let model = CameraBridgeAppModel(client: client, serviceLauncher: FakeServiceLauncher())
+    let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: permissionStatus)
+    let permissionStateStore = FakePermissionStateStore()
+    let model = CameraBridgeAppModel(
+        client: client,
+        permissionController: permissionController,
+        permissionStateStore: permissionStateStore,
+        serviceLauncher: FakeServiceLauncher()
+    )
 
     await model.refreshNow()
 
@@ -60,45 +78,58 @@ func runningServiceShowsPermissionSpecificGuidance(
     #expect(model.permissionStatusTitle == permissionStatusTitle(permissionStatus))
     #expect(model.statusSummaryTitle == expectedSummary)
     #expect(model.guidanceMessage == expectedGuidance)
+    #expect(permissionStateStore.savedStates == [.init(permissionStatus: permissionStatus)])
 }
 
 @Test
 @MainActor
-func startServiceFailureShowsErrorState() async {
+func startServiceFailurePreservesLocalPermissionState() async {
     let client = FakeCameraBridgeAppClient()
     await client.setServiceIsRunning(false)
+    let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .notDetermined)
+    let permissionStateStore = FakePermissionStateStore()
     let launcher = FakeServiceLauncher()
     launcher.error = CameraBridgeServiceLaunchError.failedToStartService
-    let model = CameraBridgeAppModel(client: client, serviceLauncher: launcher)
+    let model = CameraBridgeAppModel(
+        client: client,
+        permissionController: permissionController,
+        permissionStateStore: permissionStateStore,
+        serviceLauncher: launcher
+    )
 
     await model.startServiceNow()
 
     #expect(model.serviceStatusTitle == "Needs Attention")
-    #expect(model.guidanceMessage == "Start the local service to check camera permissions and finish onboarding.")
+    #expect(model.permissionStatusTitle == "Not Determined")
+    #expect(
+        model.guidanceMessage ==
+        "Request camera access from CameraBridge, then start the local service to finish onboarding."
+    )
     #expect(model.lastErrorMessage == "Service did not become healthy after launch")
     #expect(model.canStartService)
 }
 
 @Test
 @MainActor
-func permissionRequestFailureShowsErrorAndKeepsActionAvailable() async {
+func permissionStateSyncFailureShowsErrorWhileKeepingActionAvailable() async {
     let client = FakeCameraBridgeAppClient()
     await client.setServiceIsRunning(true)
-    await client.setPermissionStatus(.success(.notDetermined))
-    await client.setRequestPermissionResult(.failure(CameraBridgeClientError.requestFailed(
-        statusCode: 401,
-        code: "unauthorized",
-        message: "Bearer token missing or invalid"
-    )))
-    let model = CameraBridgeAppModel(client: client, serviceLauncher: FakeServiceLauncher())
+    let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .notDetermined)
+    let permissionStateStore = FakePermissionStateStore()
+    permissionStateStore.error = CameraBridgePermissionStateStoreError.invalidPermissionStateFile
+    let model = CameraBridgeAppModel(
+        client: client,
+        permissionController: permissionController,
+        permissionStateStore: permissionStateStore,
+        serviceLauncher: FakeServiceLauncher()
+    )
 
     await model.refreshNow()
-    await model.requestCameraAccessNow()
 
-    #expect(model.permissionStatusTitle == "Unavailable")
-    #expect(model.statusSummaryTitle == "Service is running")
-    #expect(model.guidanceMessage == "The service is running, but permission status could not be loaded.")
-    #expect(model.lastErrorMessage == "Bearer token missing or invalid")
+    #expect(model.permissionStatusTitle == "Not Determined")
+    #expect(model.statusSummaryTitle == "Camera access setup is incomplete")
+    #expect(model.guidanceMessage == "Request camera access from CameraBridge to continue.")
+    #expect(model.lastErrorMessage == "Stored permission state is invalid")
     #expect(model.canRequestCameraAccess)
 }
 
@@ -107,8 +138,15 @@ func permissionRequestFailureShowsErrorAndKeepsActionAvailable() async {
 func startServiceDisablesActionWhileLaunchIsInFlight() async {
     let client = FakeCameraBridgeAppClient()
     await client.setServiceIsRunning(false)
+    let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .authorized)
+    let permissionStateStore = FakePermissionStateStore()
     let launcher = FakeServiceLauncher()
-    let model = CameraBridgeAppModel(client: client, serviceLauncher: launcher)
+    let model = CameraBridgeAppModel(
+        client: client,
+        permissionController: permissionController,
+        permissionStateStore: permissionStateStore,
+        serviceLauncher: launcher
+    )
 
     let task = Task {
         await model.startServiceNow()
@@ -120,21 +158,26 @@ func startServiceDisablesActionWhileLaunchIsInFlight() async {
     #expect(!model.canStartService)
 
     await client.setServiceIsRunning(true)
-    await client.setPermissionStatus(.success(.authorized))
     launcher.finish()
     await task.value
 
     #expect(model.serviceStatusTitle == "Running")
-    #expect(model.canRequestCameraAccess)
+    #expect(!model.canRequestCameraAccess)
 }
 
 @Test
 @MainActor
-func permissionRequestDisablesActionWhilePromptIsInFlight() async {
+func permissionRequestDisablesActionWhilePromptIsInFlightAndSyncsAuthorizedState() async {
     let client = FakeCameraBridgeAppClient()
     await client.setServiceIsRunning(true)
-    await client.setPermissionStatus(.success(.notDetermined))
-    let model = CameraBridgeAppModel(client: client, serviceLauncher: FakeServiceLauncher())
+    let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .notDetermined)
+    let permissionStateStore = FakePermissionStateStore()
+    let model = CameraBridgeAppModel(
+        client: client,
+        permissionController: permissionController,
+        permissionStateStore: permissionStateStore,
+        serviceLauncher: FakeServiceLauncher()
+    )
 
     await model.refreshNow()
     let task = Task {
@@ -146,13 +189,16 @@ func permissionRequestDisablesActionWhilePromptIsInFlight() async {
     #expect(model.statusSummaryTitle == "Waiting for camera access")
     #expect(!model.canRequestCameraAccess)
 
-    await client.setRequestPermissionResult(.success(.init(status: .authorized, prompted: true)))
-    await client.setPermissionStatus(.success(.authorized))
+    permissionController.finishRequest(with: .init(status: .authorized, prompted: true))
     await task.value
 
     #expect(model.permissionStatusTitle == "Authorized")
     #expect(model.statusSummaryTitle == "CameraBridge is ready")
-    #expect(model.canRequestCameraAccess)
+    #expect(model.guidanceMessage == "The service is running and camera access is available.")
+    #expect(model.lastErrorMessage == nil)
+    #expect(permissionController.requestCount == 1)
+    #expect(permissionStateStore.savedStates == [.notDetermined, .authorized, .authorized])
+    #expect(!model.canRequestCameraAccess)
 }
 
 private func permissionStatusTitle(_ status: CameraBridgePermissionStatus) -> String {
@@ -170,35 +216,59 @@ private func permissionStatusTitle(_ status: CameraBridgePermissionStatus) -> St
 
 private actor FakeCameraBridgeAppClient: CameraBridgeAppClient {
     private var isRunning = false
-    private var permissionStatusResult: Result<CameraBridgePermissionStatus, Error> = .success(.notDetermined)
-    private var requestPermissionResult: Result<CameraBridgePermissionRequestResult, Error>?
 
     func setServiceIsRunning(_ value: Bool) {
         isRunning = value
     }
 
-    func setPermissionStatus(_ result: Result<CameraBridgePermissionStatus, Error>) {
-        permissionStatusResult = result
-    }
-
-    func setRequestPermissionResult(_ result: Result<CameraBridgePermissionRequestResult, Error>) {
-        requestPermissionResult = result
-    }
-
     func serviceIsRunning() async -> Bool {
         isRunning
     }
+}
 
-    func permissionStatus() async throws -> CameraBridgePermissionStatus {
-        try permissionStatusResult.get()
+@MainActor
+private final class FakeCameraBridgeAppPermissionController: CameraBridgeAppPermissionControlling {
+    private(set) var requestCount = 0
+    private var requestResult: CameraBridgePermissionRequestResult?
+    var currentStatus: CameraBridgePermissionStatus
+
+    init(currentStatus: CameraBridgePermissionStatus) {
+        self.currentStatus = currentStatus
     }
 
-    func requestPermission() async throws -> CameraBridgePermissionRequestResult {
-        while requestPermissionResult == nil {
+    func currentPermissionStatus() -> CameraBridgePermissionStatus {
+        currentStatus
+    }
+
+    func requestPermission() async -> CameraBridgePermissionRequestResult {
+        requestCount += 1
+
+        while requestResult == nil {
             await Task.yield()
         }
 
-        return try requestPermissionResult!.get()
+        let result = requestResult!
+        currentStatus = result.status
+        requestResult = nil
+        return result
+    }
+
+    func finishRequest(with result: CameraBridgePermissionRequestResult) {
+        requestResult = result
+        currentStatus = result.status
+    }
+}
+
+private final class FakePermissionStateStore: CameraBridgePermissionStateWriting {
+    var savedStates: [CameraBridgeStoredPermissionState] = []
+    var error: Error?
+
+    func savePermissionState(_ state: CameraBridgeStoredPermissionState) throws {
+        if let error {
+            throw error
+        }
+
+        savedStates.append(state)
     }
 }
 
@@ -220,5 +290,20 @@ private final class FakeServiceLauncher: CameraBridgeServiceLaunching {
     func finish() {
         continuation?.resume()
         continuation = nil
+    }
+}
+
+private extension CameraBridgeStoredPermissionState {
+    init(permissionStatus: CameraBridgePermissionStatus) {
+        switch permissionStatus {
+        case .notDetermined:
+            self = .notDetermined
+        case .restricted:
+            self = .restricted
+        case .denied:
+            self = .denied
+        case .authorized:
+            self = .authorized
+        }
     }
 }

--- a/tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift
+++ b/tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift
@@ -59,7 +59,7 @@ func permissionRequestSendsBearerTokenAndEmptyJSONBody() async throws {
         transport: { request in
             await recorder.record(request)
             return (
-                Data(#"{"prompted":true,"status":"not_determined"}"#.utf8),
+                Data(#"{"prompted":false,"status":"authorized"}"#.utf8),
                 makeHTTPResponse(for: request, statusCode: 200)
             )
         }
@@ -68,7 +68,7 @@ func permissionRequestSendsBearerTokenAndEmptyJSONBody() async throws {
     let result = try await client.requestPermission()
     let recordedRequest = await recorder.currentRequest()
 
-    #expect(result == .init(status: .notDetermined, prompted: true))
+    #expect(result == .init(status: .authorized, prompted: false))
     #expect(recordedRequest?.method == "POST")
     #expect(recordedRequest?.url == "http://127.0.0.1:8731/v1/permissions/request")
     #expect(recordedRequest?.authorization == "Bearer test-token")
@@ -77,21 +77,21 @@ func permissionRequestSendsBearerTokenAndEmptyJSONBody() async throws {
 }
 
 @Test
-func permissionRequestSurfacesAPIErrorDetails() async {
+func permissionRequestSurfacesUndecidedPermissionGuidance() async {
     let client = CameraBridgeClient(
         tokenProvider: { nil },
         transport: { request in
             (
-                Data(#"{"error":{"code":"unauthorized","message":"Bearer token missing or invalid"}}"#.utf8),
-                makeHTTPResponse(for: request, statusCode: 401)
+                Data(#"{"error":{"code":"invalid_state","message":"Camera permission must be requested from CameraBridgeApp"}}"#.utf8),
+                makeHTTPResponse(for: request, statusCode: 409)
             )
         }
     )
 
     await #expect(throws: CameraBridgeClientError.requestFailed(
-        statusCode: 401,
-        code: "unauthorized",
-        message: "Bearer token missing or invalid"
+        statusCode: 409,
+        code: "invalid_state",
+        message: "Camera permission must be requested from CameraBridgeApp"
     )) {
         _ = try await client.requestPermission()
     }

--- a/tests/CameraBridgeDaemonTests/CameraBridgeDaemonTests.swift
+++ b/tests/CameraBridgeDaemonTests/CameraBridgeDaemonTests.swift
@@ -2,6 +2,7 @@ import CameraBridgeSupport
 import Foundation
 import Testing
 @testable import camd
+import CameraBridgeCore
 
 @Test
 func serverConfigurationResolvedAuthTokenPrefersExplicitConfiguration() throws {
@@ -31,7 +32,61 @@ func serverConfigurationResolvedAuthTokenLoadsOrCreatesStoredTokenWhenMissing() 
     #expect(reloadedToken == createdToken)
 }
 
+@Test(arguments: [
+    (CameraBridgeStoredPermissionState.notDetermined, PermissionState.notDetermined),
+    (CameraBridgeStoredPermissionState.restricted, PermissionState.restricted),
+    (CameraBridgeStoredPermissionState.denied, PermissionState.denied),
+    (CameraBridgeStoredPermissionState.authorized, PermissionState.authorized),
+])
+func storedPermissionStatusProviderMapsStoredState(
+    storedState: CameraBridgeStoredPermissionState,
+    expectedState: PermissionState
+) throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let store = DefaultCameraBridgePermissionStateStore(baseDirectoryURL: directoryURL)
+    try store.savePermissionState(storedState)
+
+    let provider = StoredPermissionStatusProvider(permissionStateStore: store)
+
+    #expect(provider.currentPermissionState() == expectedState)
+}
+
+@Test
+func storedPermissionStatusProviderDefaultsToNotDeterminedWhenStoreIsMissing() {
+    let directoryURL = makeTemporaryDirectoryURL()
+    let store = DefaultCameraBridgePermissionStateStore(baseDirectoryURL: directoryURL)
+
+    let provider = StoredPermissionStatusProvider(permissionStateStore: store)
+
+    #expect(provider.currentPermissionState() == .notDetermined)
+}
+
+@Test
+func storedPermissionRequesterReturnsCurrentStoredPermissionWithoutPrompting() {
+    let requester = StoredPermissionRequester(
+        permissionStatusProvider: FixedPermissionStatusProvider(state: .authorized)
+    )
+    let resultBox = PermissionRequestResultBox()
+    requester.requestPermission { resultBox.result = $0 }
+
+    #expect(resultBox.result == .init(status: .authorized, prompted: false))
+}
+
 private func makeTemporaryDirectoryURL() -> URL {
     FileManager.default.temporaryDirectory
         .appendingPathComponent(UUID().uuidString, isDirectory: true)
+}
+
+private struct FixedPermissionStatusProvider: CameraPermissionStatusProviding {
+    let state: PermissionState
+
+    func currentPermissionState() -> PermissionState {
+        state
+    }
+}
+
+private final class PermissionRequestResultBox: @unchecked Sendable {
+    var result: PermissionRequestResult?
 }

--- a/tests/CameraBridgeSupportTests/CameraBridgeSupportTests.swift
+++ b/tests/CameraBridgeSupportTests/CameraBridgeSupportTests.swift
@@ -46,6 +46,47 @@ func authTokenStoreRejectsWhitespaceOnlyTokenFiles() throws {
     }
 }
 
+@Test
+func permissionStateStoreDefaultsToNotDeterminedWhenFileIsMissing() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let store = DefaultCameraBridgePermissionStateStore(baseDirectoryURL: directoryURL)
+
+    #expect(try store.loadPermissionState() == .notDetermined)
+}
+
+@Test
+func permissionStateStoreSavesAndReloadsStoredState() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let store = DefaultCameraBridgePermissionStateStore(baseDirectoryURL: directoryURL)
+
+    try store.savePermissionState(.authorized)
+
+    #expect(try store.loadPermissionState() == .authorized)
+    #expect(FileManager.default.fileExists(atPath: try store.permissionStateURL().path))
+}
+
+@Test
+func permissionStateStoreRejectsInvalidStoredState() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let store = DefaultCameraBridgePermissionStateStore(baseDirectoryURL: directoryURL)
+    let permissionStateURL = try store.permissionStateURL()
+    try FileManager.default.createDirectory(
+        at: permissionStateURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try Data("camera-maybe".utf8).write(to: permissionStateURL, options: .atomic)
+
+    #expect(throws: CameraBridgePermissionStateStoreError.invalidPermissionStateFile) {
+        _ = try store.loadPermissionState()
+    }
+}
+
 private func makeTemporaryDirectoryURL() -> URL {
     FileManager.default.temporaryDirectory
         .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
## Summary
- move camera permission reads and prompting into CameraBridgeApp and sync the observed state to ~/Library/Application Support/CameraBridge/permission-state
- make camd and the API consume the synced permission state instead of prompting from the daemon
- update tests and docs to reflect the new POST /v1/permissions/request behavior and record the completed hardware smoke run

## Files Changed
- app permission flow and menu guidance in apps/CameraBridgeApp
- stored permission-state support in packages/CameraBridgeSupport
- daemon wiring in apps/camd
- API request behavior in packages/CameraBridgeAPI
- client, daemon, app, API, and support tests
- quick start, API, architecture, roadmap, app, and release-readiness docs

## How It Was Tested
- swift test
- packaged CameraBridgeApp.app smoke run on 2026-03-21
- GET /health returned 200 OK
- GET /v1/permissions returned authorized
- POST /v1/permissions/request returned {"prompted":false,"status":"authorized"}
- python3 examples/python/capture_photo.py --device-id 0x1000002e1a4c04 completed successfully against the app-launched daemon

## Intentionally Deferred
- no new prompt-coordination endpoint was added
- CameraBridgeClient.requestPermission() remains for compatibility instead of being deprecated in this PR

Part of #46
