### PR TITLE
Redesign public homepage

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -50,11 +50,14 @@
             deliberate macOS service instead of embedding native glue repeatedly.
           </p>
           <div class="hero-actions">
-            <a class="button button-primary" href="https://github.com/rschroed/CameraBridge"
-              >View on GitHub</a
+            <a class="button button-primary" href="https://github.com/rschroed/CameraBridge/releases"
+              >Download CameraBridgeApp</a
             >
-            <a class="button" href="https://github.com/rschroed/CameraBridge/blob/main/README.md"
-              >Read the README</a
+            <a class="button" href="https://github.com/rschroed/CameraBridge/blob/main/docs/install.md"
+              >Install Guide</a
+            >
+            <a class="button" href="https://github.com/rschroed/CameraBridge"
+              >View on GitHub</a
             >
           </div>
           <ul class="hero-meta" aria-label="Highlights">
@@ -186,50 +189,66 @@
         <section class="section" id="example" aria-labelledby="example-title">
           <div class="section-heading">
             <p class="section-label">Quick example</p>
-            <h2 id="example-title">Health and permissions over local HTTP.</h2>
+            <h2 id="example-title">From device inventory to a still capture.</h2>
           </div>
           <div class="example-block">
-            <pre><code>curl http://127.0.0.1:PORT/health
+            <div class="example-segment">
+              <p class="item-label">Read-only discovery</p>
+              <pre><code>curl -s http://127.0.0.1:8731/v1/devices</code></pre>
+            </div>
+            <div class="example-segment">
+              <p class="item-label">Token-protected capture flow</p>
+              <pre><code>TOKEN="$(cat ~/Library/Application\ Support/CameraBridge/auth-token)"
 
-{
-  "status": "ok"
-}
+curl -s -X POST http://127.0.0.1:8731/v1/session/select-device \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"device_id":"YOUR_DEVICE_ID","owner_id":"client-1"}'
 
-curl http://127.0.0.1:PORT/v1/permissions
+curl -s -X POST http://127.0.0.1:8731/v1/session/start \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"owner_id":"client-1"}'
 
-{
-  "status": "not_determined"
-}</code></pre>
+curl -s -X POST http://127.0.0.1:8731/v1/capture/photo \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"owner_id":"client-1"}'</code></pre>
+            </div>
           </div>
           <p class="annotation">Readable by humans. Legible to agents.</p>
           <p class="section-copy">
-            The shipped v1 surface stays intentionally small: health, permission
-            visibility, device discovery, session control, and still capture.
-            Mutating routes use bearer-token protection, with ownership
-            established implicitly when a client starts the session.
+            The shipped path is intentionally small but real: discover a device,
+            use the local bearer token surfaced by the app, start the session,
+            and capture a still image. For a minimal end-to-end helper, the repo
+            also ships a Python first-capture example.
           </p>
         </section>
 
         <section class="section section-closing" aria-labelledby="cta-title">
           <div class="section-heading">
-            <p class="section-label">Get started</p>
-            <h2 id="cta-title">Use the repo as the source of truth.</h2>
+            <p class="section-label">Next step</p>
+            <h2 id="cta-title">Start with the packaged flow.</h2>
           </div>
           <p class="section-copy">
-            Read the docs, track current implementation status, and follow the
-            published contract for the present CameraBridge v1 slice.
+            External adopters should install the signed app bundle first, then
+            use the install guide for setup and the API contract when wiring a
+            local client against the current v1 surface.
           </p>
           <div class="cta-actions">
-            <a class="button button-primary" href="https://github.com/rschroed/CameraBridge"
-              >Open the GitHub repo</a
+            <a class="button button-primary" href="https://github.com/rschroed/CameraBridge/releases"
+              >Download CameraBridgeApp</a
+            >
+            <a class="button" href="https://github.com/rschroed/CameraBridge/blob/main/docs/install.md"
+              >Install Guide</a
             >
             <a class="button" href="https://github.com/rschroed/CameraBridge/blob/main/docs/api/v1.md"
               >API contract</a
             >
-            <a class="button" href="https://github.com/rschroed/CameraBridge/blob/main/docs/roadmap/v1.md"
-              >v1 roadmap</a
-            >
           </div>
+          <p class="supporting-link">
+            <a href="https://github.com/rschroed/CameraBridge">GitHub repo</a>
+          </p>
           <p class="annotation">
             Predictable enough for scripts. Civilized enough for people.
           </p>

--- a/site/styles.css
+++ b/site/styles.css
@@ -337,14 +337,24 @@ code {
 }
 
 .example-block {
-  overflow-x: auto;
   margin-top: var(--space-2);
   padding: var(--space-5);
   border: 1px solid var(--rule);
   background: #fcfcfc;
 }
 
+.example-segment + .example-segment {
+  margin-top: var(--space-5);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--rule);
+}
+
+.example-segment .item-label {
+  margin-bottom: var(--space-3);
+}
+
 .example-block pre {
+  overflow-x: auto;
   min-width: max-content;
   font-size: 12px;
   line-height: 1.65;
@@ -353,6 +363,20 @@ code {
 
 .section-closing .cta-actions {
   margin-top: var(--space-6);
+}
+
+.supporting-link {
+  margin-top: var(--space-4);
+  color: var(--text-muted);
+}
+
+.supporting-link a {
+  border-bottom: 1px solid var(--rule-strong);
+}
+
+.supporting-link a:hover,
+.supporting-link a:focus-visible {
+  border-bottom-color: var(--accent);
 }
 
 @media (min-width: 880px) {
@@ -418,5 +442,10 @@ code {
   .hero-actions,
   .cta-actions {
     flex-direction: column;
+  }
+
+  .example-segment + .example-segment {
+    margin-top: var(--space-4);
+    padding-top: var(--space-4);
   }
 }


### PR DESCRIPTION
## Summary
Redesign the public homepage as a narrower editorial document instead of the previous warm, card-heavy landing page. The change keeps the existing CameraBridge section structure and product claims, but rebuilds the page around system typography, restrained rules, mono metadata, minimal controls, and a clearer inline architecture sequence.

## Issue
Closes #128

## Files Changed
- `site/index.html`
- `site/styles.css`

## Testing
- [ ] `swift build`
- [ ] `swift test`
- [ ] Manual verification completed
- [x] Not run, explained below

Testing notes:
- This slice only changes static HTML/CSS in the GitHub Pages site.
- I reviewed the final diff and iterated against user visual feedback, but I did not run a browser-based manual verification pass from the CLI environment.

## Deferred
- Final in-browser polish pass for spacing and responsive presentation, if any follow-up visual adjustments are needed after review

## AGENTS.md Check
- [x] Scope stayed focused on one issue
- [x] Unrelated files were not changed without cause
- [x] Docs were updated if public behavior changed