### PR TITLE
Define the pre-launch v1 app-daemon contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,44 @@ permission prompt. `camd` reads live AVFoundation permission status directly
 for `/v1/permissions`, `/v1/permissions/request`, and the session-start
 permission precondition.
 
+## Packaged Flow
+
+The packaged `CameraBridgeApp.app` bundle is the canonical pre-launch v1
+onboarding path.
+
+- `CameraBridgeApp` is the supported manager for the bundled `camd`
+- `Start CameraBridge Service` launches the bundled daemon if the configured
+  local endpoint is not already healthy
+- `Stop CameraBridge Service` stops only the daemon instance launched and
+  managed by the app
+- `Quit CameraBridge` stops the managed daemon before the app exits
+- if another healthy local CameraBridge service is already running, the app
+  shows `Running (External)` and does not kill that service
+- the app surfaces the current base URL plus the token, log, and captures paths
+  needed by local integrators
+
+The packaged flow reads runtime configuration from:
+
+```text
+~/Library/Application Support/CameraBridge/runtime-configuration.json
+```
+
+If no configuration file exists, CameraBridge defaults to:
+
+```json
+{
+  "host": "127.0.0.1",
+  "port": 8731
+}
+```
+
+At runtime, the app surfaces the effective base URL and the default support
+paths:
+
+- token: `~/Library/Application Support/CameraBridge/auth-token`
+- log: `~/Library/Application Support/CameraBridge/Logs/camd.log`
+- captures: `~/Library/Application Support/CameraBridge/Captures/`
+
 ## v1 Auth And Ownership
 
 CameraBridge v1 keeps the trust model intentionally narrow:
@@ -32,7 +70,7 @@ CameraBridge v1 keeps the trust model intentionally narrow:
 - mutating endpoints use a bearer token or equivalent local secret
 - when `camd` starts without `CAMERABRIDGE_AUTH_TOKEN`, it loads or creates the local bearer token at `~/Library/Application Support/CameraBridge/auth-token`
 - `CameraBridgeApp` performs permission prompting when access is still `not_determined`
-- `POST /v1/permissions/request` does not prompt from `camd`; it remains the token-protected programmatic permission-check route and returns current daemon-visible state or guidance to use `CameraBridgeApp`
+- `POST /v1/permissions/request` does not prompt from `camd`; it remains the token-protected programmatic permission-check route and always returns `200 OK` with current daemon-visible state plus guided next-step data when the app must request access
 - v1 does not add separate session `claim` or `release` endpoints
 - successful `POST /v1/session/start` establishes implicit session ownership
 - session ownership is released by `POST /v1/session/stop` or when the session ends
@@ -89,16 +127,27 @@ Follow the full setup and first-capture path in [docs/quick-start.md](docs/quick
 The shortest successful path is:
 
 1. package and launch `CameraBridgeApp.app`
-2. click `Start Service`
+2. click `Start CameraBridge Service`
 3. click `Request Camera Access` if permission is not already authorized
-4. confirm `Permission: authorized`
-5. run the minimal Python example with a real device id from `GET /v1/devices`
+4. confirm `Permission: Authorized`
+5. use the base URL and token path shown in the app if you are integrating from another local client
+6. run the minimal Python example with a real device id from `GET /v1/devices`
+
+The app shows the effective connection details in its menu. In the default
+packaged flow, those values are:
+
+```text
+Base URL: http://127.0.0.1:8731
+Token: ~/Library/Application Support/CameraBridge/auth-token
+Log: ~/Library/Application Support/CameraBridge/Logs/camd.log
+Captures: ~/Library/Application Support/CameraBridge/Captures/
+```
 
 ```bash
 python3 examples/python/capture_photo.py --device-id "YOUR_DEVICE_ID"
 ```
 
-The example reads the bearer token from:
+By default the example reads the bearer token from:
 
 ```text
 ~/Library/Application Support/CameraBridge/auth-token
@@ -109,6 +158,10 @@ and writes captures under:
 ```text
 ~/Library/Application Support/CameraBridge/Captures/
 ```
+
+If you stop the managed service from the app or quit the app, that managed
+daemon shuts down before exit. If the app detects an already-running external
+daemon, it leaves that process running.
 
 ## License
 

--- a/apps/CameraBridgeApp/README.md
+++ b/apps/CameraBridgeApp/README.md
@@ -5,16 +5,26 @@
 The app remains a thin client of the localhost CameraBridge service. Its menu bar shell is limited to:
 
 - service running or stopped visibility
+- managed versus external service-state visibility
 - camera permission visibility
 - onboarding guidance for the next user action
 - starting the bundled `camd` service
+- stopping the bundled `camd` service when this app owns that process
 - requesting camera access directly from the app process
+- surfacing base URL, token path, log path, and captures path for local integrators
 - quitting the app
 
 `CameraBridgeApp` is the only supported camera-permission prompt initiator in v1.
 It reads and requests camera access through the app bundle. The bundled daemon
 reads live AVFoundation permission status directly for `/v1/permissions`,
 `/v1/permissions/request`, and session-start preconditions.
+
+The packaged app is also the supported lifecycle manager for the bundled daemon:
+
+- `Start CameraBridge Service` launches the bundled daemon when the configured endpoint is not already healthy
+- `Stop CameraBridge Service` stops only the daemon instance managed by this app
+- `Quit CameraBridge` stops the managed daemon before the app exits
+- if the app detects an already-running daemon that it did not launch, it reports `Running (External)` and does not kill that process
 
 ## Local Packaging
 
@@ -51,6 +61,23 @@ When the app starts the bundled service, `camd` loads or creates the local beare
 
 The app then reads that same token file for its protected localhost API requests.
 
+The packaged flow reads runtime configuration from:
+
+```text
+~/Library/Application Support/CameraBridge/runtime-configuration.json
+```
+
+If no configuration file exists, the app-managed daemon defaults to
+`http://127.0.0.1:8731`. The app surfaces the effective connection details in
+the menu, including:
+
+```text
+Base URL: http://127.0.0.1:8731
+Token: ~/Library/Application Support/CameraBridge/auth-token
+Log: ~/Library/Application Support/CameraBridge/Logs/camd.log
+Captures: ~/Library/Application Support/CameraBridge/Captures/
+```
+
 ## Manual Verification
 
 Use the packaged app bundle for manual verification:
@@ -61,10 +88,13 @@ Use the packaged app bundle for manual verification:
    - a clear service status row
    - a clear permission status row
    - a guidance row describing the next onboarding step
+   - developer-info rows for base URL, token path, log path, and captures path
 4. With permission not yet granted, confirm `Request Camera Access` is enabled even before the service is started.
-5. After starting the service, confirm the menu updates to show the running state.
+5. After starting the service, confirm the menu updates to show the managed running state and enables `Stop CameraBridge Service`.
 6. Confirm that clicking `Request Camera Access` prompts from `CameraBridgeApp`.
 7. After granting permission, confirm the menu reports that CameraBridge is ready.
-8. If service launch or permission request fails, confirm the last error row appears with readable wording.
+8. Confirm `Stop CameraBridge Service` returns the menu to the stopped state.
+9. Confirm quitting the app stops the managed daemon before exit.
+10. If service launch or permission request fails, confirm the last error row appears with readable wording.
 
 Capture screenshots of the refined menu states when practical for PR notes.

--- a/apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift
+++ b/apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift
@@ -8,7 +8,9 @@ final class CameraBridgeAppModel {
     enum ServiceStatus: Equatable {
         case stopped
         case starting
-        case running
+        case runningManaged
+        case runningExternal
+        case stopping
         case failed(String)
 
         var title: String {
@@ -17,15 +19,19 @@ final class CameraBridgeAppModel {
                 return "Stopped"
             case .starting:
                 return "Starting"
-            case .running:
+            case .runningManaged:
                 return "Running"
+            case .runningExternal:
+                return "Running (External)"
+            case .stopping:
+                return "Stopping"
             case .failed:
                 return "Needs Attention"
             }
         }
 
-        var isRunning: Bool {
-            if case .running = self {
+        var isManagedRunning: Bool {
+            if case .runningManaged = self {
                 return true
             }
 
@@ -72,6 +78,13 @@ final class CameraBridgeAppModel {
         }
     }
 
+    private struct DeveloperInfo: Equatable {
+        var baseURL: String
+        var tokenPath: String
+        var logPath: String
+        var capturesPath: String
+    }
+
     var onChange: (() -> Void)?
 
     var serviceStatusTitle: String {
@@ -86,20 +99,27 @@ final class CameraBridgeAppModel {
         switch (serviceStatus, permissionDisplay) {
         case (.starting, _):
             return "CameraBridge is starting"
+        case (.stopping, _):
+            return "CameraBridge is stopping"
         case (.stopped, _):
             return "Local service is stopped"
         case (.failed, _):
             return "CameraBridge needs attention"
-        case (.running, .checking):
+        case (.runningManaged, .checking), (.runningExternal, .checking):
             return "Waiting for camera access"
-        case (.running, .notDetermined):
+        case (.runningManaged, .notDetermined), (.runningExternal, .notDetermined):
             return "Camera access setup is incomplete"
-        case (.running, .restricted), (.running, .denied):
+        case (.runningManaged, .restricted), (.runningManaged, .denied),
+            (.runningExternal, .restricted), (.runningExternal, .denied):
             return "Camera access is unavailable"
-        case (.running, .authorized):
+        case (.runningManaged, .authorized):
             return "CameraBridge is ready"
-        case (.running, .unavailable):
-            return "Service is running"
+        case (.runningExternal, .authorized):
+            return "External CameraBridge service detected"
+        case (.runningManaged, .unavailable):
+            return "Managed service is running"
+        case (.runningExternal, .unavailable):
+            return "External CameraBridge service detected"
         }
     }
 
@@ -107,6 +127,8 @@ final class CameraBridgeAppModel {
         switch (serviceStatus, permissionDisplay) {
         case (.starting, _):
             return "Waiting for the local CameraBridge service to respond."
+        case (.stopping, _):
+            return "Waiting for the managed CameraBridge service to stop."
         case (.stopped, .notDetermined), (.failed, .notDetermined):
             return "Request camera access from CameraBridge, then start the local service to finish onboarding."
         case (.stopped, .restricted), (.failed, .restricted):
@@ -115,18 +137,24 @@ final class CameraBridgeAppModel {
             return "Camera access was denied. Re-enable it in System Settings > Privacy & Security > Camera."
         case (.stopped, _), (.failed, _):
             return "Start the local service to finish onboarding."
-        case (.running, .checking):
+        case (.runningManaged, .checking), (.runningExternal, .checking):
             return "Respond to the macOS camera permission prompt if it appears."
-        case (.running, .notDetermined):
+        case (.runningManaged, .notDetermined):
             return "Request camera access from CameraBridge to continue."
-        case (.running, .restricted):
+        case (.runningExternal, .notDetermined):
+            return "A local CameraBridge service is already running. Request camera access from CameraBridge to continue."
+        case (.runningManaged, .restricted), (.runningExternal, .restricted):
             return "Camera access is restricted on this Mac and cannot be granted from CameraBridge."
-        case (.running, .denied):
+        case (.runningManaged, .denied), (.runningExternal, .denied):
             return "Camera access was denied. Re-enable it in System Settings > Privacy & Security > Camera."
-        case (.running, .authorized):
-            return "The service is running and camera access is available."
-        case (.running, .unavailable):
-            return "The service is running, but permission status could not be loaded."
+        case (.runningManaged, .authorized):
+            return "The managed CameraBridge service is running and camera access is available."
+        case (.runningExternal, .authorized):
+            return "A local CameraBridge service is already running outside this app and camera access is available."
+        case (.runningManaged, .unavailable):
+            return "The managed service is running, but permission status could not be loaded."
+        case (.runningExternal, .unavailable):
+            return "A local CameraBridge service is already running, but permission status could not be loaded."
         }
     }
 
@@ -136,15 +164,35 @@ final class CameraBridgeAppModel {
 
     var canStartService: Bool {
         switch serviceStatus {
-        case .running, .starting:
+        case .runningManaged, .runningExternal, .starting, .stopping:
             return false
         case .stopped, .failed:
             return true
         }
     }
 
+    var canStopService: Bool {
+        serviceStatus.isManagedRunning
+    }
+
     var canRequestCameraAccess: Bool {
         !isRequestInFlight && (permissionDisplay == .notDetermined || permissionDisplay == .unavailable)
+    }
+
+    var developerBaseURL: String {
+        developerInfo.baseURL
+    }
+
+    var developerTokenPath: String {
+        developerInfo.tokenPath
+    }
+
+    var developerLogPath: String {
+        developerInfo.logPath
+    }
+
+    var developerCapturesPath: String {
+        developerInfo.capturesPath
     }
 
     private var serviceStatus: ServiceStatus = .stopped
@@ -152,25 +200,43 @@ final class CameraBridgeAppModel {
     private var lastError: String?
     private var isRequestInFlight = false
     private var refreshTimer: Timer?
+    private var developerInfo = DeveloperInfo(
+        baseURL: "Unavailable",
+        tokenPath: "Unavailable",
+        logPath: "Unavailable",
+        capturesPath: "Unavailable"
+    )
 
     private let client: any CameraBridgeAppClient
     private let permissionController: any CameraBridgeAppPermissionControlling
-    private let serviceLauncher: any CameraBridgeServiceLaunching
+    private let serviceController: any CameraBridgeServiceControlling
+    private let runtimeConfigurationStore: any CameraBridgeRuntimeConfigurationReading
+    private let runtimeInfoStore: any CameraBridgeRuntimeInfoReading
 
     init(
         client: (any CameraBridgeAppClient)? = nil,
         authTokenStore: any CameraBridgeAuthTokenReading = DefaultCameraBridgeAuthTokenStore(),
+        runtimeConfigurationStore: any CameraBridgeRuntimeConfigurationReading = DefaultCameraBridgeRuntimeConfigurationStore(),
+        runtimeInfoStore: any CameraBridgeRuntimeInfoReading = DefaultCameraBridgeRuntimeInfoStore(),
         permissionController: (any CameraBridgeAppPermissionControlling)? = nil,
-        serviceLauncher: (any CameraBridgeServiceLaunching)? = nil
+        serviceController: (any CameraBridgeServiceControlling)? = nil
     ) {
+        let runtimeConfiguration = (try? runtimeConfigurationStore.loadConfiguration()) ??
+            CameraBridgeRuntimeConfiguration()
         let resolvedClient = client ?? CameraBridgeClient(
+            baseURL: runtimeConfiguration.baseURL,
             tokenProvider: {
                 try? authTokenStore.loadToken()
             }
         )
         self.client = resolvedClient
+        self.runtimeConfigurationStore = runtimeConfigurationStore
+        self.runtimeInfoStore = runtimeInfoStore
         self.permissionController = permissionController ?? AVFoundationCameraBridgeAppPermissionController()
-        self.serviceLauncher = serviceLauncher ?? LocalCameraBridgeServiceLauncher(client: resolvedClient)
+        self.serviceController = serviceController ?? LocalCameraBridgeServiceController(
+            client: resolvedClient,
+            runtimeConfigurationStore: runtimeConfigurationStore
+        )
     }
 
     func start() {
@@ -199,6 +265,12 @@ final class CameraBridgeAppModel {
         }
     }
 
+    func stopService() {
+        Task { @MainActor in
+            await stopServiceNow()
+        }
+    }
+
     func requestCameraAccess() {
         Task { @MainActor in
             await requestCameraAccessNow()
@@ -213,8 +285,16 @@ final class CameraBridgeAppModel {
         await performStartService()
     }
 
+    func stopServiceNow() async {
+        await performStopService()
+    }
+
     func requestCameraAccessNow() async {
         await performRequestCameraAccess()
+    }
+
+    func prepareForTermination() async {
+        try? await serviceController.stopIfManaged()
     }
 
     private func publishChange() {
@@ -223,9 +303,16 @@ final class CameraBridgeAppModel {
 
     private func refreshState() async {
         let permissionStatus = permissionController.currentPermissionStatus()
-        let isRunning = await client.serviceIsRunning()
-        serviceStatus = isRunning ? .running : .stopped
+        switch await serviceController.currentManagementState() {
+        case .stopped:
+            serviceStatus = .stopped
+        case .runningManaged:
+            serviceStatus = .runningManaged
+        case .runningExternal:
+            serviceStatus = .runningExternal
+        }
         permissionDisplay = .init(permissionStatus: permissionStatus)
+        developerInfo = loadDeveloperInfo()
         lastError = nil
         publishChange()
     }
@@ -240,12 +327,35 @@ final class CameraBridgeAppModel {
         publishChange()
 
         do {
-            try await serviceLauncher.startIfNeeded()
+            try await serviceController.startIfNeeded()
             await refreshState()
         } catch {
             serviceStatus = .failed(displayMessage(for: error))
             let permissionStatus = permissionController.currentPermissionStatus()
             permissionDisplay = .init(permissionStatus: permissionStatus)
+            developerInfo = loadDeveloperInfo()
+            lastError = displayMessage(for: error)
+            publishChange()
+        }
+    }
+
+    private func performStopService() async {
+        guard canStopService else {
+            return
+        }
+
+        serviceStatus = .stopping
+        lastError = nil
+        publishChange()
+
+        do {
+            try await serviceController.stopIfManaged()
+            await refreshState()
+        } catch {
+            serviceStatus = .failed(displayMessage(for: error))
+            let permissionStatus = permissionController.currentPermissionStatus()
+            permissionDisplay = .init(permissionStatus: permissionStatus)
+            developerInfo = loadDeveloperInfo()
             lastError = displayMessage(for: error)
             publishChange()
         }
@@ -270,6 +380,32 @@ final class CameraBridgeAppModel {
         await refreshState()
     }
 
+    private func loadDeveloperInfo() -> DeveloperInfo {
+        let runtimeConfiguration = (try? runtimeConfigurationStore.loadConfiguration()) ??
+            CameraBridgeRuntimeConfiguration()
+        let runtimeInfo = try? runtimeInfoStore.loadRuntimeInfo()
+
+        return DeveloperInfo(
+            baseURL: (runtimeInfo?.baseURL ?? runtimeConfiguration.baseURL).absoluteString,
+            tokenPath: pathDescription(
+                runtimeInfo?.tokenFileURL,
+                fallback: try? CameraBridgeSupportPaths.authTokenURL()
+            ),
+            logPath: pathDescription(
+                runtimeInfo?.logFileURL,
+                fallback: try? CameraBridgeSupportPaths.logFileURL()
+            ),
+            capturesPath: pathDescription(
+                runtimeInfo?.capturesDirectoryURL,
+                fallback: try? CameraBridgeSupportPaths.capturesDirectoryURL()
+            )
+        )
+    }
+
+    private func pathDescription(_ value: URL?, fallback: URL?) -> String {
+        (value ?? fallback)?.path ?? "Unavailable"
+    }
+
     private func displayMessage(for error: Error) -> String {
         switch error {
         case let clientError as CameraBridgeClientError:
@@ -281,8 +417,8 @@ final class CameraBridgeAppModel {
             case .requestFailed(_, _, let message):
                 return message ?? "Service request failed"
             }
-        case let launchError as CameraBridgeServiceLaunchError:
-            return launchError.errorDescription ?? "Service failed to start"
+        case let controlError as CameraBridgeServiceControlError:
+            return controlError.errorDescription ?? "Service control failed"
         case let authTokenError as CameraBridgeAuthTokenError:
             return authTokenError.errorDescription ?? "Auth token setup failed"
         default:
@@ -296,6 +432,18 @@ protocol CameraBridgeAuthTokenReading {
 }
 
 extension DefaultCameraBridgeAuthTokenStore: CameraBridgeAuthTokenReading {}
+
+protocol CameraBridgeRuntimeConfigurationReading {
+    func loadConfiguration() throws -> CameraBridgeRuntimeConfiguration
+}
+
+extension DefaultCameraBridgeRuntimeConfigurationStore: CameraBridgeRuntimeConfigurationReading {}
+
+protocol CameraBridgeRuntimeInfoReading {
+    func loadRuntimeInfo() throws -> CameraBridgeRuntimeInfo?
+}
+
+extension DefaultCameraBridgeRuntimeInfoStore: CameraBridgeRuntimeInfoReading {}
 
 protocol CameraBridgeAppClient {
     func serviceIsRunning() async -> Bool
@@ -340,14 +488,23 @@ struct AVFoundationCameraBridgeAppPermissionController: CameraBridgeAppPermissio
     }
 }
 
-@MainActor
-protocol CameraBridgeServiceLaunching {
-    func startIfNeeded() async throws
+enum CameraBridgeManagedServiceState: Equatable {
+    case stopped
+    case runningManaged
+    case runningExternal
 }
 
-enum CameraBridgeServiceLaunchError: LocalizedError {
+@MainActor
+protocol CameraBridgeServiceControlling {
+    func startIfNeeded() async throws
+    func stopIfManaged() async throws
+    func currentManagementState() async -> CameraBridgeManagedServiceState
+}
+
+enum CameraBridgeServiceControlError: LocalizedError {
     case missingBundledDaemon
     case failedToStartService
+    case failedToStopService
     case launchLogUnavailable
 
     var errorDescription: String? {
@@ -356,6 +513,8 @@ enum CameraBridgeServiceLaunchError: LocalizedError {
             return "Bundled camd executable is missing"
         case .failedToStartService:
             return "Service did not become healthy after launch"
+        case .failedToStopService:
+            return "Managed service did not stop cleanly"
         case .launchLogUnavailable:
             return "Service log file could not be opened"
         }
@@ -363,12 +522,18 @@ enum CameraBridgeServiceLaunchError: LocalizedError {
 }
 
 @MainActor
-final class LocalCameraBridgeServiceLauncher: CameraBridgeServiceLaunching {
+final class LocalCameraBridgeServiceController: CameraBridgeServiceControlling {
     private let client: any CameraBridgeAppClient
+    private let runtimeConfigurationStore: any CameraBridgeRuntimeConfigurationReading
     private var process: Process?
+    private var logHandle: FileHandle?
 
-    init(client: any CameraBridgeAppClient) {
+    init(
+        client: any CameraBridgeAppClient,
+        runtimeConfigurationStore: any CameraBridgeRuntimeConfigurationReading
+    ) {
         self.client = client
+        self.runtimeConfigurationStore = runtimeConfigurationStore
     }
 
     func startIfNeeded() async throws {
@@ -378,14 +543,24 @@ final class LocalCameraBridgeServiceLauncher: CameraBridgeServiceLaunching {
 
         let daemonURL = try bundledDaemonURL()
         let logHandle = try makeLogHandle()
+        let runtimeConfiguration = (try? runtimeConfigurationStore.loadConfiguration()) ??
+            CameraBridgeRuntimeConfiguration()
 
         let process = Process()
         process.executableURL = daemonURL
         process.standardOutput = logHandle
         process.standardError = logHandle
+        process.environment = mergedEnvironment(runtimeConfiguration: runtimeConfiguration)
 
-        try process.run()
+        do {
+            try process.run()
+        } catch {
+            try? logHandle.close()
+            throw error
+        }
+
         self.process = process
+        self.logHandle = logHandle
 
         for _ in 0..<20 {
             if await client.serviceIsRunning() {
@@ -399,17 +574,64 @@ final class LocalCameraBridgeServiceLauncher: CameraBridgeServiceLaunching {
             try await Task.sleep(nanoseconds: 250_000_000)
         }
 
-        throw CameraBridgeServiceLaunchError.failedToStartService
+        clearManagedProcess()
+        throw CameraBridgeServiceControlError.failedToStartService
+    }
+
+    func stopIfManaged() async throws {
+        guard let process, process.isRunning else {
+            clearManagedProcess()
+            return
+        }
+
+        process.terminate()
+
+        for _ in 0..<20 {
+            if !process.isRunning {
+                break
+            }
+
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+
+        if process.isRunning {
+            clearManagedProcess()
+            throw CameraBridgeServiceControlError.failedToStopService
+        }
+
+        for _ in 0..<20 {
+            if !(await client.serviceIsRunning()) {
+                clearManagedProcess()
+                return
+            }
+
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+
+        clearManagedProcess()
+        throw CameraBridgeServiceControlError.failedToStopService
+    }
+
+    func currentManagementState() async -> CameraBridgeManagedServiceState {
+        if let process, process.isRunning, await client.serviceIsRunning() {
+            return .runningManaged
+        }
+
+        if await client.serviceIsRunning() {
+            return .runningExternal
+        }
+
+        return .stopped
     }
 
     private func bundledDaemonURL() throws -> URL {
         guard let resourceURL = Bundle.main.resourceURL else {
-            throw CameraBridgeServiceLaunchError.missingBundledDaemon
+            throw CameraBridgeServiceControlError.missingBundledDaemon
         }
 
         let daemonURL = resourceURL.appendingPathComponent("camd", isDirectory: false)
         guard FileManager.default.isExecutableFile(atPath: daemonURL.path) else {
-            throw CameraBridgeServiceLaunchError.missingBundledDaemon
+            throw CameraBridgeServiceControlError.missingBundledDaemon
         }
 
         return daemonURL
@@ -417,27 +639,33 @@ final class LocalCameraBridgeServiceLauncher: CameraBridgeServiceLaunching {
 
     private func makeLogHandle() throws -> FileHandle {
         let fileManager = FileManager.default
-        guard let applicationSupportURL =
-            fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-        else {
-            throw CameraBridgeServiceLaunchError.launchLogUnavailable
-        }
-
-        let logsURL = applicationSupportURL
-            .appendingPathComponent("CameraBridge", isDirectory: true)
-            .appendingPathComponent("Logs", isDirectory: true)
+        let logsURL = try CameraBridgeSupportPaths.logsDirectoryURL(fileManager: fileManager)
         try fileManager.createDirectory(at: logsURL, withIntermediateDirectories: true)
 
-        let logURL = logsURL.appendingPathComponent("camd.log", isDirectory: false)
+        let logURL = try CameraBridgeSupportPaths.logFileURL(fileManager: fileManager)
         if !fileManager.fileExists(atPath: logURL.path) {
             guard fileManager.createFile(atPath: logURL.path, contents: nil) else {
-                throw CameraBridgeServiceLaunchError.launchLogUnavailable
+                throw CameraBridgeServiceControlError.launchLogUnavailable
             }
         }
 
         let handle = try FileHandle(forWritingTo: logURL)
         try handle.seekToEnd()
         return handle
+    }
+
+    private func mergedEnvironment(runtimeConfiguration: CameraBridgeRuntimeConfiguration) -> [String: String] {
+        var environment = ProcessInfo.processInfo.environment
+        environment["CAMERABRIDGE_HOST"] = runtimeConfiguration.host
+        environment["CAMERABRIDGE_PORT"] = String(runtimeConfiguration.port)
+        environment["CAMERABRIDGE_RUNTIME_OWNERSHIP"] = CameraBridgeRuntimeOwnership.appManaged.rawValue
+        return environment
+    }
+
+    private func clearManagedProcess() {
+        process = nil
+        try? logHandle?.close()
+        logHandle = nil
     }
 }
 

--- a/apps/CameraBridgeApp/Sources/CameraBridgeApp/main.swift
+++ b/apps/CameraBridgeApp/Sources/CameraBridgeApp/main.swift
@@ -12,6 +12,7 @@ application.run()
 final class CameraBridgeStatusBarDelegate: NSObject, NSApplicationDelegate {
     private let model = CameraBridgeAppModel()
     private var statusItem: NSStatusItem?
+    private var terminationRequested = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -30,9 +31,27 @@ final class CameraBridgeStatusBarDelegate: NSObject, NSApplicationDelegate {
         model.stop()
     }
 
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard !terminationRequested else {
+            return .terminateNow
+        }
+
+        terminationRequested = true
+        Task { @MainActor in
+            await model.prepareForTermination()
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
+    }
+
     @objc
     private func startService(_ sender: Any?) {
         model.startService()
+    }
+
+    @objc
+    private func stopService(_ sender: Any?) {
+        model.stopService()
     }
 
     @objc
@@ -76,6 +95,15 @@ final class CameraBridgeStatusBarDelegate: NSObject, NSApplicationDelegate {
         startServiceItem.isEnabled = model.canStartService
         menu.addItem(startServiceItem)
 
+        let stopServiceItem = NSMenuItem(
+            title: "Stop CameraBridge Service",
+            action: #selector(stopService(_:)),
+            keyEquivalent: ""
+        )
+        stopServiceItem.target = self
+        stopServiceItem.isEnabled = model.canStopService
+        menu.addItem(stopServiceItem)
+
         let requestPermissionItem = NSMenuItem(
             title: "Request Camera Access",
             action: #selector(requestCameraAccess(_:)),
@@ -84,6 +112,12 @@ final class CameraBridgeStatusBarDelegate: NSObject, NSApplicationDelegate {
         requestPermissionItem.target = self
         requestPermissionItem.isEnabled = model.canRequestCameraAccess
         menu.addItem(requestPermissionItem)
+
+        menu.addItem(.separator())
+        menu.addItem(disabledItem(title: "Base URL: \(model.developerBaseURL)"))
+        menu.addItem(disabledItem(title: "Token: \(model.developerTokenPath)"))
+        menu.addItem(disabledItem(title: "Log: \(model.developerLogPath)"))
+        menu.addItem(disabledItem(title: "Captures: \(model.developerCapturesPath)"))
 
         menu.addItem(.separator())
 

--- a/apps/camd/README.md
+++ b/apps/camd/README.md
@@ -2,6 +2,16 @@
 
 `camd` hosts process startup, configuration bootstrap, dependency wiring, and logging for the local CameraBridge service.
 
+In the packaged flow, `camd` reads runtime configuration from:
+
+```text
+~/Library/Application Support/CameraBridge/runtime-configuration.json
+```
+
+If no configuration file exists, the daemon defaults to `127.0.0.1:8731`.
+Direct developer startup can still override host and port with
+`CAMERABRIDGE_HOST` and `CAMERABRIDGE_PORT`.
+
 When `camd` starts without `CAMERABRIDGE_AUTH_TOKEN`, it loads or creates the local bearer token at:
 
 ```text
@@ -9,3 +19,10 @@ When `camd` starts without `CAMERABRIDGE_AUTH_TOKEN`, it loads or creates the lo
 ```
 
 This is the default local token contract used by both direct daemon startup and the packaged app launcher.
+
+On successful startup, `camd` also writes runtime metadata for the packaged app
+under:
+
+```text
+~/Library/Application Support/CameraBridge/runtime-info.json
+```

--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -6,19 +6,29 @@ import Foundation
 struct ServerConfiguration: Sendable, Equatable {
     static let defaultHost = "127.0.0.1"
     static let defaultPort: UInt16 = 8731
+    static let hostEnvironmentVariable = "CAMERABRIDGE_HOST"
+    static let portEnvironmentVariable = "CAMERABRIDGE_PORT"
     static let authTokenEnvironmentVariable = "CAMERABRIDGE_AUTH_TOKEN"
+    static let runtimeOwnershipEnvironmentVariable = "CAMERABRIDGE_RUNTIME_OWNERSHIP"
 
     var host: String
     var port: UInt16
     var authToken: String?
 
     init(
-        host: String = ServerConfiguration.defaultHost,
-        port: UInt16 = ServerConfiguration.defaultPort,
-        authToken: String? = ProcessInfo.processInfo.environment[ServerConfiguration.authTokenEnvironmentVariable]
+        host: String? = nil,
+        port: UInt16? = nil,
+        authToken: String? = ProcessInfo.processInfo.environment[ServerConfiguration.authTokenEnvironmentVariable],
+        runtimeConfigurationStore: DefaultCameraBridgeRuntimeConfigurationStore = DefaultCameraBridgeRuntimeConfigurationStore()
     ) {
-        self.host = host
-        self.port = port
+        let storedConfiguration = (try? runtimeConfigurationStore.loadConfiguration()) ??
+            CameraBridgeRuntimeConfiguration()
+        self.host = host ??
+            ProcessInfo.processInfo.environment[ServerConfiguration.hostEnvironmentVariable] ??
+            storedConfiguration.host
+        self.port = port ??
+            Self.environmentPortValue() ??
+            storedConfiguration.port
         self.authToken = authToken
     }
 
@@ -33,6 +43,25 @@ struct ServerConfiguration: Sendable, Equatable {
         }
 
         return try authTokenStore.loadOrCreateToken()
+    }
+
+    func resolvedRuntimeOwnership() -> CameraBridgeRuntimeOwnership {
+        guard let rawValue =
+            ProcessInfo.processInfo.environment[ServerConfiguration.runtimeOwnershipEnvironmentVariable],
+            let ownership = CameraBridgeRuntimeOwnership(rawValue: rawValue)
+        else {
+            return .external
+        }
+
+        return ownership
+    }
+
+    private static func environmentPortValue() -> UInt16? {
+        guard let rawValue = ProcessInfo.processInfo.environment[portEnvironmentVariable] else {
+            return nil
+        }
+
+        return UInt16(rawValue)
     }
 }
 
@@ -92,6 +121,21 @@ struct CameraBridgeDaemon {
         let port = try server.start()
         logger("camd ready on \(configuration.host):\(port)")
         return server
+    }
+
+    func runtimeInfo(
+        boundPort: UInt16,
+        authTokenStore: DefaultCameraBridgeAuthTokenStore = DefaultCameraBridgeAuthTokenStore()
+    ) throws -> CameraBridgeRuntimeInfo {
+        CameraBridgeRuntimeInfo(
+            pid: Int32(ProcessInfo.processInfo.processIdentifier),
+            host: configuration.host,
+            port: boundPort,
+            tokenFileURL: try authTokenStore.authTokenURL(),
+            logFileURL: try CameraBridgeSupportPaths.logFileURL(),
+            capturesDirectoryURL: try CameraBridgeSupportPaths.capturesDirectoryURL(),
+            ownership: configuration.resolvedRuntimeOwnership()
+        )
     }
 }
 

--- a/apps/camd/Sources/camd/main.swift
+++ b/apps/camd/Sources/camd/main.swift
@@ -1,17 +1,56 @@
 import CameraBridgeAPI
 import CameraBridgeCore
+import CameraBridgeSupport
+import Darwin
 import Dispatch
+import Foundation
 
 _ = CameraBridgeAPIModule.name
 _ = CameraBridgeCoreModule.name
 
-let daemon = CameraBridgeDaemon()
+final class CameraBridgeDaemonRuntime {
+    private let daemon = CameraBridgeDaemon()
+    private let runtimeInfoStore = DefaultCameraBridgeRuntimeInfoStore()
+    private var server: LocalHTTPServer?
+    private var signalSources: [DispatchSourceSignal] = []
+    private let signalQueue = DispatchQueue(label: "camd.signal-handling")
 
-do {
-    let server = try daemon.start()
-    withExtendedLifetime(server) {
+    func run() throws {
+        let server = try daemon.start()
+        self.server = server
+        try runtimeInfoStore.saveRuntimeInfo(
+            daemon.runtimeInfo(boundPort: server.boundPort ?? daemon.configuration.port)
+        )
+        installSignalHandlers()
         dispatchMain()
     }
+
+    private func installSignalHandlers() {
+        signal(SIGTERM, SIG_IGN)
+        signal(SIGINT, SIG_IGN)
+
+        for signalValue in [SIGTERM, SIGINT] {
+            let source = DispatchSource.makeSignalSource(signal: signalValue, queue: signalQueue)
+            source.setEventHandler { [weak self] in
+                self?.shutdown()
+            }
+            source.resume()
+            signalSources.append(source)
+        }
+    }
+
+    private func shutdown() {
+        server?.stop()
+        try? runtimeInfoStore.clearRuntimeInfo()
+        exit(0)
+    }
+}
+
+let runtime = CameraBridgeDaemonRuntime()
+
+do {
+    try runtime.run()
 } catch {
+    try? DefaultCameraBridgeRuntimeInfoStore().clearRuntimeInfo()
     fputs("camd failed to start: \(error)\n", stderr)
 }

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -34,7 +34,7 @@ This document defines the current CameraBridge API contract for the shipped v1 f
 - successful `POST /v1/session/select-device` does not create or transfer session ownership
 - `POST /v1/permissions/request` remains in the API as the stable token-protected programmatic permission-check route even though prompting remains app-owned
 
-Current error categories for mutating endpoints:
+Current error categories across auth-protected endpoints:
 
 - `unauthorized`: bearer token missing or invalid
 - `ownership_conflict`: another client already owns the active session
@@ -106,7 +106,7 @@ Behavior:
 - does not trigger the macOS system prompt from `camd`
 - remains the token-protected programmatic permission-check route for local clients that need to know whether permission is now usable before camera actions
 - when permission has already been decided, returns the current state with `prompted: false`
-- when permission is still `not_determined`, the caller must use `CameraBridgeApp` to request access
+- when permission is still `not_determined`, returns guided next-step information telling the caller to use `CameraBridgeApp` to request access
 - does not create or transfer session ownership
 - returns the same daemon-visible permission state later consumed by `POST /v1/session/start`
 
@@ -114,6 +114,8 @@ Successful response: `200 OK`
 
 ```json
 {
+  "message": null,
+  "next_step": null,
   "prompted": false,
   "status": "authorized"
 }
@@ -123,17 +125,26 @@ Response fields:
 
 - `status`: resulting permission state
 - `prompted`: always `false` for daemon responses in v1
+- `message`: optional short guidance message for local clients
+- `next_step`: optional object describing the next supported action when permission is not yet usable
+- `next_step.kind`: currently `open_camera_bridge_app`
 
-Undecided permission response: `409 invalid_state`
+Undecided permission response: `200 OK`
 
 ```json
 {
-  "error": {
-    "code": "invalid_state",
-    "message": "Camera permission must be requested from CameraBridgeApp"
-  }
+  "message": "Open CameraBridgeApp to request camera access.",
+  "next_step": {
+    "kind": "open_camera_bridge_app"
+  },
+  "prompted": false,
+  "status": "not_determined"
 }
 ```
+
+Error cases:
+
+- `401 unauthorized` when the bearer token is missing or invalid
 
 ### `GET /v1/devices`
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -34,11 +34,11 @@ CameraBridge is:
 
 CameraBridge owns:
 
-- camera permission state and requests
+- camera permission state and app-assisted permission requests
 - device discovery
 - capture session lifecycle
 - still image capture
-- minimal runtime state
+- minimal runtime state, runtime config, and runtime metadata
 
 CameraBridge does NOT own:
 
@@ -129,6 +129,7 @@ No AVFoundation logic and no parallel permission state.
 - process entrypoint
 - config + bootstrap
 - dependency wiring
+- writes runtime metadata for the packaged app flow
 
 No domain logic.
 
@@ -140,17 +141,20 @@ No domain logic.
 - onboarding
 - status display
 - app-owned camera permission prompting
+- packaged daemon lifecycle control
+- developer-facing connection info
 
 No backend logic.
 
-## 5.1 Current v1 permission ownership note
+## 5.1 Current v1 permission and lifecycle model
 
-The current shipped v1 permission model is intentionally narrow but not yet the
-final architectural end state:
+The current shipped v1 packaged flow is intentionally narrow:
 
 - `CameraBridgeApp` owns the macOS permission prompt
 - `camd` reads live AVFoundation permission status for `/v1/permissions`, `/v1/permissions/request`, and session-start validation
-- source-of-truth consolidation for permission state remains deferred follow-up work after the shipped behavior is documented clearly
+- `POST /v1/permissions/request` remains API-first and returns guided next-step data when permission is still `not_determined`
+- the packaged app supervises the bundled daemon with explicit start, stop, and quit semantics
+- runtime configuration and runtime metadata live under Application Support so the app can surface effective connection details without repo-specific knowledge
 
 ---
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -4,7 +4,7 @@ This guide walks through the current working v1 loop on macOS:
 
 1. build the repo
 2. package and launch `CameraBridgeApp`
-3. start the local service and confirm camera permission
+3. start the local service, confirm camera permission, and read the surfaced connection details
 4. run one minimal example client that selects a device, starts a session, captures a still image, and stops the session
 
 ## Prerequisites
@@ -46,35 +46,45 @@ $(swift build --show-bin-path)/CameraBridgeApp.app
 
 From the menu bar app:
 
-1. click `Start Service`
-2. confirm the app shows `Service: running`
+1. click `Start CameraBridge Service`
+2. confirm the app shows `Service: Running`
 3. click `Request Camera Access` if permission is still undecided
 4. allow the macOS camera prompt shown by `CameraBridgeApp`
-5. confirm the app shows `Permission: authorized`
+5. confirm the app shows `Permission: Authorized`
+6. note the `Base URL`, `Token`, `Log`, and `Captures` rows shown in the menu
 
-When `camd` starts without `CAMERABRIDGE_AUTH_TOKEN`, it loads or creates the local bearer token at:
+The packaged app supervises the bundled daemon in the supported v1 flow:
+
+- `Start CameraBridge Service` launches the bundled `camd` if the configured endpoint is not already healthy
+- `Stop CameraBridge Service` stops only the daemon instance launched by the app
+- `Quit CameraBridge` stops that managed daemon before exit
+- if the app detects an already-running daemon that it did not launch, it shows `Running (External)` and leaves that process alone
+
+The app surfaces the effective connection details in its menu. In the default packaged flow they are:
 
 ```text
-~/Library/Application Support/CameraBridge/auth-token
+Base URL: http://127.0.0.1:8731
+Token: ~/Library/Application Support/CameraBridge/auth-token
+Log: ~/Library/Application Support/CameraBridge/Logs/camd.log
+Captures: ~/Library/Application Support/CameraBridge/Captures/
 ```
 
-The packaged app uses that same daemon-owned token contract when it launches the bundled service.
+The packaged flow reads runtime configuration from:
+
+```text
+~/Library/Application Support/CameraBridge/runtime-configuration.json
+```
+
+If no configuration file exists, CameraBridge defaults to `127.0.0.1:8731`.
 
 The daemon reads live AVFoundation permission status directly for
 `/v1/permissions`, `/v1/permissions/request`, and the session-start permission
 precondition.
 
-The packaged app starts `camd` as a localhost-only service intended to be reachable from other local clients at `127.0.0.1:8731`.
-
-Camera captures are stored under:
-
-```text
-~/Library/Application Support/CameraBridge/Captures/
-```
-
 ## Verify The Local API
 
-Check the service health and current permission state:
+Use the base URL and token path surfaced by the app. With the default packaged
+flow, check the service health and current permission state with:
 
 ```bash
 curl -s http://127.0.0.1:8731/health
@@ -86,13 +96,24 @@ curl -s -X POST http://127.0.0.1:8731/v1/permissions/request \
 curl -s http://127.0.0.1:8731/v1/devices
 ```
 
-If permission is already decided, `POST /v1/permissions/request` returns the
-current daemon-visible status with `prompted: false`. The route remains in the
-API so local clients have a stable token-protected way to check whether
-permission is now usable. If it returns `409 invalid_state`, go back to the
-menu bar app and request access there.
+`POST /v1/permissions/request` now returns `200 OK` for every permission state.
+When permission is already decided, the response keeps `prompted: false` and
+returns `message: null` and `next_step: null`. When permission is still
+`not_determined`, the route returns guided next-step data instead of `409`:
 
-The mutating endpoints use the bearer token from Application Support:
+```json
+{
+  "message": "Open CameraBridgeApp to request camera access.",
+  "next_step": {
+    "kind": "open_camera_bridge_app"
+  },
+  "prompted": false,
+  "status": "not_determined"
+}
+```
+
+The mutating endpoints use the bearer token shown in the app. In the default
+packaged flow:
 
 ```bash
 TOKEN="$(cat ~/Library/Application\ Support/CameraBridge/auth-token)"

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -15,9 +15,9 @@ It is intentionally manual. CI should continue to avoid hardware dependencies.
 
 ### Goal
 
-Validate the packaged app, daemon bootstrap, local token path, permission flow,
-device selection, still capture, and capture artifact path in one repeatable
-manual run.
+Validate the packaged app, app-supervised daemon lifecycle, local token path,
+permission flow, developer-info surfacing, device selection, still capture, and
+capture artifact path in one repeatable manual run.
 
 ### Prerequisites
 
@@ -52,14 +52,17 @@ Expected checkpoints:
 - the menu bar app appears
 - the initial state reports the service as stopped
 - `Start CameraBridge Service` is available
+- developer info rows are visible even before capture
 
 3. Start the service from the menu bar app.
 
 Expected checkpoints:
 
 - the menu updates to `Service: Running`
+- `Stop CameraBridge Service` becomes available
 - `camd` binds to `127.0.0.1:8731`
 - `~/Library/Application Support/CameraBridge/auth-token` exists
+- the menu surfaces the effective base URL, token path, log path, and captures path
 
 4. Request camera access from the menu bar app if permission is not already
    authorized.
@@ -69,6 +72,10 @@ Expected checkpoints:
 - the macOS permission prompt appears from `CameraBridgeApp` when status is `not_determined`
 - the menu reaches `Permission: Authorized`
 - failures are surfaced in the menu with readable text
+
+If the machine is in a fresh `not_determined` state before permission is
+granted, `POST /v1/permissions/request` should return `200 OK` with a guided
+`next_step.kind` of `open_camera_bridge_app` rather than `409 invalid_state`.
 
 5. Verify the local API:
 
@@ -87,7 +94,7 @@ Expected checkpoints:
 
 - `/health` returns `{"status":"ok"}`
 - `/v1/permissions` returns `authorized`
-- `/v1/permissions/request` returns `{"prompted":false,"status":"authorized"}`
+- `/v1/permissions/request` returns `{"message":null,"next_step":null,"prompted":false,"status":"authorized"}`
 - `/v1/devices` returns at least one real camera device
 
 5a. Verify stale file non-involvement:
@@ -128,6 +135,8 @@ Expected checkpoints:
 - `GET /v1/session` reports `state: stopped`
 - the selected `active_device_id` is preserved for later restart
 - the app remains responsive after capture
+- stopping the service from the app returns the menu to the stopped state
+- quitting the app after a managed start leaves no healthy managed daemon behind
 
 ## Failure Surfaces To Record
 
@@ -139,6 +148,7 @@ Record any failure in these areas:
 - permission prompt does not appear when expected
 - permission state does not update after the prompt
 - daemon permission routes do not reflect live OS permission state
+- permission request route returns an error instead of guided `200 OK` data for undecided permission
 - device listing is empty despite connected hardware
 - session start or device selection fails unexpectedly
 - capture fails or no artifact is written
@@ -156,14 +166,17 @@ release:
 - [ ] Packaged `CameraBridgeApp.app` launched successfully
 - [ ] `camd` started from the app and reported healthy on `127.0.0.1:8731`
 - [ ] Auth token file existed at `~/Library/Application Support/CameraBridge/auth-token`
+- [ ] App surfaced base URL, token path, log path, and captures path
 - [ ] Camera permission reached `authorized`
 - [ ] `GET /v1/permissions` reflected live OS permission state
-- [ ] `POST /v1/permissions/request` returned `prompted:false` after authorization
+- [ ] `POST /v1/permissions/request` returned `message:null`, `next_step:null`, and `prompted:false` after authorization
 - [ ] Stale `permission-state` file had no effect on daemon permission responses
 - [ ] `GET /v1/devices` returned the expected camera
 - [ ] Python first-capture example completed successfully
 - [ ] Capture artifact existed at the reported `local_path`
 - [ ] `GET /v1/session` returned `stopped` after cleanup
+- [ ] `Stop CameraBridge Service` returned the app to the stopped state
+- [ ] Quitting the app stopped the managed daemon
 - [ ] Any issues or follow-up fixes were recorded before release
 
 ## Result Template
@@ -183,7 +196,7 @@ Fill this in during the manual run:
 - Machine: Mac17,3
 - macOS version: 26.3.1 (25D2128)
 - Camera device: Insta360 Link 2
-- Result: Passed
+- Result: Passed (pre-contract-cleanup run)
 - Notes:
   - `GET /health` returned `200 OK`
   - `GET /v1/permissions` returned `authorized`
@@ -191,3 +204,4 @@ Fill this in during the manual run:
   - A stale `~/Library/Application Support/CameraBridge/permission-state` file did not affect daemon permission responses
   - `examples/python/capture_photo.py --device-id 0x1000002e1a4c04` completed successfully
   - Capture artifact written to `~/Library/Application Support/CameraBridge/Captures/capture-20260321T194247439Z-e21df7e5-ca86-4529-982f-a4a511053f7e.jpg`
+  - This run predates the guided permission-response and app-supervised lifecycle cleanup and should be repeated before release

--- a/docs/roadmap/v1.md
+++ b/docs/roadmap/v1.md
@@ -20,7 +20,7 @@ The shipped v1 slice is intentionally narrow. It prioritizes:
 A user can:
 
 1. Install and run CameraBridge
-2. Start the `camd` service
+2. Start the service from `CameraBridgeApp`
 3. Verify the service is running (`/health`)
 4. Inspect camera permission status
 5. List available camera devices
@@ -55,6 +55,7 @@ This flow is the current bar for the shipped v1 first-capture slice.
 - Read permission state
 - Request camera permission via `CameraBridgeApp`
 - In the shipped slice, `camd` reports live AVFoundation permission status used for session preconditions
+- `POST /v1/permissions/request` stays API-first and returns guided next-step data when `CameraBridgeApp` must request access
 
 #### Device Discovery
 
@@ -83,7 +84,8 @@ This flow is the current bar for the shipped v1 first-capture slice.
 - `camd` daemon:
   - localhost HTTP server
   - readable startup and failure logging
-  - config + token management
+  - runtime config + token management
+  - runtime metadata for app-visible connection details
 
 - Default binding:
   - `127.0.0.1`
@@ -94,7 +96,7 @@ This flow is the current bar for the shipped v1 first-capture slice.
 - Read-only endpoints remain unauthenticated in the shipped localhost-only slice
 - Shipped mutating endpoints require a bearer token or equivalent local secret
 - `POST /v1/permissions/request` is token-protected, does not create session ownership, and does not trigger the macOS prompt from `camd`
-- when permission is still `not_determined`, callers must use `CameraBridgeApp` to request access
+- when permission is still `not_determined`, the route returns guided next-step data telling callers to use `CameraBridgeApp`
 - `POST /v1/session/start` acquires implicit session ownership on success
 - `POST /v1/session/stop`, `POST /v1/session/select-device`, and `POST /v1/capture/photo` require the current session owner
 - v1 uses explicit error categories for unauthorized, ownership-conflict, and invalid-state requests
@@ -106,7 +108,8 @@ This flow is the current bar for the shipped v1 first-capture slice.
 - macOS menu bar app
 - first-run onboarding
 - permission status visibility
-- basic service status (running / stopped)
+- app-supervised packaged daemon lifecycle with explicit start / stop / quit behavior
+- developer-visible base URL, token path, log path, and captures path
 - custom URL scheme is deferred until after v1
 
 ---

--- a/packages/CameraBridgeAPI/README.md
+++ b/packages/CameraBridgeAPI/README.md
@@ -16,7 +16,8 @@ The current v1 surface includes:
 - `POST /v1/capture/photo`
 
 `POST /v1/permissions/request` does not invoke the macOS permission prompt from
-the daemon. It returns the live daemon-visible permission state and directs
-callers to `CameraBridgeApp` when permission is still undecided. The route
-remains in the API as the stable token-protected programmatic permission-check
-endpoint for local clients.
+the daemon. It returns the live daemon-visible permission state with
+`prompted: false` for all permission states. When permission is still
+undecided, the response remains `200 OK` and includes guided next-step data
+that directs callers to `CameraBridgeApp`. The route remains in the API as the
+stable token-protected programmatic permission-check endpoint for local clients.

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -184,11 +184,15 @@ public enum CameraBridgeRoutes {
             }
 
             let currentPermissionState = controller.currentPermissionState()
-            guard currentPermissionState != .notDetermined else {
-                return .error(
-                    statusCode: 409,
-                    code: "invalid_state",
-                    message: "Camera permission must be requested from CameraBridgeApp"
+            if currentPermissionState == .notDetermined {
+                return .json(
+                    statusCode: 200,
+                    body: PermissionRequestResponse(
+                        status: currentPermissionState.rawValue,
+                        prompted: false,
+                        message: "Open CameraBridgeApp to request camera access.",
+                        nextStep: .init(kind: PermissionRequestNextStepKind.openCameraBridgeApp.rawValue)
+                    )
                 )
             }
 
@@ -728,11 +732,60 @@ private struct ErrorBody: Encodable, Equatable {
 private struct PermissionRequestResponse: Encodable, Equatable {
     var status: String
     var prompted: Bool
+    var message: String?
+    var nextStep: PermissionRequestNextStepResponse?
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case prompted
+        case message
+        case nextStep = "next_step"
+    }
 
     init(result: PermissionRequestResult) {
         self.status = result.status.rawValue
         self.prompted = result.prompted
+        self.message = nil
+        self.nextStep = nil
     }
+
+    init(
+        status: String,
+        prompted: Bool,
+        message: String?,
+        nextStep: PermissionRequestNextStepResponse?
+    ) {
+        self.status = status
+        self.prompted = prompted
+        self.message = message
+        self.nextStep = nextStep
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(status, forKey: .status)
+        try container.encode(prompted, forKey: .prompted)
+
+        if let message {
+            try container.encode(message, forKey: .message)
+        } else {
+            try container.encodeNil(forKey: .message)
+        }
+
+        if let nextStep {
+            try container.encode(nextStep, forKey: .nextStep)
+        } else {
+            try container.encodeNil(forKey: .nextStep)
+        }
+    }
+}
+
+private enum PermissionRequestNextStepKind: String, Equatable {
+    case openCameraBridgeApp = "open_camera_bridge_app"
+}
+
+private struct PermissionRequestNextStepResponse: Encodable, Equatable {
+    var kind: String
 }
 
 private struct DevicesResponse: Encodable, Equatable {

--- a/packages/CameraBridgeClientSwift/README.md
+++ b/packages/CameraBridgeClientSwift/README.md
@@ -31,11 +31,13 @@ let client = CameraBridgeClient(tokenProvider: { try? String(contentsOfFile: tok
 The request and response contract for the full shipped client surface is
 covered by `swift test` in `tests/CameraBridgeClientSwiftTests`.
 
-`requestPermission()` no longer triggers a macOS prompt from `camd`. It returns
-the daemon's live permission state with `prompted: false`, or surfaces the
-`409 invalid_state` response that tells callers to use `CameraBridgeApp` when
-permission is still `not_determined`. The route remains available so local
-clients can programmatically check whether permission is now usable before
-camera actions.
+`requestPermission()` does not trigger a macOS prompt from `camd`. It returns
+the daemon's live permission state with `prompted: false` for all permission
+states. When permission is still `not_determined`, the response includes a
+typed `nextStep` value with kind `openCameraBridgeApp` plus a short guidance
+message telling the caller to use `CameraBridgeApp`. The route remains
+available so local clients can programmatically check whether permission is now
+usable before camera actions without treating the undecided state as a transport
+or route error.
 
 For the current repo-level setup and first capture flow, see [docs/quick-start.md](../../docs/quick-start.md).

--- a/packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
+++ b/packages/CameraBridgeClientSwift/Sources/CameraBridgeClientSwift/CameraBridgeClient.swift
@@ -10,10 +10,31 @@ public enum CameraBridgePermissionStatus: String, Sendable, CaseIterable, Equata
 public struct CameraBridgePermissionRequestResult: Sendable, Equatable {
     public var status: CameraBridgePermissionStatus
     public var prompted: Bool
+    public var message: String?
+    public var nextStep: CameraBridgePermissionNextStep?
 
-    public init(status: CameraBridgePermissionStatus, prompted: Bool) {
+    public init(
+        status: CameraBridgePermissionStatus,
+        prompted: Bool,
+        message: String? = nil,
+        nextStep: CameraBridgePermissionNextStep? = nil
+    ) {
         self.status = status
         self.prompted = prompted
+        self.message = message
+        self.nextStep = nextStep
+    }
+}
+
+public enum CameraBridgePermissionNextStepKind: String, Sendable, CaseIterable, Equatable {
+    case openCameraBridgeApp = "open_camera_bridge_app"
+}
+
+public struct CameraBridgePermissionNextStep: Sendable, Equatable {
+    public var kind: CameraBridgePermissionNextStepKind
+
+    public init(kind: CameraBridgePermissionNextStepKind) {
+        self.kind = kind
     }
 }
 
@@ -146,7 +167,22 @@ public struct CameraBridgeClient {
             throw CameraBridgeClientError.invalidStatus(response.status)
         }
 
-        return CameraBridgePermissionRequestResult(status: status, prompted: response.prompted)
+        let nextStep: CameraBridgePermissionNextStep?
+        if let responseNextStep = response.nextStep {
+            guard let kind = CameraBridgePermissionNextStepKind(rawValue: responseNextStep.kind) else {
+                throw CameraBridgeClientError.invalidStatus(responseNextStep.kind)
+            }
+            nextStep = CameraBridgePermissionNextStep(kind: kind)
+        } else {
+            nextStep = nil
+        }
+
+        return CameraBridgePermissionRequestResult(
+            status: status,
+            prompted: response.prompted,
+            message: response.message,
+            nextStep: nextStep
+        )
     }
 
     public func devices() async throws -> [CameraBridgeDevice] {
@@ -308,6 +344,19 @@ private struct PermissionStatusResponse: Decodable {
 private struct PermissionRequestResponse: Decodable {
     var status: String
     var prompted: Bool
+    var message: String?
+    var nextStep: PermissionRequestNextStepResponse?
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case prompted
+        case message
+        case nextStep = "next_step"
+    }
+}
+
+private struct PermissionRequestNextStepResponse: Decodable {
+    var kind: String
 }
 
 private struct DevicesResponse: Decodable {

--- a/packages/CameraBridgeSupport/Sources/CameraBridgeSupport/CameraBridgeSupport.swift
+++ b/packages/CameraBridgeSupport/Sources/CameraBridgeSupport/CameraBridgeSupport.swift
@@ -4,6 +4,17 @@ public enum CameraBridgeSupportModule {
     public static let name = "CameraBridgeSupport"
 }
 
+public enum CameraBridgeSupportPathError: LocalizedError, Equatable {
+    case supportDirectoryUnavailable
+
+    public var errorDescription: String? {
+        switch self {
+        case .supportDirectoryUnavailable:
+            return "CameraBridge support directory is unavailable"
+        }
+    }
+}
+
 public enum CameraBridgeAuthTokenError: LocalizedError, Equatable {
     case invalidTokenFile
     case supportDirectoryUnavailable
@@ -33,6 +44,34 @@ public enum CameraBridgePermissionStateStoreError: LocalizedError, Equatable {
         switch self {
         case .invalidPermissionStateFile:
             return "Stored permission state is invalid"
+        case .supportDirectoryUnavailable:
+            return "CameraBridge support directory is unavailable"
+        }
+    }
+}
+
+public enum CameraBridgeRuntimeConfigurationStoreError: LocalizedError, Equatable {
+    case invalidRuntimeConfigurationFile
+    case supportDirectoryUnavailable
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRuntimeConfigurationFile:
+            return "Stored runtime configuration is invalid"
+        case .supportDirectoryUnavailable:
+            return "CameraBridge support directory is unavailable"
+        }
+    }
+}
+
+public enum CameraBridgeRuntimeInfoStoreError: LocalizedError, Equatable {
+    case invalidRuntimeInfoFile
+    case supportDirectoryUnavailable
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRuntimeInfoFile:
+            return "Stored runtime info is invalid"
         case .supportDirectoryUnavailable:
             return "CameraBridge support directory is unavailable"
         }
@@ -76,23 +115,15 @@ public struct DefaultCameraBridgeAuthTokenStore {
     }
 
     public func authTokenURL() throws -> URL {
-        try supportDirectoryURL()
-            .appendingPathComponent("auth-token", isDirectory: false)
+        try CameraBridgeSupportPaths.authTokenURL(baseDirectoryURL: baseDirectoryURL, fileManager: fileManager)
     }
 
     private func supportDirectoryURL() throws -> URL {
-        if let baseDirectoryURL {
-            return baseDirectoryURL
-        }
-
-        guard let applicationSupportURL =
-            fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-        else {
-            throw CameraBridgeAuthTokenError.supportDirectoryUnavailable
-        }
-
-        return applicationSupportURL
-            .appendingPathComponent("CameraBridge", isDirectory: true)
+        try resolvedSupportDirectoryURL(
+            baseDirectoryURL: baseDirectoryURL,
+            fileManager: fileManager,
+            unavailableError: CameraBridgeAuthTokenError.supportDirectoryUnavailable
+        )
     }
 
     private func normalizedToken(from tokenURL: URL) throws -> String {
@@ -140,22 +171,254 @@ public struct DefaultCameraBridgePermissionStateStore {
     }
 
     public func permissionStateURL() throws -> URL {
-        try supportDirectoryURL()
-            .appendingPathComponent("permission-state", isDirectory: false)
+        try CameraBridgeSupportPaths.permissionStateURL(
+            baseDirectoryURL: baseDirectoryURL,
+            fileManager: fileManager
+        )
     }
 
     private func supportDirectoryURL() throws -> URL {
-        if let baseDirectoryURL {
-            return baseDirectoryURL
-        }
-
-        guard let applicationSupportURL =
-            fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
-        else {
-            throw CameraBridgePermissionStateStoreError.supportDirectoryUnavailable
-        }
-
-        return applicationSupportURL
-            .appendingPathComponent("CameraBridge", isDirectory: true)
+        try resolvedSupportDirectoryURL(
+            baseDirectoryURL: baseDirectoryURL,
+            fileManager: fileManager,
+            unavailableError: CameraBridgePermissionStateStoreError.supportDirectoryUnavailable
+        )
     }
+}
+
+public enum CameraBridgeRuntimeOwnership: String, Sendable, CaseIterable, Equatable, Codable {
+    case external
+    case appManaged = "app_managed"
+}
+
+public struct CameraBridgeRuntimeConfiguration: Sendable, Equatable, Codable {
+    public static let defaultHost = "127.0.0.1"
+    public static let defaultPort: UInt16 = 8731
+
+    public var host: String
+    public var port: UInt16
+
+    public init(host: String = defaultHost, port: UInt16 = defaultPort) {
+        self.host = host
+        self.port = port
+    }
+
+    public var baseURL: URL {
+        URL(string: "http://\(host):\(port)")!
+    }
+}
+
+public struct CameraBridgeRuntimeInfo: Sendable, Equatable, Codable {
+    public var pid: Int32
+    public var host: String
+    public var port: UInt16
+    public var tokenFileURL: URL
+    public var logFileURL: URL
+    public var capturesDirectoryURL: URL
+    public var ownership: CameraBridgeRuntimeOwnership
+
+    public init(
+        pid: Int32,
+        host: String,
+        port: UInt16,
+        tokenFileURL: URL,
+        logFileURL: URL,
+        capturesDirectoryURL: URL,
+        ownership: CameraBridgeRuntimeOwnership
+    ) {
+        self.pid = pid
+        self.host = host
+        self.port = port
+        self.tokenFileURL = tokenFileURL
+        self.logFileURL = logFileURL
+        self.capturesDirectoryURL = capturesDirectoryURL
+        self.ownership = ownership
+    }
+
+    public var baseURL: URL {
+        URL(string: "http://\(host):\(port)")!
+    }
+}
+
+public struct DefaultCameraBridgeRuntimeConfigurationStore {
+    public var baseDirectoryURL: URL?
+
+    private let fileManager: FileManager
+
+    public init(fileManager: FileManager = .default, baseDirectoryURL: URL? = nil) {
+        self.fileManager = fileManager
+        self.baseDirectoryURL = baseDirectoryURL
+    }
+
+    public func loadConfiguration() throws -> CameraBridgeRuntimeConfiguration {
+        let configurationURL = try runtimeConfigurationURL()
+        guard fileManager.fileExists(atPath: configurationURL.path) else {
+            return CameraBridgeRuntimeConfiguration()
+        }
+
+        let data = try Data(contentsOf: configurationURL)
+        do {
+            return try JSONDecoder().decode(CameraBridgeRuntimeConfiguration.self, from: data)
+        } catch {
+            throw CameraBridgeRuntimeConfigurationStoreError.invalidRuntimeConfigurationFile
+        }
+    }
+
+    public func saveConfiguration(_ configuration: CameraBridgeRuntimeConfiguration) throws {
+        let configurationURL = try runtimeConfigurationURL()
+        try fileManager.createDirectory(
+            at: configurationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try encoder.encode(configuration).write(to: configurationURL, options: .atomic)
+    }
+
+    public func runtimeConfigurationURL() throws -> URL {
+        try CameraBridgeSupportPaths.runtimeConfigurationURL(
+            baseDirectoryURL: baseDirectoryURL,
+            fileManager: fileManager
+        )
+    }
+}
+
+public struct DefaultCameraBridgeRuntimeInfoStore {
+    public var baseDirectoryURL: URL?
+
+    private let fileManager: FileManager
+
+    public init(fileManager: FileManager = .default, baseDirectoryURL: URL? = nil) {
+        self.fileManager = fileManager
+        self.baseDirectoryURL = baseDirectoryURL
+    }
+
+    public func loadRuntimeInfo() throws -> CameraBridgeRuntimeInfo? {
+        let runtimeInfoURL = try self.runtimeInfoURL()
+        guard fileManager.fileExists(atPath: runtimeInfoURL.path) else {
+            return nil
+        }
+
+        let data = try Data(contentsOf: runtimeInfoURL)
+        do {
+            return try JSONDecoder().decode(CameraBridgeRuntimeInfo.self, from: data)
+        } catch {
+            throw CameraBridgeRuntimeInfoStoreError.invalidRuntimeInfoFile
+        }
+    }
+
+    public func saveRuntimeInfo(_ runtimeInfo: CameraBridgeRuntimeInfo) throws {
+        let runtimeInfoURL = try self.runtimeInfoURL()
+        try fileManager.createDirectory(
+            at: runtimeInfoURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try encoder.encode(runtimeInfo).write(to: runtimeInfoURL, options: .atomic)
+    }
+
+    public func clearRuntimeInfo() throws {
+        let runtimeInfoURL = try self.runtimeInfoURL()
+        guard fileManager.fileExists(atPath: runtimeInfoURL.path) else {
+            return
+        }
+
+        try fileManager.removeItem(at: runtimeInfoURL)
+    }
+
+    public func runtimeInfoURL() throws -> URL {
+        try CameraBridgeSupportPaths.runtimeInfoURL(
+            baseDirectoryURL: baseDirectoryURL,
+            fileManager: fileManager
+        )
+    }
+}
+
+public enum CameraBridgeSupportPaths {
+    public static func supportDirectoryURL(
+        baseDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try resolvedSupportDirectoryURL(
+            baseDirectoryURL: baseDirectoryURL,
+            fileManager: fileManager,
+            unavailableError: CameraBridgeSupportPathError.supportDirectoryUnavailable
+        )
+    }
+
+    public static func authTokenURL(
+        baseDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try supportDirectoryURL(baseDirectoryURL: baseDirectoryURL, fileManager: fileManager)
+            .appendingPathComponent("auth-token", isDirectory: false)
+    }
+
+    public static func permissionStateURL(
+        baseDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try supportDirectoryURL(baseDirectoryURL: baseDirectoryURL, fileManager: fileManager)
+            .appendingPathComponent("permission-state", isDirectory: false)
+    }
+
+    public static func runtimeConfigurationURL(
+        baseDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try supportDirectoryURL(baseDirectoryURL: baseDirectoryURL, fileManager: fileManager)
+            .appendingPathComponent("runtime-configuration.json", isDirectory: false)
+    }
+
+    public static func runtimeInfoURL(
+        baseDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try supportDirectoryURL(baseDirectoryURL: baseDirectoryURL, fileManager: fileManager)
+            .appendingPathComponent("runtime-info.json", isDirectory: false)
+    }
+
+    public static func logsDirectoryURL(
+        baseDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try supportDirectoryURL(baseDirectoryURL: baseDirectoryURL, fileManager: fileManager)
+            .appendingPathComponent("Logs", isDirectory: true)
+    }
+
+    public static func logFileURL(
+        baseDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try logsDirectoryURL(baseDirectoryURL: baseDirectoryURL, fileManager: fileManager)
+            .appendingPathComponent("camd.log", isDirectory: false)
+    }
+
+    public static func capturesDirectoryURL(
+        baseDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try supportDirectoryURL(baseDirectoryURL: baseDirectoryURL, fileManager: fileManager)
+            .appendingPathComponent("Captures", isDirectory: true)
+    }
+}
+
+private func resolvedSupportDirectoryURL<E: Error>(
+    baseDirectoryURL: URL?,
+    fileManager: FileManager,
+    unavailableError: E
+) throws -> URL {
+    if let baseDirectoryURL {
+        return baseDirectoryURL
+    }
+
+    guard let applicationSupportURL =
+        fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+    else {
+        throw unavailableError
+    }
+
+    return applicationSupportURL
+        .appendingPathComponent("CameraBridge", isDirectory: true)
 }

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -158,7 +158,7 @@ func routerRejectsPermissionRequestWithoutBearerToken() {
 }
 
 @Test
-func routerRejectsPermissionRequestWhenPromptMustComeFromApp() {
+func routerReturnsGuidedPermissionRequestResultWhenPromptMustComeFromApp() {
     let sessionController = makeSessionController(
         state: CameraState(permissionState: .denied),
         permissionStatusProvider: FixedPermissionStatusProvider(state: .notDetermined)
@@ -172,10 +172,10 @@ func routerRejectsPermissionRequestWhenPromptMustComeFromApp() {
         )
     )
 
-    #expect(response.statusCode == 409)
+    #expect(response.statusCode == 200)
     #expect(
         String(decoding: response.body, as: UTF8.self) ==
-        #"{"error":{"code":"invalid_state","message":"Camera permission must be requested from CameraBridgeApp"}}"#
+        #"{"message":"Open CameraBridgeApp to request camera access.","next_step":{"kind":"open_camera_bridge_app"},"prompted":false,"status":"not_determined"}"#
     )
     #expect(sessionController.currentCameraState().permissionState == .notDetermined)
 }
@@ -195,7 +195,10 @@ func routerReturnsStoredPermissionRequestResultForAuthorizedRequest() {
     )
 
     #expect(response.statusCode == 200)
-    #expect(String(decoding: response.body, as: UTF8.self) == #"{"prompted":false,"status":"authorized"}"#)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"message":null,"next_step":null,"prompted":false,"status":"authorized"}"#
+    )
     #expect(sessionController.currentCameraState().permissionState == .authorized)
 }
 
@@ -214,7 +217,10 @@ func routerReturnsStoredPermissionRequestResultForRestrictedRequest() {
     )
 
     #expect(response.statusCode == 200)
-    #expect(String(decoding: response.body, as: UTF8.self) == #"{"prompted":false,"status":"restricted"}"#)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"message":null,"next_step":null,"prompted":false,"status":"restricted"}"#
+    )
     #expect(sessionController.currentCameraState().permissionState == .restricted)
 }
 
@@ -233,7 +239,10 @@ func routerReturnsStoredPermissionRequestResultForDeniedRequest() {
     )
 
     #expect(response.statusCode == 200)
-    #expect(String(decoding: response.body, as: UTF8.self) == #"{"prompted":false,"status":"denied"}"#)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"message":null,"next_step":null,"prompted":false,"status":"denied"}"#
+    )
     #expect(sessionController.currentCameraState().permissionState == .denied)
 }
 
@@ -258,7 +267,10 @@ func localHTTPServerReturnsStoredPermissionRequestResultForAuthorizedRequest() a
     let httpResponse = try #require(response as? HTTPURLResponse)
 
     #expect(httpResponse.statusCode == 200)
-    #expect(String(decoding: data, as: UTF8.self) == #"{"prompted":false,"status":"denied"}"#)
+    #expect(
+        String(decoding: data, as: UTF8.self) ==
+        #"{"message":null,"next_step":null,"prompted":false,"status":"denied"}"#
+    )
     #expect(sessionController.currentCameraState().permissionState == .denied)
 }
 

--- a/tests/CameraBridgeAppTests/CameraBridgeAppModelTests.swift
+++ b/tests/CameraBridgeAppTests/CameraBridgeAppModelTests.swift
@@ -1,18 +1,25 @@
 import CameraBridgeClientSwift
+import CameraBridgeSupport
 import Foundation
 import Testing
 @testable import CameraBridgeApp
 
 @Test
 @MainActor
-func stoppedServiceStateShowsLocalPermissionGuidance() async {
+func stoppedServiceStateShowsLocalPermissionGuidanceAndDeveloperInfo() async {
     let client = FakeCameraBridgeAppClient()
     await client.setServiceIsRunning(false)
     let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .notDetermined)
+    let configurationStore = FakeRuntimeConfigurationStore(
+        configuration: .init(host: "127.0.0.1", port: 9100)
+    )
+    let runtimeInfoStore = FakeRuntimeInfoStore(runtimeInfo: nil)
     let model = CameraBridgeAppModel(
         client: client,
+        runtimeConfigurationStore: configurationStore,
+        runtimeInfoStore: runtimeInfoStore,
         permissionController: permissionController,
-        serviceLauncher: FakeServiceLauncher()
+        serviceController: FakeServiceController()
     )
 
     await model.refreshNow()
@@ -25,79 +32,73 @@ func stoppedServiceStateShowsLocalPermissionGuidance() async {
         "Request camera access from CameraBridge, then start the local service to finish onboarding."
     )
     #expect(model.canStartService)
+    #expect(!model.canStopService)
     #expect(model.canRequestCameraAccess)
-    #expect(model.lastErrorMessage == nil)
+    #expect(model.developerBaseURL == "http://127.0.0.1:9100")
 }
 
-@Test(arguments: [
-    (
-        CameraBridgePermissionStatus.notDetermined,
-        "Camera access setup is incomplete",
-        "Request camera access from CameraBridge to continue."
-    ),
-    (
-        CameraBridgePermissionStatus.restricted,
-        "Camera access is unavailable",
-        "Camera access is restricted on this Mac and cannot be granted from CameraBridge."
-    ),
-    (
-        CameraBridgePermissionStatus.denied,
-        "Camera access is unavailable",
-        "Camera access was denied. Re-enable it in System Settings > Privacy & Security > Camera."
-    ),
-    (
-        CameraBridgePermissionStatus.authorized,
-        "CameraBridge is ready",
-        "The service is running and camera access is available."
-    ),
-])
+@Test
 @MainActor
-func runningServiceShowsAppLocalPermissionGuidance(
-    permissionStatus: CameraBridgePermissionStatus,
-    expectedSummary: String,
-    expectedGuidance: String
-) async {
+func runningManagedServiceShowsReadyStateAndAllowsStop() async {
     let client = FakeCameraBridgeAppClient()
     await client.setServiceIsRunning(true)
-    let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: permissionStatus)
+    let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .authorized)
+    let runtimeInfoStore = FakeRuntimeInfoStore(
+        runtimeInfo: .init(
+            pid: 42,
+            host: "127.0.0.1",
+            port: 9101,
+            tokenFileURL: URL(fileURLWithPath: "/tmp/auth-token"),
+            logFileURL: URL(fileURLWithPath: "/tmp/camd.log"),
+            capturesDirectoryURL: URL(fileURLWithPath: "/tmp/Captures", isDirectory: true),
+            ownership: .appManaged
+        )
+    )
+    let serviceController = FakeServiceController(state: .runningManaged)
     let model = CameraBridgeAppModel(
         client: client,
+        runtimeConfigurationStore: FakeRuntimeConfigurationStore(configuration: .init(host: "127.0.0.1", port: 9101)),
+        runtimeInfoStore: runtimeInfoStore,
         permissionController: permissionController,
-        serviceLauncher: FakeServiceLauncher()
+        serviceController: serviceController
     )
 
     await model.refreshNow()
 
     #expect(model.serviceStatusTitle == "Running")
-    #expect(model.permissionStatusTitle == permissionStatusTitle(permissionStatus))
-    #expect(model.statusSummaryTitle == expectedSummary)
-    #expect(model.guidanceMessage == expectedGuidance)
+    #expect(model.statusSummaryTitle == "CameraBridge is ready")
+    #expect(model.guidanceMessage == "The managed CameraBridge service is running and camera access is available.")
+    #expect(!model.canStartService)
+    #expect(model.canStopService)
+    #expect(model.developerBaseURL == "http://127.0.0.1:9101")
+    #expect(model.developerTokenPath == "/tmp/auth-token")
 }
 
 @Test
 @MainActor
-func startServiceFailurePreservesLocalPermissionState() async {
+func runningExternalServiceShowsExternalStateAndDisablesStop() async {
     let client = FakeCameraBridgeAppClient()
-    await client.setServiceIsRunning(false)
-    let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .notDetermined)
-    let launcher = FakeServiceLauncher()
-    launcher.error = CameraBridgeServiceLaunchError.failedToStartService
+    await client.setServiceIsRunning(true)
+    let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .authorized)
+    let serviceController = FakeServiceController(state: .runningExternal)
     let model = CameraBridgeAppModel(
         client: client,
+        runtimeConfigurationStore: FakeRuntimeConfigurationStore(configuration: .init(host: "127.0.0.1", port: 8731)),
+        runtimeInfoStore: FakeRuntimeInfoStore(runtimeInfo: nil),
         permissionController: permissionController,
-        serviceLauncher: launcher
+        serviceController: serviceController
     )
 
-    await model.startServiceNow()
+    await model.refreshNow()
 
-    #expect(model.serviceStatusTitle == "Needs Attention")
-    #expect(model.permissionStatusTitle == "Not Determined")
+    #expect(model.serviceStatusTitle == "Running (External)")
+    #expect(model.statusSummaryTitle == "External CameraBridge service detected")
+    #expect(!model.canStartService)
+    #expect(!model.canStopService)
     #expect(
         model.guidanceMessage ==
-        "Request camera access from CameraBridge, then start the local service to finish onboarding."
+        "A local CameraBridge service is already running outside this app and camera access is available."
     )
-    #expect(model.lastErrorMessage == "Service did not become healthy after launch")
-    #expect(model.canStartService)
 }
 
 @Test
@@ -106,11 +107,13 @@ func startServiceDisablesActionWhileLaunchIsInFlight() async {
     let client = FakeCameraBridgeAppClient()
     await client.setServiceIsRunning(false)
     let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .authorized)
-    let launcher = FakeServiceLauncher()
+    let controller = FakeServiceController()
     let model = CameraBridgeAppModel(
         client: client,
+        runtimeConfigurationStore: FakeRuntimeConfigurationStore(configuration: .init()),
+        runtimeInfoStore: FakeRuntimeInfoStore(runtimeInfo: nil),
         permissionController: permissionController,
-        serviceLauncher: launcher
+        serviceController: controller
     )
 
     let task = Task {
@@ -123,11 +126,46 @@ func startServiceDisablesActionWhileLaunchIsInFlight() async {
     #expect(!model.canStartService)
 
     await client.setServiceIsRunning(true)
-    launcher.finish()
+    controller.state = .runningManaged
+    controller.finishStart()
     await task.value
 
     #expect(model.serviceStatusTitle == "Running")
-    #expect(!model.canRequestCameraAccess)
+    #expect(model.canStopService)
+}
+
+@Test
+@MainActor
+func stopServiceTransitionsThroughStoppingAndStopsManagedService() async {
+    let client = FakeCameraBridgeAppClient()
+    await client.setServiceIsRunning(true)
+    let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .authorized)
+    let controller = FakeServiceController(state: .runningManaged)
+    let model = CameraBridgeAppModel(
+        client: client,
+        runtimeConfigurationStore: FakeRuntimeConfigurationStore(configuration: .init()),
+        runtimeInfoStore: FakeRuntimeInfoStore(runtimeInfo: nil),
+        permissionController: permissionController,
+        serviceController: controller
+    )
+
+    await model.refreshNow()
+    let task = Task {
+        await model.stopServiceNow()
+    }
+    await Task.yield()
+
+    #expect(model.serviceStatusTitle == "Stopping")
+    #expect(model.statusSummaryTitle == "CameraBridge is stopping")
+
+    await client.setServiceIsRunning(false)
+    controller.state = .stopped
+    controller.finishStop()
+    await task.value
+
+    #expect(model.serviceStatusTitle == "Stopped")
+    #expect(model.canStartService)
+    #expect(!model.canStopService)
 }
 
 @Test
@@ -138,8 +176,10 @@ func permissionRequestDisablesActionWhilePromptIsInFlightAndSyncsAuthorizedState
     let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .notDetermined)
     let model = CameraBridgeAppModel(
         client: client,
+        runtimeConfigurationStore: FakeRuntimeConfigurationStore(configuration: .init()),
+        runtimeInfoStore: FakeRuntimeInfoStore(runtimeInfo: nil),
         permissionController: permissionController,
-        serviceLauncher: FakeServiceLauncher()
+        serviceController: FakeServiceController(state: .runningManaged)
     )
 
     await model.refreshNow()
@@ -157,23 +197,8 @@ func permissionRequestDisablesActionWhilePromptIsInFlightAndSyncsAuthorizedState
 
     #expect(model.permissionStatusTitle == "Authorized")
     #expect(model.statusSummaryTitle == "CameraBridge is ready")
-    #expect(model.guidanceMessage == "The service is running and camera access is available.")
-    #expect(model.lastErrorMessage == nil)
+    #expect(model.guidanceMessage == "The managed CameraBridge service is running and camera access is available.")
     #expect(permissionController.requestCount == 1)
-    #expect(!model.canRequestCameraAccess)
-}
-
-private func permissionStatusTitle(_ status: CameraBridgePermissionStatus) -> String {
-    switch status {
-    case .notDetermined:
-        return "Not Determined"
-    case .restricted:
-        return "Restricted"
-    case .denied:
-        return "Denied"
-    case .authorized:
-        return "Authorized"
-    }
 }
 
 private actor FakeCameraBridgeAppClient: CameraBridgeAppClient {
@@ -185,6 +210,22 @@ private actor FakeCameraBridgeAppClient: CameraBridgeAppClient {
 
     func serviceIsRunning() async -> Bool {
         isRunning
+    }
+}
+
+private struct FakeRuntimeConfigurationStore: CameraBridgeRuntimeConfigurationReading {
+    var configuration: CameraBridgeRuntimeConfiguration
+
+    func loadConfiguration() throws -> CameraBridgeRuntimeConfiguration {
+        configuration
+    }
+}
+
+private struct FakeRuntimeInfoStore: CameraBridgeRuntimeInfoReading {
+    var runtimeInfo: CameraBridgeRuntimeInfo?
+
+    func loadRuntimeInfo() throws -> CameraBridgeRuntimeInfo? {
+        runtimeInfo
     }
 }
 
@@ -222,22 +263,48 @@ private final class FakeCameraBridgeAppPermissionController: CameraBridgeAppPerm
 }
 
 @MainActor
-private final class FakeServiceLauncher: CameraBridgeServiceLaunching {
-    var error: Error?
-    private var continuation: CheckedContinuation<Void, Never>?
+private final class FakeServiceController: CameraBridgeServiceControlling {
+    var state: CameraBridgeManagedServiceState
+    var startError: Error?
+    var stopError: Error?
+    private var startContinuation: CheckedContinuation<Void, Never>?
+    private var stopContinuation: CheckedContinuation<Void, Never>?
+
+    init(state: CameraBridgeManagedServiceState = .stopped) {
+        self.state = state
+    }
 
     func startIfNeeded() async throws {
-        if let error {
-            throw error
+        if let startError {
+            throw startError
         }
 
         await withCheckedContinuation { continuation in
-            self.continuation = continuation
+            startContinuation = continuation
         }
     }
 
-    func finish() {
-        continuation?.resume()
-        continuation = nil
+    func stopIfManaged() async throws {
+        if let stopError {
+            throw stopError
+        }
+
+        await withCheckedContinuation { continuation in
+            stopContinuation = continuation
+        }
+    }
+
+    func currentManagementState() async -> CameraBridgeManagedServiceState {
+        state
+    }
+
+    func finishStart() {
+        startContinuation?.resume()
+        startContinuation = nil
+    }
+
+    func finishStop() {
+        stopContinuation?.resume()
+        stopContinuation = nil
     }
 }

--- a/tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift
+++ b/tests/CameraBridgeClientSwiftTests/CameraBridgeClientRequestTests.swift
@@ -59,7 +59,7 @@ func permissionRequestSendsBearerTokenAndEmptyJSONBody() async throws {
         transport: { request in
             await recorder.record(request)
             return (
-                Data(#"{"prompted":false,"status":"authorized"}"#.utf8),
+                Data(#"{"prompted":false,"status":"authorized","message":null,"next_step":null}"#.utf8),
                 makeHTTPResponse(for: request, statusCode: 200)
             )
         }
@@ -68,7 +68,7 @@ func permissionRequestSendsBearerTokenAndEmptyJSONBody() async throws {
     let result = try await client.requestPermission()
     let recordedRequest = await recorder.currentRequest()
 
-    #expect(result == .init(status: .authorized, prompted: false))
+    #expect(result == .init(status: .authorized, prompted: false, message: nil, nextStep: nil))
     #expect(recordedRequest?.method == "POST")
     #expect(recordedRequest?.url == "http://127.0.0.1:8731/v1/permissions/request")
     #expect(recordedRequest?.authorization == "Bearer test-token")
@@ -77,24 +77,25 @@ func permissionRequestSendsBearerTokenAndEmptyJSONBody() async throws {
 }
 
 @Test
-func permissionRequestSurfacesUndecidedPermissionGuidance() async {
+func permissionRequestReturnsGuidedNextStepForUndecidedPermission() async throws {
     let client = CameraBridgeClient(
         tokenProvider: { nil },
         transport: { request in
             (
-                Data(#"{"error":{"code":"invalid_state","message":"Camera permission must be requested from CameraBridgeApp"}}"#.utf8),
-                makeHTTPResponse(for: request, statusCode: 409)
+                Data(#"{"prompted":false,"status":"not_determined","message":"Open CameraBridgeApp to request camera access.","next_step":{"kind":"open_camera_bridge_app"}}"#.utf8),
+                makeHTTPResponse(for: request, statusCode: 200)
             )
         }
     )
 
-    await #expect(throws: CameraBridgeClientError.requestFailed(
-        statusCode: 409,
-        code: "invalid_state",
-        message: "Camera permission must be requested from CameraBridgeApp"
-    )) {
-        _ = try await client.requestPermission()
-    }
+    let result = try await client.requestPermission()
+
+    #expect(result == .init(
+        status: .notDetermined,
+        prompted: false,
+        message: "Open CameraBridgeApp to request camera access.",
+        nextStep: .init(kind: .openCameraBridgeApp)
+    ))
 }
 
 @Test

--- a/tests/CameraBridgeDaemonTests/CameraBridgeDaemonTests.swift
+++ b/tests/CameraBridgeDaemonTests/CameraBridgeDaemonTests.swift
@@ -74,6 +74,43 @@ func daemonNonPromptingPermissionRequesterIgnoresStalePermissionStateFiles() thr
     #expect(try String(contentsOf: staleFileURL, encoding: .utf8) == "authorized")
 }
 
+@Test
+func serverConfigurationUsesStoredRuntimeConfigurationWhenHostAndPortAreNotProvided() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let runtimeConfigurationStore = DefaultCameraBridgeRuntimeConfigurationStore(baseDirectoryURL: directoryURL)
+    try runtimeConfigurationStore.saveConfiguration(.init(host: "127.0.0.1", port: 9101))
+
+    let configuration = ServerConfiguration(runtimeConfigurationStore: runtimeConfigurationStore)
+
+    #expect(configuration.host == "127.0.0.1")
+    #expect(configuration.port == 9101)
+}
+
+@Test
+func daemonRuntimeInfoUsesRuntimeOwnershipAndStablePaths() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let authTokenStore = DefaultCameraBridgeAuthTokenStore(baseDirectoryURL: directoryURL)
+    let token = try authTokenStore.loadOrCreateToken()
+    #expect(!token.isEmpty)
+
+    let daemon = CameraBridgeDaemon(configuration: .init(host: "127.0.0.1", port: 9102))
+    let runtimeInfo = try daemon.runtimeInfo(
+        boundPort: 9102,
+        authTokenStore: authTokenStore
+    )
+
+    #expect(runtimeInfo.host == "127.0.0.1")
+    #expect(runtimeInfo.port == 9102)
+    #expect(runtimeInfo.tokenFileURL.path.hasSuffix("auth-token"))
+    #expect(runtimeInfo.logFileURL.path.hasSuffix("Logs/camd.log"))
+    #expect(runtimeInfo.capturesDirectoryURL.path.hasSuffix("Captures"))
+    #expect(runtimeInfo.ownership == .external)
+}
+
 private func makeTemporaryDirectoryURL() -> URL {
     FileManager.default.temporaryDirectory
         .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/tests/CameraBridgeSupportTests/CameraBridgeSupportTests.swift
+++ b/tests/CameraBridgeSupportTests/CameraBridgeSupportTests.swift
@@ -87,6 +87,63 @@ func permissionStateStoreRejectsInvalidStoredState() throws {
     }
 }
 
+@Test
+func runtimeConfigurationStoreDefaultsToLocalhostConfigurationWhenFileIsMissing() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let store = DefaultCameraBridgeRuntimeConfigurationStore(baseDirectoryURL: directoryURL)
+
+    #expect(try store.loadConfiguration() == .init())
+}
+
+@Test
+func runtimeConfigurationStoreSavesAndReloadsConfiguration() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let store = DefaultCameraBridgeRuntimeConfigurationStore(baseDirectoryURL: directoryURL)
+    let configuration = CameraBridgeRuntimeConfiguration(host: "127.0.0.1", port: 9123)
+
+    try store.saveConfiguration(configuration)
+
+    #expect(try store.loadConfiguration() == configuration)
+    #expect(FileManager.default.fileExists(atPath: try store.runtimeConfigurationURL().path))
+}
+
+@Test
+func runtimeInfoStoreReturnsNilWhenFileIsMissing() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let store = DefaultCameraBridgeRuntimeInfoStore(baseDirectoryURL: directoryURL)
+
+    #expect(try store.loadRuntimeInfo() == nil)
+}
+
+@Test
+func runtimeInfoStoreSavesReloadsAndClearsRuntimeInfo() throws {
+    let directoryURL = makeTemporaryDirectoryURL()
+    defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+    let store = DefaultCameraBridgeRuntimeInfoStore(baseDirectoryURL: directoryURL)
+    let runtimeInfo = CameraBridgeRuntimeInfo(
+        pid: 42,
+        host: "127.0.0.1",
+        port: 8731,
+        tokenFileURL: directoryURL.appendingPathComponent("auth-token", isDirectory: false),
+        logFileURL: directoryURL.appendingPathComponent("Logs/camd.log", isDirectory: false),
+        capturesDirectoryURL: directoryURL.appendingPathComponent("Captures", isDirectory: true),
+        ownership: .appManaged
+    )
+
+    try store.saveRuntimeInfo(runtimeInfo)
+    #expect(try store.loadRuntimeInfo() == runtimeInfo)
+
+    try store.clearRuntimeInfo()
+    #expect(try store.loadRuntimeInfo() == nil)
+}
+
 private func makeTemporaryDirectoryURL() -> URL {
     FileManager.default.temporaryDirectory
         .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
## Summary
- replace the old permission-request error story with a guided 200 OK API response and typed Swift client support
- make the packaged CameraBridgeApp flow explicitly app-supervised with managed/external service states, stop semantics, runtime metadata, and surfaced developer info
- document the pre-launch v1 contract across README, API docs, quick start, release-readiness, architecture, roadmap, and daemon/app readmes

## Files Changed
- app lifecycle and menu behavior in apps/CameraBridgeApp
- daemon bootstrap/runtime config and runtime metadata in apps/camd and packages/CameraBridgeSupport
- permission route and client models in packages/CameraBridgeAPI and packages/CameraBridgeClientSwift
- tests for API, app, daemon, support, and Swift client behavior
- repo docs for onboarding, API contract, and release-readiness

## How It Was Tested
- swift test

## Intentionally Deferred
- launch-at-login and installer/distribution work
- new lifecycle HTTP endpoints
- browser/CORS work
- compatibility shims for the old permission-request semantics

Closes #100
Closes #101
Closes #102
Closes #103
Closes #104