### PR TITLE
Define the external release and runtime contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release CameraBridge
+
+on:
+  push:
+    tags:
+      - "v0.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version tag, for example v0.1.0"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: macos-14
+    env:
+      CAMERABRIDGE_SIGNING_IDENTITY: ${{ secrets.CAMERABRIDGE_SIGNING_IDENTITY }}
+      CAMERABRIDGE_NOTARY_ISSUER_ID: ${{ secrets.CAMERABRIDGE_NOTARY_ISSUER_ID }}
+      CAMERABRIDGE_NOTARY_KEY_ID: ${{ secrets.CAMERABRIDGE_NOTARY_KEY_ID }}
+      CAMERABRIDGE_NOTARY_PRIVATE_KEY: ${{ secrets.CAMERABRIDGE_NOTARY_PRIVATE_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve release version
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "CAMERABRIDGE_VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
+          else
+            echo "CAMERABRIDGE_VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Import Developer ID certificate
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.CAMERABRIDGE_DEVELOPER_ID_APPLICATION_CERT_P12_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.CAMERABRIDGE_DEVELOPER_ID_APPLICATION_CERT_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.CAMERABRIDGE_CI_KEYCHAIN_PASSWORD }}
+        run: |
+          CERTIFICATE_PATH="$RUNNER_TEMP/camerabridge-developer-id.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/camerabridge-release.keychain-db"
+          echo "$CERTIFICATE_BASE64" | base64 -D > "$CERTIFICATE_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security find-identity -p codesigning -v "$KEYCHAIN_PATH"
+
+      - name: Build signed release artifacts
+        run: |
+          chmod +x scripts/release/package-app-bundle.sh scripts/release/create-release-artifacts.sh
+          scripts/release/create-release-artifacts.sh \
+            --version "$CAMERABRIDGE_VERSION" \
+            --output-dir "$RUNNER_TEMP/release"
+
+      - name: Publish GitHub Release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.CAMERABRIDGE_VERSION }}
+          generate_release_notes: true
+          files: |
+            ${{ runner.temp }}/release/CameraBridgeApp-${{ env.CAMERABRIDGE_VERSION }}-macos.zip
+            ${{ runner.temp }}/release/CameraBridgeApp-${{ env.CAMERABRIDGE_VERSION }}-macos.zip.sha256

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .build/
+dist/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ metadata. It also includes the minimal menu bar app shell, the Python
 first-capture example, and the core v1 docs needed to run that flow end to end.
 Preview transport and broader client surfaces remain deferred until after v1.
 
+CameraBridge product releases start at `v0.x`. The supported localhost API
+surface remains `/v1`.
+
 In the shipped v1 permission flow, `CameraBridgeApp` owns the macOS camera
 permission prompt. `camd` reads live AVFoundation permission status directly
 for `/v1/permissions`, `/v1/permissions/request`, and the session-start
@@ -80,6 +83,8 @@ CameraBridge v1 keeps the trust model intentionally narrow:
 
 - The documents below describe the shipped first-capture v1 slice and the
   deferred work that remains outside that slice.
+- [Install Guide](docs/install.md)
+- [Compatibility](docs/compatibility.md)
 - [Quick Start](docs/quick-start.md)
 - [Release Readiness](docs/release-readiness.md)
 - [Architecture Overview](docs/architecture-overview.md)
@@ -101,6 +106,23 @@ swift build
 swift test
 ```
 
+## External Install
+
+The supported external install flow uses signed GitHub Release artifacts, not a
+source checkout. Download the current `CameraBridgeApp-v0.x.y-macos.zip`,
+verify the checksum, move `CameraBridgeApp.app` to `/Applications`, and launch
+the app from there.
+
+Use these docs as the source of truth for external adopters:
+
+- [Install Guide](docs/install.md)
+- [Compatibility](docs/compatibility.md)
+
+`/Applications/CameraBridgeApp.app` is the supported user install target for
+the packaged flow. It is not the downstream runtime-discovery contract.
+External apps should rely on the localhost service and documented support-path
+artifacts at runtime.
+
 Package the local menu bar app bundle with:
 
 ```bash
@@ -113,6 +135,9 @@ can survive rebuilds more predictably than plain cdhash-only ad-hoc signing.
 If your machine previously granted camera access to an older packaged build,
 re-request permission once after adopting the newer packaging flow so macOS can
 record the updated local code requirement.
+
+For published external releases, use the signed and notarized GitHub Release
+artifact path instead of this local contributor packaging flow.
 
 The packaged app bundle, including the bundled `camd` executable, is written to:
 

--- a/apps/CameraBridgeApp/README.md
+++ b/apps/CameraBridgeApp/README.md
@@ -28,6 +28,10 @@ The packaged app is also the supported lifecycle manager for the bundled daemon:
 
 ## Local Packaging
 
+For external adopters, the supported install path is the signed GitHub Release
+artifact flow documented in [docs/install.md](../../docs/install.md). This
+section remains the contributor-focused local packaging path.
+
 Package a local `.app` bundle with:
 
 ```bash
@@ -77,6 +81,10 @@ Token: ~/Library/Application Support/CameraBridge/auth-token
 Log: ~/Library/Application Support/CameraBridge/Logs/camd.log
 Captures: ~/Library/Application Support/CameraBridge/Captures/
 ```
+
+For the supported packaged flow, external apps should rely on the localhost
+service and support-path artifacts above at runtime. They should not depend on
+hardcoded app-bundle path discovery.
 
 ## Manual Verification
 

--- a/apps/CameraBridgeApp/scripts/package-app.sh
+++ b/apps/CameraBridgeApp/scripts/package-app.sh
@@ -3,35 +3,10 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
-APP_NAME="CameraBridgeApp"
-DAEMON_NAME="camd"
-APP_IDENTIFIER="io.camerabridge.CameraBridgeApp"
-DAEMON_IDENTIFIER="io.camerabridge.camd"
-APP_REQUIREMENT="designated => identifier \"$APP_IDENTIFIER\""
-DAEMON_REQUIREMENT="designated => identifier \"$DAEMON_IDENTIFIER\""
 
 cd "$ROOT_DIR"
-
-swift build --product "$APP_NAME"
-swift build --product "$DAEMON_NAME"
-
 BIN_DIR="$(swift build --show-bin-path)"
-APP_DIR="$BIN_DIR/$APP_NAME.app"
-CONTENTS_DIR="$APP_DIR/Contents"
-MACOS_DIR="$CONTENTS_DIR/MacOS"
-RESOURCES_DIR="$CONTENTS_DIR/Resources"
-
-rm -rf "$APP_DIR"
-mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
-
-cp "$BIN_DIR/$APP_NAME" "$MACOS_DIR/$APP_NAME"
-cp "$ROOT_DIR/apps/CameraBridgeApp/Info.plist" "$CONTENTS_DIR/Info.plist"
-cp "$BIN_DIR/$DAEMON_NAME" "$RESOURCES_DIR/$DAEMON_NAME"
-chmod +x "$RESOURCES_DIR/$DAEMON_NAME"
-
-codesign --force --sign - -i "$DAEMON_IDENTIFIER" -r="$DAEMON_REQUIREMENT" \
-    "$RESOURCES_DIR/$DAEMON_NAME" >/dev/null
-codesign --force --sign - -i "$APP_IDENTIFIER" -r="$APP_REQUIREMENT" \
-    "$APP_DIR" >/dev/null
-
-echo "Packaged $APP_DIR"
+"$ROOT_DIR/scripts/release/package-app-bundle.sh" \
+    --build-configuration debug \
+    --output-dir "$BIN_DIR" \
+    --signing-mode adhoc

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,57 @@
+# CameraBridge Compatibility
+
+This document defines the supported external runtime contract for pre-1.0
+CameraBridge adopters.
+
+## Product And API Versioning
+
+- CameraBridge product releases start at `v0.x`
+- the supported localhost API surface remains `/v1`
+- downstream apps should pin to an explicit tested CameraBridge release or a
+  narrow tested `v0.x` range
+- broad “latest” dependencies are not supported
+
+## Supported Runtime Contract
+
+The supported packaged-flow defaults are:
+
+- endpoint: `http://127.0.0.1:8731`
+- health signal: `GET /health` returning `200 OK`
+- permission signals:
+  - `GET /v1/permissions`
+  - `POST /v1/permissions/request`
+- auth token path:
+  - `~/Library/Application Support/CameraBridge/auth-token`
+
+For this slice, external adopters should rely on those runtime signals and
+support-directory artifacts. They should not rely on discovering CameraBridge
+by app bundle path, bundle identifier inspection, or direct daemon process
+management.
+
+## Availability And Readiness
+
+- CameraBridge is **available** when the localhost service responds at
+  `http://127.0.0.1:8731/health`
+- CameraBridge is **ready for capture** when the service is available and the
+  permission/session preconditions exposed by the published API are satisfied
+- if permission is still undecided, downstream apps should expect the guided
+  `POST /v1/permissions/request` response and direct the user to
+  `CameraBridgeApp`
+
+## Packaged Flow Assumptions
+
+- `CameraBridgeApp` is the supported manager of bundled `camd`
+- the service is not guaranteed to be available unless the app is running and
+  the user has started the service
+- downstream apps must not assume the daemon persists independently of the app
+  in the supported packaged flow
+
+## Install Path Policy
+
+`/Applications/CameraBridgeApp.app` is the supported install target for user
+guidance, support, and manual verification.
+
+That path is not the downstream runtime compatibility guarantee. Downstream
+code should not hardcode the bundle path as a discovery mechanism. If an
+integrating app wants to help the user find or launch CameraBridge, it should
+do so as a UX convenience rather than as part of the runtime contract.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,93 @@
+# CameraBridge Install Guide
+
+This guide describes the supported external installation flow for CameraBridge
+as a standalone macOS dependency.
+
+## Supported Install Flow
+
+The supported external install target is:
+
+```text
+/Applications/CameraBridgeApp.app
+```
+
+That path is a support and documentation convention for the packaged flow. It
+is not the downstream runtime-discovery contract. External apps should rely on
+the localhost service and documented support-directory artifacts at runtime, not
+on finding or inspecting the app bundle path.
+
+## Install
+
+1. Download the current signed release assets from GitHub Releases:
+   - `CameraBridgeApp-v0.x.y-macos.zip`
+   - `CameraBridgeApp-v0.x.y-macos.zip.sha256`
+2. Verify the checksum before installation:
+
+```bash
+shasum -a 256 CameraBridgeApp-v0.x.y-macos.zip
+cat CameraBridgeApp-v0.x.y-macos.zip.sha256
+```
+
+The output lines should match exactly.
+
+3. Unzip the archive.
+4. Move `CameraBridgeApp.app` into `/Applications/`.
+5. Launch `CameraBridgeApp.app` from `/Applications`.
+6. From the menu bar app, click `Start CameraBridge Service`.
+7. If prompted, click `Request Camera Access` and complete the macOS camera
+   permission prompt.
+
+## Runtime Expectations
+
+In the supported packaged flow:
+
+- `CameraBridgeApp` is the manager of the bundled `camd`
+- the service is not guaranteed to be available unless the app is running and
+  the user has started the service
+- `Start CameraBridge Service` launches the bundled daemon
+- `Stop CameraBridge Service` stops the app-managed daemon
+- `Quit CameraBridge` stops the managed daemon before the app exits
+
+External apps should treat CameraBridge as an external local service that may
+require the user to launch the app first.
+
+## Upgrade
+
+1. Quit `CameraBridgeApp`.
+2. Download the newer signed release zip and verify its checksum.
+3. Replace `/Applications/CameraBridgeApp.app` with the newer app bundle.
+4. Relaunch `CameraBridgeApp`.
+
+Upgrades preserve the existing support directory by default:
+
+```text
+~/Library/Application Support/CameraBridge/
+```
+
+That means existing token, logs, runtime metadata, and captures remain in
+place across upgrades unless explicitly removed.
+
+## Uninstall
+
+Default uninstall:
+
+1. Quit `CameraBridgeApp`.
+2. Remove `/Applications/CameraBridgeApp.app`.
+
+Default uninstall leaves support files in place:
+
+```text
+~/Library/Application Support/CameraBridge/
+```
+
+Full uninstall:
+
+1. Quit `CameraBridgeApp`.
+2. Remove `/Applications/CameraBridgeApp.app`.
+3. Remove `~/Library/Application Support/CameraBridge/` if you also want to
+   delete:
+   - `auth-token`
+   - `runtime-configuration.json`
+   - `runtime-info.json`
+   - `Logs/`
+   - `Captures/`

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,5 +1,10 @@
 # CameraBridge Quick Start
 
+If you are adopting CameraBridge as an external dependency, start with the
+[Install Guide](./install.md) and [Compatibility](./compatibility.md). This
+quick start remains the repo-local source-build path for contributors and local
+verification.
+
 This guide walks through the current working v1 loop on macOS:
 
 1. build the repo
@@ -175,6 +180,8 @@ curl -s -X POST http://127.0.0.1:8731/v1/session/stop \
 
 ## Next References
 
+- [Install Guide](./install.md)
+- [Compatibility](./compatibility.md)
 - [API v1 Contract](./api/v1.md)
 - [Release Readiness](./release-readiness.md)
 - [CameraBridgeApp README](../apps/CameraBridgeApp/README.md)

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -11,6 +11,20 @@ This validation requires:
 
 It is intentionally manual. CI should continue to avoid hardware dependencies.
 
+## External Artifact Validation
+
+Before treating a GitHub Release as ready for external adopters, validate the
+published artifact path as well as the repo-local smoke test.
+
+Expected checks:
+
+- download the published `CameraBridgeApp-v0.x.y-macos.zip` asset from GitHub
+  Releases
+- verify the published checksum matches the downloaded zip
+- install the downloaded app bundle into `/Applications`
+- confirm Gatekeeper accepts launch of the notarized app
+- confirm the installed app can complete the packaged-flow smoke test
+
 ## First-Capture Smoke Test
 
 ### Goal
@@ -163,6 +177,10 @@ release:
 - [ ] Camera device model or built-in camera noted
 - [ ] `swift build` passed
 - [ ] `swift test` passed
+- [ ] Published GitHub Release zip downloaded successfully
+- [ ] Published checksum matched the downloaded zip
+- [ ] Installed app bundle launched successfully from `/Applications`
+- [ ] Gatekeeper accepted the notarized app
 - [ ] Packaged `CameraBridgeApp.app` launched successfully
 - [ ] `camd` started from the app and reported healthy on `127.0.0.1:8731`
 - [ ] Auth token file existed at `~/Library/Application Support/CameraBridge/auth-token`

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -128,6 +128,29 @@ Recommended labels:
 - `hardware-needed`
 - `agent-safe`
 
+## Release Workflow
+
+External CameraBridge releases should be published from GitHub tags, not from a
+local manually distributed app bundle.
+
+For the external release path:
+
+1. Tag the release with `v0.x.y`.
+2. Let the macOS release workflow build, sign, notarize, staple, zip, and
+   checksum the app bundle.
+3. Publish the signed artifact and checksum to GitHub Releases.
+4. Treat the GitHub Release assets as the source of truth for external adopters.
+
+Required GitHub Actions secrets:
+
+- `CAMERABRIDGE_DEVELOPER_ID_APPLICATION_CERT_P12_BASE64`
+- `CAMERABRIDGE_DEVELOPER_ID_APPLICATION_CERT_PASSWORD`
+- `CAMERABRIDGE_CI_KEYCHAIN_PASSWORD`
+- `CAMERABRIDGE_SIGNING_IDENTITY`
+- `CAMERABRIDGE_NOTARY_KEY_ID`
+- `CAMERABRIDGE_NOTARY_ISSUER_ID`
+- `CAMERABRIDGE_NOTARY_PRIVATE_KEY`
+
 ## Definition Of Ready
 
 Before starting implementation, the issue should answer:

--- a/scripts/release/create-release-artifacts.sh
+++ b/scripts/release/create-release-artifacts.sh
@@ -1,0 +1,113 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+PACKAGE_SCRIPT="$ROOT_DIR/scripts/release/package-app-bundle.sh"
+
+VERSION="${CAMERABRIDGE_VERSION:-}"
+OUTPUT_DIR="${CAMERABRIDGE_RELEASE_OUTPUT_DIR:-$ROOT_DIR/dist}"
+SIGNING_MODE="${CAMERABRIDGE_RELEASE_SIGNING_MODE:-developer-id}"
+SKIP_NOTARIZATION="${CAMERABRIDGE_SKIP_NOTARIZATION:-0}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  create-release-artifacts.sh --version <v0.x.y> [options]
+
+Options:
+  --version <version>
+  --output-dir <path>
+  --signing-mode <adhoc|developer-id>
+  --skip-notarization
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --signing-mode)
+            SIGNING_MODE="$2"
+            shift 2
+            ;;
+        --skip-notarization)
+            SKIP_NOTARIZATION="1"
+            shift 1
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$VERSION" ]]; then
+    echo "A release version is required" >&2
+    exit 1
+fi
+
+if [[ ! "$VERSION" =~ ^v0\.[0-9]+\.[0-9]+([-.][A-Za-z0-9._-]+)?$ ]]; then
+    echo "Release version must match v0.x.y or a tagged pre-release derived from v0.x.y" >&2
+    exit 1
+fi
+
+if [[ "$SIGNING_MODE" != "adhoc" && "$SIGNING_MODE" != "developer-id" ]]; then
+    echo "Unsupported signing mode: $SIGNING_MODE" >&2
+    exit 1
+fi
+
+ARTIFACT_PREFIX="CameraBridgeApp-${VERSION}-macos"
+STAGE_DIR="$OUTPUT_DIR/stage"
+APP_PATH="$STAGE_DIR/CameraBridgeApp.app"
+NOTARIZATION_ZIP="$OUTPUT_DIR/${ARTIFACT_PREFIX}-notarization.zip"
+RELEASE_ZIP="$OUTPUT_DIR/${ARTIFACT_PREFIX}.zip"
+CHECKSUM_FILE="$OUTPUT_DIR/${ARTIFACT_PREFIX}.zip.sha256"
+
+mkdir -p "$STAGE_DIR"
+rm -f "$NOTARIZATION_ZIP" "$RELEASE_ZIP" "$CHECKSUM_FILE"
+
+"$PACKAGE_SCRIPT" \
+    --build-configuration release \
+    --output-dir "$STAGE_DIR" \
+    --signing-mode "$SIGNING_MODE"
+
+if [[ "$SIGNING_MODE" == "developer-id" && "$SKIP_NOTARIZATION" != "1" ]]; then
+    : "${CAMERABRIDGE_NOTARY_KEY_ID:?CAMERABRIDGE_NOTARY_KEY_ID is required for notarization}"
+    : "${CAMERABRIDGE_NOTARY_ISSUER_ID:?CAMERABRIDGE_NOTARY_ISSUER_ID is required for notarization}"
+    : "${CAMERABRIDGE_NOTARY_PRIVATE_KEY:?CAMERABRIDGE_NOTARY_PRIVATE_KEY is required for notarization}"
+
+    PRIVATE_KEY_FILE="$(mktemp "$OUTPUT_DIR/notary-key.XXXXXX.p8")"
+    trap 'rm -f "$PRIVATE_KEY_FILE"' EXIT
+    printf '%s' "$CAMERABRIDGE_NOTARY_PRIVATE_KEY" > "$PRIVATE_KEY_FILE"
+
+    ditto -c -k --keepParent "$APP_PATH" "$NOTARIZATION_ZIP"
+    xcrun notarytool submit "$NOTARIZATION_ZIP" \
+        --key "$PRIVATE_KEY_FILE" \
+        --key-id "$CAMERABRIDGE_NOTARY_KEY_ID" \
+        --issuer "$CAMERABRIDGE_NOTARY_ISSUER_ID" \
+        --wait
+
+    xcrun stapler staple "$APP_PATH"
+    spctl -a -vv --type exec "$APP_PATH"
+fi
+
+ditto -c -k --keepParent "$APP_PATH" "$RELEASE_ZIP"
+shasum -a 256 "$RELEASE_ZIP" > "$CHECKSUM_FILE"
+
+codesign --verify --strict --verbose=2 "$APP_PATH"
+
+echo "Release app: $APP_PATH"
+echo "Release zip: $RELEASE_ZIP"
+echo "Checksum: $CHECKSUM_FILE"

--- a/scripts/release/package-app-bundle.sh
+++ b/scripts/release/package-app-bundle.sh
@@ -1,0 +1,117 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+APP_NAME="CameraBridgeApp"
+DAEMON_NAME="camd"
+APP_IDENTIFIER="io.camerabridge.CameraBridgeApp"
+DAEMON_IDENTIFIER="io.camerabridge.camd"
+APP_REQUIREMENT="designated => identifier \"$APP_IDENTIFIER\""
+DAEMON_REQUIREMENT="designated => identifier \"$DAEMON_IDENTIFIER\""
+
+BUILD_CONFIGURATION="release"
+OUTPUT_DIR=""
+SIGNING_MODE="adhoc"
+SIGNING_IDENTITY="${CAMERABRIDGE_SIGNING_IDENTITY:-}"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  package-app-bundle.sh [options]
+
+Options:
+  --build-configuration <debug|release>
+  --output-dir <path>
+  --signing-mode <adhoc|developer-id>
+  --signing-identity <identity>
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build-configuration)
+            BUILD_CONFIGURATION="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --signing-mode)
+            SIGNING_MODE="$2"
+            shift 2
+            ;;
+        --signing-identity)
+            SIGNING_IDENTITY="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$BUILD_CONFIGURATION" != "debug" && "$BUILD_CONFIGURATION" != "release" ]]; then
+    echo "Unsupported build configuration: $BUILD_CONFIGURATION" >&2
+    exit 1
+fi
+
+if [[ "$SIGNING_MODE" != "adhoc" && "$SIGNING_MODE" != "developer-id" ]]; then
+    echo "Unsupported signing mode: $SIGNING_MODE" >&2
+    exit 1
+fi
+
+cd "$ROOT_DIR"
+
+swift build --configuration "$BUILD_CONFIGURATION" --product "$APP_NAME"
+swift build --configuration "$BUILD_CONFIGURATION" --product "$DAEMON_NAME"
+
+BIN_DIR="$(swift build --configuration "$BUILD_CONFIGURATION" --show-bin-path)"
+OUTPUT_DIR="${OUTPUT_DIR:-$BIN_DIR}"
+APP_DIR="$OUTPUT_DIR/$APP_NAME.app"
+CONTENTS_DIR="$APP_DIR/Contents"
+MACOS_DIR="$CONTENTS_DIR/MacOS"
+RESOURCES_DIR="$CONTENTS_DIR/Resources"
+
+rm -rf "$APP_DIR"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+
+cp "$BIN_DIR/$APP_NAME" "$MACOS_DIR/$APP_NAME"
+cp "$ROOT_DIR/apps/CameraBridgeApp/Info.plist" "$CONTENTS_DIR/Info.plist"
+cp "$BIN_DIR/$DAEMON_NAME" "$RESOURCES_DIR/$DAEMON_NAME"
+chmod +x "$RESOURCES_DIR/$DAEMON_NAME"
+xattr -cr "$APP_DIR" || true
+
+sign_path() {
+    local target_path="$1"
+    local identifier="$2"
+    local requirement="$3"
+
+    if [[ "$SIGNING_MODE" == "adhoc" ]]; then
+        codesign --force --sign - -i "$identifier" -r="$requirement" \
+            "$target_path" >/dev/null
+        return
+    fi
+
+    if [[ -z "$SIGNING_IDENTITY" ]]; then
+        echo "CAMERABRIDGE_SIGNING_IDENTITY or --signing-identity is required for developer-id signing" >&2
+        exit 1
+    fi
+
+    codesign --force --sign "$SIGNING_IDENTITY" --timestamp --options runtime \
+        -i "$identifier" "$target_path" >/dev/null
+}
+
+sign_path "$RESOURCES_DIR/$DAEMON_NAME" "$DAEMON_IDENTIFIER" "$DAEMON_REQUIREMENT"
+sign_path "$APP_DIR" "$APP_IDENTIFIER" "$APP_REQUIREMENT"
+
+codesign --verify --strict --verbose=2 "$APP_DIR"
+
+echo "Packaged $APP_DIR"


### PR DESCRIPTION
## Summary
- add a release packaging path and macOS GitHub Actions workflow for signed, notarized, versioned CameraBridge app artifacts
- publish external install and compatibility docs that anchor adopters to the localhost service contract instead of bundle-path discovery
- tighten README, quick start, workflow, and release-readiness docs around the packaged lifecycle and external validation path

## Files Changed
- new release scripts in scripts/release and a new .github/workflows/release.yml workflow
- new external-facing docs in docs/install.md and docs/compatibility.md
- README, quick-start, workflow, release-readiness, and app packaging docs

## How It Was Tested
- swift test
- apps/CameraBridgeApp/scripts/package-app.sh
- scripts/release/create-release-artifacts.sh --version v0.0.0-test --signing-mode adhoc --skip-notarization --output-dir /tmp/camerabridge-release-test

## Intentionally Deferred
- no installer package or disk image
- no auto-update mechanism
- no new localhost lifecycle endpoints
- no runtime behavior changes beyond the published release/install contract

Closes #108
Closes #109
Closes #110
Closes #111
Closes #112