### PR TITLE
Align v1 permission ownership docs with shipped behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ also includes the minimal menu bar app shell, the Python first-capture example,
 and the core v1 docs needed to run that flow end to end. Preview transport and
 broader client surfaces remain deferred until after v1.
 
+In the shipped v1 permission flow, `CameraBridgeApp` owns the macOS camera
+permission prompt and syncs the resulting permission state into Application
+Support. `camd` reads that stored state for `/v1/permissions`,
+`/v1/permissions/request`, and the session-start permission precondition.
+
 ## v1 Auth And Ownership
 
 CameraBridge v1 keeps the trust model intentionally narrow:
@@ -26,6 +31,8 @@ CameraBridge v1 keeps the trust model intentionally narrow:
 - read-only localhost endpoints may remain unauthenticated in the early v1 slices
 - mutating endpoints use a bearer token or equivalent local secret
 - when `camd` starts without `CAMERABRIDGE_AUTH_TOKEN`, it loads or creates the local bearer token at `~/Library/Application Support/CameraBridge/auth-token`
+- `CameraBridgeApp` performs permission prompting when access is still `not_determined`
+- `POST /v1/permissions/request` does not prompt from `camd`; it returns current daemon-visible state or guidance to use `CameraBridgeApp`
 - v1 does not add separate session `claim` or `release` endpoints
 - successful `POST /v1/session/start` establishes implicit session ownership
 - session ownership is released by `POST /v1/session/stop` or when the session ends

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -77,7 +77,7 @@ Status: shipped
 
 - auth: none for the shipped read-only slice
 - response: `200 OK`
-- returns the current permission state from the app-synced permission store consumed by the Core-owned permission controller
+- returns the current permission state from the app-synced permission store consumed by `camd` and the session controller in the shipped v1 slice
 
 ```json
 {
@@ -106,7 +106,7 @@ Behavior:
 - when permission has already been decided, returns the current state with `prompted: false`
 - when permission is still `not_determined`, the caller must use `CameraBridgeApp` to request access
 - does not create or transfer session ownership
-- returns the shared permission state later consumed by `POST /v1/session/start`
+- returns the same daemon-visible permission state later consumed by `POST /v1/session/start`
 
 Successful response: `200 OK`
 
@@ -202,7 +202,7 @@ Request fields:
 Behavior:
 
 - requires camera permission state `authorized`
-- reads that permission precondition from the same Core-owned permission path exposed by the permission endpoints
+- reads that permission precondition from the same daemon-visible stored permission state exposed by the permission endpoints in the shipped v1 slice
 - requires a previously selected `active_device_id`
 - does not implicitly pick or change the active device
 - successful start sets `state` to `running` and `owner_id` to the provided caller identity

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -62,9 +62,11 @@ A single, centralized representation of:
 - active device
 - last error
 
-This state lives in `CameraBridgeCore` and is the source of truth.
-Permission reads, permission requests, and permission-dependent session
-preconditions must all flow through this Core-owned state path.
+The camera and session state model lives in `CameraBridgeCore`.
+In the shipped v1 slice, permission prompting is performed by
+`CameraBridgeApp`, which syncs the resulting permission state to Application
+Support. `camd` and the session controller consume that stored state for
+permission reporting and permission-dependent session preconditions.
 The shipped v1 surface does not expose preview transport or preview endpoints.
 
 ---
@@ -105,7 +107,7 @@ Must never be inferred implicitly.
 - AVFoundation integration
 - domain models
 - state management
-- permission status and request coordination
+- session logic that consumes the daemon-visible permission state
 
 No HTTP, no UI.
 
@@ -116,7 +118,7 @@ No HTTP, no UI.
 - HTTP interface
 - request/response models
 - auth validation
-- translation of HTTP permission routes into Core-owned permission operations
+- translation of HTTP permission routes into the shipped daemon-visible permission behavior
 
 No AVFoundation logic and no parallel permission state.
 
@@ -141,6 +143,16 @@ No domain logic.
 - permission-state sync to Application Support
 
 No backend logic.
+
+## 5.1 Current v1 permission ownership note
+
+The current shipped v1 permission model is intentionally narrow but not yet the
+final architectural end state:
+
+- `CameraBridgeApp` owns the macOS permission prompt
+- the app writes the resulting permission state to `~/Library/Application Support/CameraBridge/permission-state`
+- `camd` reads that stored state for `/v1/permissions`, `/v1/permissions/request`, and session-start validation
+- source-of-truth consolidation for permission state remains deferred follow-up work after the shipped behavior is documented clearly
 
 ---
 

--- a/docs/roadmap/v1.md
+++ b/docs/roadmap/v1.md
@@ -54,6 +54,7 @@ This flow is the current bar for the shipped v1 first-capture slice.
 
 - Read permission state
 - Request camera permission via `CameraBridgeApp`
+- In the shipped slice, `camd` reports the synchronized stored permission state used for session preconditions
 
 #### Device Discovery
 
@@ -92,7 +93,8 @@ This flow is the current bar for the shipped v1 first-capture slice.
 
 - Read-only endpoints remain unauthenticated in the shipped localhost-only slice
 - Shipped mutating endpoints require a bearer token or equivalent local secret
-- `POST /v1/permissions/request` is token-protected but does not create session ownership
+- `POST /v1/permissions/request` is token-protected, does not create session ownership, and does not trigger the macOS prompt from `camd`
+- when permission is still `not_determined`, callers must use `CameraBridgeApp` to request access
 - `POST /v1/session/start` acquires implicit session ownership on success
 - `POST /v1/session/stop`, `POST /v1/session/select-device`, and `POST /v1/capture/photo` require the current session owner
 - v1 uses explicit error categories for unauthorized, ownership-conflict, and invalid-state requests


### PR DESCRIPTION
## Summary
- align the core v1 docs with the shipped permission ownership model
- clarify that `CameraBridgeApp` owns macOS permission prompting in the current shipped slice
- clarify that `camd` reads the synchronized stored permission state for `/v1/permissions`, `/v1/permissions/request`, and session-start validation

## Files Changed
- `README.md`
- `docs/architecture-overview.md`
- `docs/roadmap/v1.md`
- `docs/api/v1.md`

## How It Was Tested
- `swift test`

## Deferred
- changing runtime permission behavior
- removing the Application Support permission-state sync
- redesigning permission state ownership across app, daemon, and Core

Closes #75
