### PR TITLE
Narrow public positioning around current service shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CameraBridge
 
-CameraBridge is a local macOS camera service that exposes AVFoundation over a localhost API.
+CameraBridge is a local macOS camera service with a small, versioned localhost API for camera permissions, device discovery, session control, and still image capture.
 
 This repository is organized with strict package boundaries:
 
@@ -12,12 +12,12 @@ This repository is organized with strict package boundaries:
 - `docs/` for RFCs and API documentation
 - `examples/` for small example clients
 
-The repository currently ships the v1 first-capture loop: health, permission
-status and request, device listing and selection, session state, session
-lifecycle control, and still photo capture with local artifact metadata. It
-also includes the minimal menu bar app shell, the Python first-capture example,
-and the core v1 docs needed to run that flow end to end. Preview transport and
-broader client surfaces remain deferred until after v1.
+The repository currently ships a narrow v1 first-capture loop: health,
+permission status and request, device listing and selection, session state,
+session lifecycle control, and still photo capture with local artifact
+metadata. It also includes the minimal menu bar app shell, the Python
+first-capture example, and the core v1 docs needed to run that flow end to end.
+Preview transport and broader client surfaces remain deferred until after v1.
 
 In the shipped v1 permission flow, `CameraBridgeApp` owns the macOS camera
 permission prompt. `camd` reads live AVFoundation permission status directly

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -2,13 +2,13 @@
 
 ## 1. Purpose
 
-CameraBridge is a local macOS camera service that exposes AVFoundation over a localhost API.
+CameraBridge is a local macOS camera service with a small, versioned localhost API for camera permissions, device discovery, session control, and still image capture.
 
 It exists to separate:
 - native camera complexity
 - from application-level logic
 
-This allows local apps (desktop apps, local web apps, scripts) to use the camera without embedding native macOS code.
+This gives apps, scripts, and other local software a narrow local boundary for camera access without embedding AVFoundation in every host app.
 
 ---
 

--- a/site/index.html
+++ b/site/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CameraBridge | Native macOS camera access over localhost</title>
+    <title>CameraBridge | Local macOS camera service over localhost</title>
     <meta
       name="description"
-      content="CameraBridge is a local macOS camera service that exposes AVFoundation over a stable localhost API for apps, scripts, and local web tools."
+      content="CameraBridge is a local macOS camera service with a small, versioned localhost API for apps, scripts, and local software."
     />
     <meta
       property="og:title"
-      content="CameraBridge | Native macOS camera access over localhost"
+      content="CameraBridge | Local macOS camera service over localhost"
     />
     <meta
       property="og:description"
@@ -21,11 +21,11 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta
       name="twitter:title"
-      content="CameraBridge | Native macOS camera access over localhost"
+      content="CameraBridge | Local macOS camera service over localhost"
     />
     <meta
       name="twitter:description"
-      content="Local macOS camera access for apps and scripts without embedding AVFoundation."
+      content="A local macOS camera service for apps and scripts without embedding AVFoundation."
     />
     <link rel="stylesheet" href="styles.css" />
   </head>
@@ -43,11 +43,11 @@
 
         <section class="hero-content" id="top">
           <p class="eyebrow">Local-only macOS camera service</p>
-          <h1>Native macOS camera access over localhost.</h1>
+          <h1>Local macOS camera service over localhost.</h1>
           <p class="hero-copy">
             CameraBridge exposes AVFoundation through a small, versioned local
-            API so desktop apps, local web tools, and scripts can use the camera
-            without embedding native macOS code.
+            API so apps, scripts, and local software can use the camera through
+            one narrow macOS service.
           </p>
           <div class="hero-actions">
             <a class="button button-primary" href="https://github.com/rschroed/CameraBridge"
@@ -90,7 +90,7 @@
             <article class="card">
               <h3>Local workflows need a stable boundary</h3>
               <p>
-                Scripts, local web apps, and desktop apps can talk to one narrow
+                Apps, scripts, and local software can talk to one narrow
                 localhost API instead of embedding AVFoundation directly.
               </p>
             </article>
@@ -114,7 +114,7 @@
           <p class="section-copy">
             Clients talk HTTP. CameraBridge owns native camera interaction. macOS
             still owns permissions. The result is a predictable local boundary
-            instead of app-specific native camera code.
+            for local software instead of app-specific native camera code.
           </p>
         </section>
 
@@ -196,11 +196,10 @@ curl http://127.0.0.1:PORT/v1/permissions
 }</code></pre>
           </div>
           <p class="section-copy">
-            The early public surface is intentionally small. Start with health
-            and permission visibility, then grow into device, session, and
-            capture flows as v1 is completed. Mutating routes are planned to use
-            bearer-token protection, with ownership established implicitly when a
-            client starts the session.
+            The shipped v1 surface is intentionally small: health, permission
+            visibility, device discovery, session control, and still capture.
+            Mutating routes use bearer-token protection, with ownership
+            established implicitly when a client starts the session.
           </p>
         </section>
 
@@ -211,7 +210,7 @@ curl http://127.0.0.1:PORT/v1/permissions
               <h2>Use the repo as the source of truth.</h2>
               <p>
                 Read the docs, track the current implementation status, and
-                follow the API contract as CameraBridge v1 comes together.
+                follow the API contract for the current CameraBridge v1 slice.
               </p>
             </div>
             <div class="cta-actions">


### PR DESCRIPTION
## Summary
- narrow CameraBridge positioning around the current local macOS camera-service shape
- align README, architecture overview, and site copy on the same product description
- remove broader top-level phrasing around local web tools/apps

## Files Changed
- `README.md`
- `docs/architecture-overview.md`
- `site/index.html`

## How It Was Tested
- manually reviewed the edited surfaces side by side for message consistency
- searched the touched files for the broader audience phrases being removed

## Intentionally Deferred
- any behavior or API changes
- broader docs rewrites outside the top-level positioning surfaces

Closes #96
