### PR TITLE
Stabilize local app identity for packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Package the local menu bar app bundle with:
 apps/CameraBridgeApp/scripts/package-app.sh
 ```
 
+The local packaging script signs `CameraBridgeApp.app` and its bundled `camd`
+with stable identifier-based ad-hoc requirements so local TCC permission checks
+can survive rebuilds more predictably than plain cdhash-only ad-hoc signing.
+If your machine previously granted camera access to an older packaged build,
+re-request permission once after adopting the newer packaging flow so macOS can
+record the updated local code requirement.
+
 The packaged app bundle, including the bundled `camd` executable, is written to:
 
 ```text

--- a/apps/CameraBridgeApp/README.md
+++ b/apps/CameraBridgeApp/README.md
@@ -30,6 +30,13 @@ Package a local `.app` bundle with:
 apps/CameraBridgeApp/scripts/package-app.sh
 ```
 
+The packaging script signs the app bundle and bundled `camd` with stable
+identifier-based ad-hoc requirements for local testing. That is intended to
+avoid the plain cdhash-only identity drift that can make macOS camera
+permission checks fall back to `not_determined` after a rebuild. If you granted
+camera access to an older locally packaged build before this signing flow was
+added, request access once again so TCC can record the newer requirement.
+
 This produces a menu bar app bundle that includes the `camd` executable:
 
 ```text

--- a/apps/CameraBridgeApp/scripts/package-app.sh
+++ b/apps/CameraBridgeApp/scripts/package-app.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
 APP_NAME="CameraBridgeApp"
 DAEMON_NAME="camd"
+APP_IDENTIFIER="io.camerabridge.CameraBridgeApp"
+DAEMON_IDENTIFIER="io.camerabridge.camd"
+APP_REQUIREMENT="designated => identifier \"$APP_IDENTIFIER\""
+DAEMON_REQUIREMENT="designated => identifier \"$DAEMON_IDENTIFIER\""
 
 cd "$ROOT_DIR"
 
@@ -25,6 +29,9 @@ cp "$ROOT_DIR/apps/CameraBridgeApp/Info.plist" "$CONTENTS_DIR/Info.plist"
 cp "$BIN_DIR/$DAEMON_NAME" "$RESOURCES_DIR/$DAEMON_NAME"
 chmod +x "$RESOURCES_DIR/$DAEMON_NAME"
 
-codesign --force --sign - "$APP_DIR" >/dev/null
+codesign --force --sign - -i "$DAEMON_IDENTIFIER" -r="$DAEMON_REQUIREMENT" \
+    "$RESOURCES_DIR/$DAEMON_NAME" >/dev/null
+codesign --force --sign - -i "$APP_IDENTIFIER" -r="$APP_REQUIREMENT" \
+    "$APP_DIR" >/dev/null
 
 echo "Packaged $APP_DIR"

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -36,6 +36,11 @@ swift test
 apps/CameraBridgeApp/scripts/package-app.sh
 ```
 
+Before treating camera permission continuity as a regression signal, note that
+older locally packaged builds used plain cdhash-only ad-hoc signing. After
+adopting the current packaging flow, re-grant camera access once so TCC can
+store the newer identifier-based local requirement for `CameraBridgeApp.app`.
+
 2. Launch the packaged app:
 
 ```bash


### PR DESCRIPTION
## Summary
- sign the packaged app bundle and bundled `camd` with stable identifier-based ad-hoc designated requirements instead of the default cdhash-only requirement
- document the local packaging behavior and the one-time camera permission regrant caveat for machines that previously used older packaged builds
- keep the change scoped to local packaging and release-readiness guidance for issue #92

## Files Changed
- `apps/CameraBridgeApp/scripts/package-app.sh`
- `README.md`
- `apps/CameraBridgeApp/README.md`
- `docs/release-readiness.md`

## How It Was Tested
- `swift test`
- `apps/CameraBridgeApp/scripts/package-app.sh`
- `codesign -d -r- .build/arm64-apple-macosx/debug/CameraBridgeApp.app`
- `codesign -d -r- .build/arm64-apple-macosx/debug/CameraBridgeApp.app/Contents/Resources/camd`
- repackaged and verified the designated requirements remained identifier-based rather than reverting to cdhash-only signing

## Deferred
- confirming end-to-end TCC continuity on a machine that re-grants camera access after adopting the new packaging flow
- any production signing, certificate, or notarization work
- re-evaluating PR #78 until the local permission continuity workflow is confirmed under the new packaging behavior

Refs #92