### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ryan Schroeder and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -109,3 +109,7 @@ and writes captures under:
 ```text
 ~/Library/Application Support/CameraBridge/Captures/
 ```
+
+## License
+
+CameraBridge is licensed under the MIT License. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- add a root `LICENSE` file with the standard MIT text
- add a short `License` section to `README.md`
- keep this slice limited to the minimum repo metadata needed for clear downstream reuse

## Testing
- verified `LICENSE` contains the canonical MIT text with the requested copyright line
- verified `README.md` points to `LICENSE`
- verified no conflicting license statements remain in the repo

## Deferred
- site footer or marketing-page license references
- per-file SPDX headers
- broader compliance or contributor policy work

Closes #94