### PR TITLE
Remove CameraBridgeClientSwift dependency on CameraBridgeAPI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,6 @@ let package = Package(
         ),
         .target(
             name: "CameraBridgeClientSwift",
-            dependencies: ["CameraBridgeAPI"],
             path: "packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift"
         ),
         .target(

--- a/packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
+++ b/packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
@@ -1,4 +1,3 @@
-import CameraBridgeAPI
 import Foundation
 
 public enum CameraBridgePermissionStatus: String, Sendable, CaseIterable, Equatable {
@@ -91,9 +90,6 @@ public struct CameraBridgeClient {
     public typealias Transport = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse)
 
     public var baseURL: URL
-    public var apiModuleName: String {
-        CameraBridgeAPIModule.name
-    }
 
     private let tokenProvider: TokenProvider
     private let transport: Transport

--- a/tests/CameraBridgeClientSwiftTests/CameraBridgeClientSwiftTests.swift
+++ b/tests/CameraBridgeClientSwiftTests/CameraBridgeClientSwiftTests.swift
@@ -1,8 +1,0 @@
-import Testing
-@testable import CameraBridgeClientSwift
-
-@Test
-func clientExposesAPIModuleName() {
-    let client = CameraBridgeClient()
-    #expect(client.apiModuleName == "CameraBridgeAPI")
-}


### PR DESCRIPTION
## Summary
- remove the `CameraBridgeAPI` target dependency from `CameraBridgeClientSwift`
- remove `CameraBridgeClient.apiModuleName`, which was the only client-facing use of that dependency
- delete the obsolete client test that only asserted the removed symbol

## Files Changed
- `Package.swift`
- `packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift`
- `tests/CameraBridgeClientSwiftTests/CameraBridgeClientSwiftTests.swift`

## How It Was Tested
- `swift test`

## Deferred
- introducing any shared constants or wire-contract package
- changing localhost API routes, auth, ownership, or runtime behavior

Closes #73
