### PR TITLE
Tighten CameraBridge local release prep verification

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -8,6 +8,7 @@ Official external releases are:
 - signed on a trusted maintainer Mac
 - notarized on that trusted maintainer Mac
 - published to GitHub Releases
+- stamped with bundle metadata derived from the tag core version
 
 GitHub Actions is not the signing or notarization authority for CameraBridge
 releases.
@@ -46,11 +47,15 @@ v0.x.y
    artifact script:
 
 ```bash
-export CAMERABRIDGE_SIGNING_IDENTITY="Developer ID Application: ..."
+export CAMERABRIDGE_SIGNING_IDENTITY="Developer ID Application: Ryan Schroeder (8QU25M896L)"
 export CAMERABRIDGE_NOTARY_KEY_ID="..."
 export CAMERABRIDGE_NOTARY_ISSUER_ID="..."
 export CAMERABRIDGE_NOTARY_PRIVATE_KEY="$(cat /path/to/AuthKey_XXXX.p8)"
 ```
+
+These are the only maintainer-side release inputs required by the current
+scripts. No provisioning profiles, App Store packaging, or additional
+certificate types are part of the release flow.
 
 4. Build the official release artifacts locally:
 
@@ -63,12 +68,20 @@ Expected outputs:
 - `dist/CameraBridgeApp-v0.x.y-macos.zip`
 - `dist/CameraBridgeApp-v0.x.y-macos.zip.sha256`
 
+Bundle metadata inside the packaged app is stamped from the tag core version.
+Examples:
+
+- `v0.2.0` -> `CFBundleShortVersionString=0.2.0`, `CFBundleVersion=0.2.0`
+- `v0.2.0-rc.1` -> `CFBundleShortVersionString=0.2.0`, `CFBundleVersion=0.2.0`
+
 The script is responsible for:
 
 - release-mode build
 - Developer ID signing
 - notarization submission
 - stapling
+- stapler validation
+- app-open Gatekeeper assessment
 - zip creation
 - checksum generation
 
@@ -101,6 +114,9 @@ gh release upload v0.x.y \
 
 - download the uploaded zip and checksum from GitHub Releases
 - verify the checksum against the downloaded zip
+- confirm the maintainer build completed `xcrun notarytool submit --wait`
+- confirm the maintainer build completed `xcrun stapler validate`
+- confirm the maintainer build completed `spctl --assess --type open` for the stapled app
 - install the downloaded app bundle into `/Applications`
 - confirm Gatekeeper accepts launch
 - complete the packaged-flow smoke test in `docs/release-readiness.md`
@@ -132,4 +148,5 @@ Official external release packaging:
 
 - uses `scripts/release/create-release-artifacts.sh --signing-mode developer-id`
 - is maintainer-signed and maintainer-notarized
+- stamps bundle metadata from the tag core version
 - produces the only official external release artifacts

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -21,8 +21,13 @@ Expected checks:
 - download the published maintainer-produced
   `CameraBridgeApp-v0.x.y-macos.zip` asset from GitHub Releases
 - verify the published checksum matches the downloaded zip
+- maintainer-side `xcrun notarytool submit --wait` completed successfully
+- maintainer-side `xcrun stapler validate` completed successfully
+- maintainer-side `spctl --assess --type open` accepted the stapled app bundle
 - install the downloaded app bundle into `/Applications`
 - confirm Gatekeeper accepts launch of the notarized app
+- confirm the installed app bundle reports the tag core version in
+  `CFBundleShortVersionString` and `CFBundleVersion`
 - confirm the installed app can complete the packaged-flow smoke test
 
 ## First-Capture Smoke Test
@@ -179,8 +184,12 @@ release:
 - [ ] `swift test` passed
 - [ ] Published GitHub Release zip downloaded successfully
 - [ ] Published checksum matched the downloaded zip
+- [ ] Maintainer run completed `xcrun notarytool submit --wait`
+- [ ] Maintainer run completed `xcrun stapler validate`
+- [ ] Maintainer run passed `spctl --assess --type open`
 - [ ] Installed app bundle launched successfully from `/Applications`
 - [ ] Gatekeeper accepted the notarized app
+- [ ] Installed app bundle metadata matched the release tag core version
 - [ ] Packaged `CameraBridgeApp.app` launched successfully
 - [ ] `camd` started from the app and reported healthy on `127.0.0.1:8731`
 - [ ] Auth token file existed at `~/Library/Application Support/CameraBridge/auth-token`

--- a/scripts/release/create-release-artifacts.sh
+++ b/scripts/release/create-release-artifacts.sh
@@ -69,6 +69,7 @@ if [[ "$SIGNING_MODE" != "adhoc" && "$SIGNING_MODE" != "developer-id" ]]; then
 fi
 
 ARTIFACT_PREFIX="CameraBridgeApp-${VERSION}-macos"
+BUNDLE_VERSION="$(printf '%s' "$VERSION" | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+)([-.].*)?$/\1/')"
 STAGE_DIR="$OUTPUT_DIR/stage"
 APP_PATH="$STAGE_DIR/CameraBridgeApp.app"
 NOTARIZATION_ZIP="$OUTPUT_DIR/${ARTIFACT_PREFIX}-notarization.zip"
@@ -81,7 +82,8 @@ rm -f "$NOTARIZATION_ZIP" "$RELEASE_ZIP" "$CHECKSUM_FILE"
 "$PACKAGE_SCRIPT" \
     --build-configuration release \
     --output-dir "$STAGE_DIR" \
-    --signing-mode "$SIGNING_MODE"
+    --signing-mode "$SIGNING_MODE" \
+    --bundle-version "$BUNDLE_VERSION"
 
 if [[ "$SIGNING_MODE" == "developer-id" && "$SKIP_NOTARIZATION" != "1" ]]; then
     : "${CAMERABRIDGE_NOTARY_KEY_ID:?CAMERABRIDGE_NOTARY_KEY_ID is required for notarization}"
@@ -100,7 +102,8 @@ if [[ "$SIGNING_MODE" == "developer-id" && "$SKIP_NOTARIZATION" != "1" ]]; then
         --wait
 
     xcrun stapler staple "$APP_PATH"
-    spctl -a -vv --type exec "$APP_PATH"
+    xcrun stapler validate "$APP_PATH"
+    spctl -a -vv --type open "$APP_PATH"
 fi
 
 ditto -c -k --keepParent "$APP_PATH" "$RELEASE_ZIP"
@@ -109,5 +112,6 @@ shasum -a 256 "$RELEASE_ZIP" > "$CHECKSUM_FILE"
 codesign --verify --strict --verbose=2 "$APP_PATH"
 
 echo "Release app: $APP_PATH"
+echo "Bundle version: $BUNDLE_VERSION"
 echo "Release zip: $RELEASE_ZIP"
 echo "Checksum: $CHECKSUM_FILE"

--- a/scripts/release/package-app-bundle.sh
+++ b/scripts/release/package-app-bundle.sh
@@ -14,6 +14,7 @@ BUILD_CONFIGURATION="release"
 OUTPUT_DIR=""
 SIGNING_MODE="adhoc"
 SIGNING_IDENTITY="${CAMERABRIDGE_SIGNING_IDENTITY:-}"
+BUNDLE_VERSION=""
 
 usage() {
     cat <<'EOF'
@@ -25,6 +26,7 @@ Options:
   --output-dir <path>
   --signing-mode <adhoc|developer-id>
   --signing-identity <identity>
+  --bundle-version <0.x.y>
 EOF
 }
 
@@ -44,6 +46,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --signing-identity)
             SIGNING_IDENTITY="$2"
+            shift 2
+            ;;
+        --bundle-version)
+            BUNDLE_VERSION="$2"
             shift 2
             ;;
         --help|-h)
@@ -68,6 +74,11 @@ if [[ "$SIGNING_MODE" != "adhoc" && "$SIGNING_MODE" != "developer-id" ]]; then
     exit 1
 fi
 
+if [[ -n "$BUNDLE_VERSION" && ! "$BUNDLE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Bundle version must match 0.x.y when provided" >&2
+    exit 1
+fi
+
 cd "$ROOT_DIR"
 
 swift build --configuration "$BUILD_CONFIGURATION" --product "$APP_NAME"
@@ -87,6 +98,14 @@ cp "$BIN_DIR/$APP_NAME" "$MACOS_DIR/$APP_NAME"
 cp "$ROOT_DIR/apps/CameraBridgeApp/Info.plist" "$CONTENTS_DIR/Info.plist"
 cp "$BIN_DIR/$DAEMON_NAME" "$RESOURCES_DIR/$DAEMON_NAME"
 chmod +x "$RESOURCES_DIR/$DAEMON_NAME"
+
+if [[ -n "$BUNDLE_VERSION" ]]; then
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $BUNDLE_VERSION" \
+        "$CONTENTS_DIR/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUNDLE_VERSION" \
+        "$CONTENTS_DIR/Info.plist"
+fi
+
 xattr -cr "$APP_DIR" || true
 
 sign_path() {


### PR DESCRIPTION
## Summary
- stamp packaged app bundle metadata from the release tag core version during local release builds
- strengthen the local maintainer release flow with stapler validation and app-open spctl assessment
- clarify the exact maintainer signing/notary inputs and release-readiness expectations

## Files Changed
- scripts/release/package-app-bundle.sh
- scripts/release/create-release-artifacts.sh
- docs/release-process.md
- docs/release-readiness.md

## How It Was Tested
- `swift test`
- `scripts/release/create-release-artifacts.sh --version v0.1.2-test --signing-mode adhoc --skip-notarization --output-dir /tmp/camerabridge-release-audit-2`
- verified staged app metadata via `defaults read`:
  - `CFBundleIdentifier=io.camerabridge.CameraBridgeApp`
  - `CFBundleShortVersionString=0.1.2`
  - `CFBundleVersion=0.1.2`

## Intentionally Deferred
- live Developer ID signing validation
- live notarytool submission/authentication validation
- live stapler validation against Apple notarization results
- Gatekeeper validation of a downloaded GitHub Release artifact

Closes #122
Closes #120
Closes #121
Closes #119