### PR TITLE
Pivot CameraBridge releases to a manual maintainer trust model

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release CameraBridge
+name: Validate CameraBridge Release Contract
 
 on:
   push:
@@ -12,58 +12,49 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  release:
-    runs-on: macos-14
+  validate-release-contract:
+    runs-on: ubuntu-latest
     env:
-      CAMERABRIDGE_SIGNING_IDENTITY: ${{ secrets.CAMERABRIDGE_SIGNING_IDENTITY }}
-      CAMERABRIDGE_NOTARY_ISSUER_ID: ${{ secrets.CAMERABRIDGE_NOTARY_ISSUER_ID }}
-      CAMERABRIDGE_NOTARY_KEY_ID: ${{ secrets.CAMERABRIDGE_NOTARY_KEY_ID }}
-      CAMERABRIDGE_NOTARY_PRIVATE_KEY: ${{ secrets.CAMERABRIDGE_NOTARY_PRIVATE_KEY }}
+      CAMERABRIDGE_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Resolve release version
+      - name: Validate release version shape
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            echo "CAMERABRIDGE_VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
-          else
-            echo "CAMERABRIDGE_VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+          if [[ ! "$CAMERABRIDGE_VERSION" =~ ^v0\.[0-9]+\.[0-9]+([-.][A-Za-z0-9._-]+)?$ ]]; then
+            echo "Invalid release version: $CAMERABRIDGE_VERSION" >&2
+            exit 1
           fi
 
-      - name: Import Developer ID certificate
+      - name: Validate release docs exist
+        run: |
+          test -f README.md
+          test -f docs/install.md
+          test -f docs/compatibility.md
+          test -f docs/release-process.md
+          test -f docs/release-readiness.md
+
+      - name: Validate release docs are linked
+        run: |
+          grep -q "docs/install.md" README.md
+          grep -q "docs/compatibility.md" README.md
+          grep -q "docs/release-process.md" README.md
+          grep -q "docs/release-process.md" docs/workflow.md
+
+      - name: Explain manual release model
+        run: |
+          echo "CameraBridge official releases are produced on a trusted maintainer Mac."
+          echo "Run the manual maintainer release process after tagging to create and upload artifacts."
+
+      - name: Verify published release assets
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         env:
-          CERTIFICATE_BASE64: ${{ secrets.CAMERABRIDGE_DEVELOPER_ID_APPLICATION_CERT_P12_BASE64 }}
-          CERTIFICATE_PASSWORD: ${{ secrets.CAMERABRIDGE_DEVELOPER_ID_APPLICATION_CERT_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.CAMERABRIDGE_CI_KEYCHAIN_PASSWORD }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          CERTIFICATE_PATH="$RUNNER_TEMP/camerabridge-developer-id.p12"
-          KEYCHAIN_PATH="$RUNNER_TEMP/camerabridge-release.keychain-db"
-          echo "$CERTIFICATE_BASE64" | base64 -D > "$CERTIFICATE_PATH"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$CERTIFICATE_PATH" -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security list-keychains -d user -s "$KEYCHAIN_PATH"
-          security default-keychain -d user -s "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security find-identity -p codesigning -v "$KEYCHAIN_PATH"
-
-      - name: Build signed release artifacts
-        run: |
-          chmod +x scripts/release/package-app-bundle.sh scripts/release/create-release-artifacts.sh
-          scripts/release/create-release-artifacts.sh \
-            --version "$CAMERABRIDGE_VERSION" \
-            --output-dir "$RUNNER_TEMP/release"
-
-      - name: Publish GitHub Release assets
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.CAMERABRIDGE_VERSION }}
-          generate_release_notes: true
-          files: |
-            ${{ runner.temp }}/release/CameraBridgeApp-${{ env.CAMERABRIDGE_VERSION }}-macos.zip
-            ${{ runner.temp }}/release/CameraBridgeApp-${{ env.CAMERABRIDGE_VERSION }}-macos.zip.sha256
+          ASSET_JSON="$(gh release view "$CAMERABRIDGE_VERSION" --json assets --jq '.assets[].name')"
+          echo "$ASSET_JSON" | grep -x "CameraBridgeApp-${CAMERABRIDGE_VERSION}-macos.zip"
+          echo "$ASSET_JSON" | grep -x "CameraBridgeApp-${CAMERABRIDGE_VERSION}-macos.zip.sha256"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ CameraBridge v1 keeps the trust model intentionally narrow:
   deferred work that remains outside that slice.
 - [Install Guide](docs/install.md)
 - [Compatibility](docs/compatibility.md)
+- [Release Process](docs/release-process.md)
 - [Quick Start](docs/quick-start.md)
 - [Release Readiness](docs/release-readiness.md)
 - [Architecture Overview](docs/architecture-overview.md)
@@ -136,8 +137,9 @@ If your machine previously granted camera access to an older packaged build,
 re-request permission once after adopting the newer packaging flow so macOS can
 record the updated local code requirement.
 
-For published external releases, use the signed and notarized GitHub Release
-artifact path instead of this local contributor packaging flow.
+For published external releases, use the official maintainer-signed and
+maintainer-notarized GitHub Release artifact path instead of this local
+contributor packaging flow.
 
 The packaged app bundle, including the bundled `camd` executable, is written to:
 

--- a/apps/CameraBridgeApp/README.md
+++ b/apps/CameraBridgeApp/README.md
@@ -28,9 +28,10 @@ The packaged app is also the supported lifecycle manager for the bundled daemon:
 
 ## Local Packaging
 
-For external adopters, the supported install path is the signed GitHub Release
-artifact flow documented in [docs/install.md](../../docs/install.md). This
-section remains the contributor-focused local packaging path.
+For external adopters, the supported install path is the official
+maintainer-signed and maintainer-notarized GitHub Release artifact flow
+documented in [docs/install.md](../../docs/install.md). This section remains
+the contributor-focused local packaging path.
 
 Package a local `.app` bundle with:
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,6 +10,8 @@ CameraBridge adopters.
 - downstream apps should pin to an explicit tested CameraBridge release or a
   narrow tested `v0.x` range
 - broad “latest” dependencies are not supported
+- official external release artifacts are maintainer-signed and
+  maintainer-notarized before publication to GitHub Releases
 
 ## Supported Runtime Contract
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,8 @@ on finding or inspecting the app bundle path.
 
 ## Install
 
-1. Download the current signed release assets from GitHub Releases:
+1. Download the current official maintainer-signed and maintainer-notarized
+   release assets from GitHub Releases:
    - `CameraBridgeApp-v0.x.y-macos.zip`
    - `CameraBridgeApp-v0.x.y-macos.zip.sha256`
 2. Verify the checksum before installation:
@@ -91,3 +92,6 @@ Full uninstall:
    - `runtime-info.json`
    - `Logs/`
    - `Captures/`
+
+For maintainers producing those official artifacts, use
+[docs/release-process.md](./release-process.md).

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,135 @@
+# CameraBridge Release Process
+
+This document defines the canonical maintainer-only process for producing an
+official CameraBridge external release.
+
+Official external releases are:
+
+- signed on a trusted maintainer Mac
+- notarized on that trusted maintainer Mac
+- published to GitHub Releases
+
+GitHub Actions is not the signing or notarization authority for CameraBridge
+releases.
+
+## Prerequisites
+
+On the trusted maintainer Mac:
+
+- Apple Developer credentials required for Developer ID signing
+- local notarization credentials configured for the maintainer
+- `gh` authenticated with permission to create or edit GitHub Releases
+- clean working copy of the CameraBridge repository
+
+The existing release scripts remain the source of truth:
+
+- `scripts/release/package-app-bundle.sh`
+- `scripts/release/create-release-artifacts.sh`
+
+## Official Release Procedure
+
+1. Start from clean, up-to-date `main`:
+
+```bash
+git checkout main
+git pull --ff-only
+git status --short
+```
+
+2. Choose the release version:
+
+```text
+v0.x.y
+```
+
+3. Export the local signing and notarization environment expected by the
+   artifact script:
+
+```bash
+export CAMERABRIDGE_SIGNING_IDENTITY="Developer ID Application: ..."
+export CAMERABRIDGE_NOTARY_KEY_ID="..."
+export CAMERABRIDGE_NOTARY_ISSUER_ID="..."
+export CAMERABRIDGE_NOTARY_PRIVATE_KEY="$(cat /path/to/AuthKey_XXXX.p8)"
+```
+
+4. Build the official release artifacts locally:
+
+```bash
+scripts/release/create-release-artifacts.sh --version v0.x.y --signing-mode developer-id
+```
+
+Expected outputs:
+
+- `dist/CameraBridgeApp-v0.x.y-macos.zip`
+- `dist/CameraBridgeApp-v0.x.y-macos.zip.sha256`
+
+The script is responsible for:
+
+- release-mode build
+- Developer ID signing
+- notarization submission
+- stapling
+- zip creation
+- checksum generation
+
+5. Create and push the release tag:
+
+```bash
+git tag v0.x.y
+git push origin v0.x.y
+```
+
+6. Create or update the GitHub Release and upload the official artifacts:
+
+```bash
+gh release create v0.x.y \
+  dist/CameraBridgeApp-v0.x.y-macos.zip \
+  dist/CameraBridgeApp-v0.x.y-macos.zip.sha256 \
+  --generate-notes
+```
+
+If the release already exists:
+
+```bash
+gh release upload v0.x.y \
+  dist/CameraBridgeApp-v0.x.y-macos.zip \
+  dist/CameraBridgeApp-v0.x.y-macos.zip.sha256 \
+  --clobber
+```
+
+7. Validate the distributed artifact, not the local app bundle:
+
+- download the uploaded zip and checksum from GitHub Releases
+- verify the checksum against the downloaded zip
+- install the downloaded app bundle into `/Applications`
+- confirm Gatekeeper accepts launch
+- complete the packaged-flow smoke test in `docs/release-readiness.md`
+
+8. Record release-readiness verification notes for the release.
+
+## Validation Workflow
+
+The repository keeps a validation-only GitHub Actions workflow for release
+contract checks.
+
+Use it in two ways:
+
+- tag push: validates tag shape and required docs/links
+- manual dispatch: validates the release asset names after the maintainer has
+  uploaded the official artifacts
+
+This workflow does not sign, notarize, or upload the official app bundle.
+
+## Contributor Packaging Versus Official Releases
+
+Contributor-local packaging:
+
+- uses `apps/CameraBridgeApp/scripts/package-app.sh`
+- is ad-hoc signed
+- is intended for development and local verification
+
+Official external release packaging:
+
+- uses `scripts/release/create-release-artifacts.sh --signing-mode developer-id`
+- is maintainer-signed and maintainer-notarized
+- produces the only official external release artifacts

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -18,8 +18,8 @@ published artifact path as well as the repo-local smoke test.
 
 Expected checks:
 
-- download the published `CameraBridgeApp-v0.x.y-macos.zip` asset from GitHub
-  Releases
+- download the published maintainer-produced
+  `CameraBridgeApp-v0.x.y-macos.zip` asset from GitHub Releases
 - verify the published checksum matches the downloaded zip
 - install the downloaded app bundle into `/Applications`
 - confirm Gatekeeper accepts launch of the notarized app

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -130,26 +130,25 @@ Recommended labels:
 
 ## Release Workflow
 
-External CameraBridge releases should be published from GitHub tags, not from a
-local manually distributed app bundle.
+External CameraBridge releases should be published from GitHub Releases, but
+official signing and notarization happen on a trusted maintainer Mac rather
+than in GitHub Actions.
 
-For the external release path:
+For the official external release path:
 
-1. Tag the release with `v0.x.y`.
-2. Let the macOS release workflow build, sign, notarize, staple, zip, and
-   checksum the app bundle.
-3. Publish the signed artifact and checksum to GitHub Releases.
-4. Treat the GitHub Release assets as the source of truth for external adopters.
+1. Follow the maintainer procedure in `docs/release-process.md`.
+2. Produce the official zip and checksum locally on the trusted maintainer Mac.
+3. Publish those artifacts to GitHub Releases.
+4. Treat the uploaded GitHub Release assets as the source of truth for
+   external adopters.
 
-Required GitHub Actions secrets:
+The repository keeps a validation-only release workflow for:
 
-- `CAMERABRIDGE_DEVELOPER_ID_APPLICATION_CERT_P12_BASE64`
-- `CAMERABRIDGE_DEVELOPER_ID_APPLICATION_CERT_PASSWORD`
-- `CAMERABRIDGE_CI_KEYCHAIN_PASSWORD`
-- `CAMERABRIDGE_SIGNING_IDENTITY`
-- `CAMERABRIDGE_NOTARY_KEY_ID`
-- `CAMERABRIDGE_NOTARY_ISSUER_ID`
-- `CAMERABRIDGE_NOTARY_PRIVATE_KEY`
+- tag/version shape validation
+- required release-doc checks
+- optional post-publication asset-name validation
+
+GitHub Actions is not the signing authority for official CameraBridge releases.
 
 ## Definition Of Ready
 


### PR DESCRIPTION
## Summary
- convert the release workflow to validation-only with no signing or notarization secrets
- add a maintainer-only release process document for producing official signed and notarized artifacts locally
- update install, compatibility, workflow, and app docs so official releases are maintainer-signed, maintainer-notarized, and GitHub-published

## Files Changed
- .github/workflows/release.yml
- README.md
- apps/CameraBridgeApp/README.md
- docs/compatibility.md
- docs/install.md
- docs/release-process.md
- docs/release-readiness.md
- docs/workflow.md

## How It Was Tested
- `swift test`
- manual diff review of workflow/docs trust-model changes

## Intentionally Deferred
- changes to the downstream runtime/API contract
- new installer formats or auto-update support
- any new localhost lifecycle endpoints

Closes #114
Closes #115
Closes #116
Closes #117