### PR TITLE
Make staged release spctl checks advisory

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -81,7 +81,7 @@ The script is responsible for:
 - notarization submission
 - stapling
 - stapler validation
-- app-open Gatekeeper assessment
+- best-effort staged app-open Gatekeeper assessment
 - zip creation
 - checksum generation
 
@@ -116,7 +116,7 @@ gh release upload v0.x.y \
 - verify the checksum against the downloaded zip
 - confirm the maintainer build completed `xcrun notarytool submit --wait`
 - confirm the maintainer build completed `xcrun stapler validate`
-- confirm the maintainer build completed `spctl --assess --type open` for the stapled app
+- review any staged-path `spctl --assess --type open` warning from the maintainer build, but do not treat `source=Insufficient Context` on the staged app as a release blocker by itself
 - install the downloaded app bundle into `/Applications`
 - confirm Gatekeeper accepts launch
 - complete the packaged-flow smoke test in `docs/release-readiness.md`

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -23,7 +23,7 @@ Expected checks:
 - verify the published checksum matches the downloaded zip
 - maintainer-side `xcrun notarytool submit --wait` completed successfully
 - maintainer-side `xcrun stapler validate` completed successfully
-- maintainer-side `spctl --assess --type open` accepted the stapled app bundle
+- any staged-path `spctl --assess --type open` warning was reviewed, but downloaded-artifact launch remained the real Gatekeeper signal
 - install the downloaded app bundle into `/Applications`
 - confirm Gatekeeper accepts launch of the notarized app
 - confirm the installed app bundle reports the tag core version in
@@ -186,7 +186,7 @@ release:
 - [ ] Published checksum matched the downloaded zip
 - [ ] Maintainer run completed `xcrun notarytool submit --wait`
 - [ ] Maintainer run completed `xcrun stapler validate`
-- [ ] Maintainer run passed `spctl --assess --type open`
+- [ ] Any staged-path `spctl --assess --type open` warning was reviewed and did not contradict downloaded-artifact validation
 - [ ] Installed app bundle launched successfully from `/Applications`
 - [ ] Gatekeeper accepted the notarized app
 - [ ] Installed app bundle metadata matched the release tag core version

--- a/scripts/release/create-release-artifacts.sh
+++ b/scripts/release/create-release-artifacts.sh
@@ -103,7 +103,14 @@ if [[ "$SIGNING_MODE" == "developer-id" && "$SKIP_NOTARIZATION" != "1" ]]; then
 
     xcrun stapler staple "$APP_PATH"
     xcrun stapler validate "$APP_PATH"
-    spctl -a -vv --type open "$APP_PATH"
+
+    if ! SPCTL_OUTPUT="$(spctl -a -vv --type open "$APP_PATH" 2>&1)"; then
+        echo "Warning: staged app Gatekeeper assessment did not pass for $APP_PATH" >&2
+        echo "$SPCTL_OUTPUT" >&2
+        echo "Continue with downloaded-artifact validation from GitHub Releases before treating the release as ready." >&2
+    else
+        echo "$SPCTL_OUTPUT"
+    fi
 fi
 
 ditto -c -k --keepParent "$APP_PATH" "$RELEASE_ZIP"


### PR DESCRIPTION
## Summary
- make the staged-app `spctl --type open` check advisory instead of fatal in the local maintainer release script
- keep notarization acceptance, stapling, and stapler validation required
- update maintainer docs so the real release gate stays on the downloaded GitHub Release artifact and normal Gatekeeper launch behavior

## Files Changed
- scripts/release/create-release-artifacts.sh
- docs/release-process.md
- docs/release-readiness.md

## How It Was Tested
- `zsh -n scripts/release/create-release-artifacts.sh`
- `swift test`

## Intentionally Deferred
- changing any runtime or API contract
- changing the downloaded-artifact validation path
- adding new release pipeline surface area

Closes #124