### PR TITLE
Add third-party developer POV skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -6,6 +6,7 @@ This directory contains repo-local skills for recurring CameraBridge work. The i
 
 - [camerabridge-pm](./camerabridge-pm/SKILL.md): Use for scope framing, PRD or roadmap shaping, issue or PR breakdowns, acceptance criteria, and honest PR packaging.
 - [technical-architect](./technical-architect/SKILL.md): Use for package placement, boundary decisions, explicit state ownership, v1 scope guardrails, and architecture ambiguity.
+- [third-party-developer-pov](./third-party-developer-pov/SKILL.md): Use for evaluating public APIs, permission flows, helper or daemon ownership, and reusable seams from the perspective of an external integrator.
 - [core-engineer](./core-engineer/SKILL.md): Use for `CameraBridgeCore` models, state machines, permission and device logic, AVFoundation isolation, and hardware-free Core tests.
 - [api-engineer](./api-engineer/SKILL.md): Use for `CameraBridgeAPI` routes, request and response models, auth checks, error handling, and handler or integration tests.
 - [qa-test-strategy](./qa-test-strategy/SKILL.md): Use for choosing the right automated tests, manual verification notes, and merge-bar evidence for a change.
@@ -18,17 +19,19 @@ Use this order when a task touches multiple concerns:
 
 1. [camerabridge-pm](./camerabridge-pm/SKILL.md) for scope and slice definition.
 2. [technical-architect](./technical-architect/SKILL.md) for placement and boundary decisions.
-3. The implementation skill for the owning layer:
+3. [third-party-developer-pov](./third-party-developer-pov/SKILL.md) when the slice changes public semantics or may be reused outside this repo.
+4. The implementation skill for the owning layer:
    [core-engineer](./core-engineer/SKILL.md),
    [api-engineer](./api-engineer/SKILL.md), or
    [macos-app-engineer](./macos-app-engineer/SKILL.md).
-4. [qa-test-strategy](./qa-test-strategy/SKILL.md) to set verification expectations.
-5. [docs-dx](./docs-dx/SKILL.md) if public behavior, setup, or examples changed.
+5. [qa-test-strategy](./qa-test-strategy/SKILL.md) to set verification expectations.
+6. [docs-dx](./docs-dx/SKILL.md) if public behavior, setup, or examples changed.
 
 ## Handoff rules
 
 - If the question is “should we build this now, and how small can the slice be?”, start with [camerabridge-pm](./camerabridge-pm/SKILL.md).
 - If the question is “where should this logic live?”, start with [technical-architect](./technical-architect/SKILL.md).
+- If the question is “would an external developer understand and trust this interface?”, use [third-party-developer-pov](./third-party-developer-pov/SKILL.md).
 - If the question is “how do we implement this inside the owning layer?”, use the matching engineer skill.
 - If the question is “what evidence is enough to merge this safely?”, use [qa-test-strategy](./qa-test-strategy/SKILL.md).
 - If the question is “what docs or examples must change?”, use [docs-dx](./docs-dx/SKILL.md).

--- a/skills/third-party-developer-pov/SKILL.md
+++ b/skills/third-party-developer-pov/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: third-party-developer-pov
+description: Evaluate CameraBridge features, public APIs, permission flows, and architecture decisions from the perspective of a third-party developer integrating the system into another app. Use when introducing or changing endpoints, reusable library seams, ownership between app/backend/helper processes, system-level interactions, or any behavior that may feel clever internally but confusing externally.
+---
+
+# Third-Party Developer POV
+
+## Overview
+
+Act as the external integrator's sanity check.
+Keep public behavior understandable, predictable, and honest without requiring repository-specific tribal knowledge.
+
+Use this skill when the question is not only "does this work?" but also "would another developer understand how to use it correctly?"
+
+## Working Style
+
+Start from the interface a third-party developer sees, not the implementation details we already know.
+Prefer explicit ownership and explicit failure semantics over convenience hidden behind abstractions.
+Treat surprising behavior, overloaded terminology, and setup friction as product flaws even if the code is technically correct.
+
+## Inputs To Gather
+
+Before evaluating, collect the smallest set of context needed:
+
+- the feature or decision being proposed
+- the intended integrating developer or host app
+- the ownership model across app, backend, and helper or daemon
+- the public interface: endpoints, methods, models, state transitions, or user-visible flows
+- defaults and configuration knobs
+- known failure modes and recovery paths
+
+If any of these are unclear, call that out as part of the evaluation instead of filling gaps with internal assumptions.
+
+## Evaluation Workflow
+
+1. State the mental model a first-time integrator will likely infer from the interface.
+2. Compare that expectation with the real ownership, state, and side effects.
+3. Identify where setup burden, naming, or defaults make first success harder than necessary.
+4. Check whether failures are understandable and whether the next step is obvious.
+5. Judge whether the surface feels reusable outside this repository or too tailored to current internals.
+
+## Evaluation Dimensions
+
+Evaluate explicitly across these dimensions:
+
+- mental model
+- API honesty
+- integration burden
+- defaults and configuration
+- failure and recovery
+- portability and reusability
+
+## Output Expectations
+
+Return a concise, decision-oriented evaluation with these sections:
+
+- `Expected Mental Model`
+- `Likely Confusion`
+- `Integration Burden`
+- `API Honesty`
+- `What Feels Clean`
+- `What Feels Leaky or Overloaded`
+- `Recommendation`
+
+Choose exactly one recommendation:
+
+- `Public-ready`
+- `Internal-only for now`
+- `Promising but needs cleanup before reuse`
+
+End with 1 to 3 concrete suggestions such as renaming an API, splitting a responsibility, moving behavior to the correct owner, or clarifying docs and constraints.
+
+## Guardrails
+
+Optimize for first-time developer understanding, not internal convenience.
+Prefer explicit ownership over hidden behavior.
+Treat misleading interfaces as worse than incomplete ones.
+Avoid "it works if you already know how it works" reasoning.
+Keep the evaluation concise and actionable rather than theoretical.


### PR DESCRIPTION
## Summary
- add a repo-local third-party-developer-pov skill for evaluating public interfaces from an external integrator perspective
- update the skills index so the new skill appears in the current list, recommended order, and handoff rules

## How it was tested
- read back the new skill and updated index
- reviewed git diff for the two changed files

## Intentionally deferred
- no additional agent metadata or references because the current repo-local skills do not use them