### PR TITLE
[App]: Add CameraBridgeApp URL scheme handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ onboarding path.
 - `Quit CameraBridge` stops the managed daemon before the app exits
 - if another healthy local CameraBridge service is already running, the app
   shows `Running (External)` and does not kill that service
+- local macOS clients can open `camerabridge://permission` to launch or focus
+  the app and surface the current onboarding or ready-state menu
 - the app surfaces the current base URL plus the token, log, and captures paths
   needed by local integrators
 
@@ -122,7 +124,9 @@ Use these docs as the source of truth for external adopters:
 `/Applications/CameraBridgeApp.app` is the supported user install target for
 the packaged flow. It is not the downstream runtime-discovery contract.
 External apps should rely on the localhost service and documented support-path
-artifacts at runtime.
+artifacts at runtime. When a local integration receives
+`next_step.kind = open_camera_bridge_app`, it can hand off to the packaged app
+with `open "camerabridge://permission"`.
 
 Package the local menu bar app bundle with:
 
@@ -137,15 +141,18 @@ If your machine previously granted camera access to an older packaged build,
 re-request permission once after adopting the newer packaging flow so macOS can
 record the updated local code requirement.
 
+By default the contributor-local app bundle is staged outside the repo at:
+
+```text
+/tmp/CameraBridgeApp-local/CameraBridgeApp.app
+```
+
+Override that location with `CAMERABRIDGE_LOCAL_APP_OUTPUT_DIR=/your/path` if
+needed.
+
 For published external releases, use the official maintainer-signed and
 maintainer-notarized GitHub Release artifact path instead of this local
 contributor packaging flow.
-
-The packaged app bundle, including the bundled `camd` executable, is written to:
-
-```text
-$(swift build --show-bin-path)/CameraBridgeApp.app
-```
 
 ## First Capture
 
@@ -159,6 +166,17 @@ The shortest successful path is:
 4. confirm `Permission: Authorized`
 5. use the base URL and token path shown in the app if you are integrating from another local client
 6. run the minimal Python example with a real device id from `GET /v1/devices`
+
+For local macOS integrations, the concrete handoff for
+`open_camera_bridge_app` is:
+
+```bash
+open "camerabridge://permission"
+```
+
+That handoff opens the app’s existing menu bar onboarding/status UI only. It
+does not auto-start `camd` and does not auto-trigger the camera permission
+prompt.
 
 The app shows the effective connection details in its menu. In the default
 packaged flow, those values are:

--- a/apps/CameraBridgeApp/Info.plist
+++ b/apps/CameraBridgeApp/Info.plist
@@ -14,6 +14,19 @@
     <string>CameraBridge</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>CFBundleURLName</key>
+            <string>io.camerabridge.CameraBridgeApp.handoff</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>camerabridge</string>
+            </array>
+        </dict>
+    </array>
     <key>CFBundleShortVersionString</key>
     <string>0.1.0</string>
     <key>CFBundleVersion</key>

--- a/apps/CameraBridgeApp/README.md
+++ b/apps/CameraBridgeApp/README.md
@@ -11,6 +11,7 @@ The app remains a thin client of the localhost CameraBridge service. Its menu ba
 - starting the bundled `camd` service
 - stopping the bundled `camd` service when this app owns that process
 - requesting camera access directly from the app process
+- responding to `camerabridge://permission` by surfacing the existing onboarding or status menu
 - surfacing base URL, token path, log path, and captures path for local integrators
 - quitting the app
 
@@ -49,13 +50,16 @@ added, request access once again so TCC can record the newer requirement.
 This produces a menu bar app bundle that includes the `camd` executable:
 
 ```text
-$(swift build --show-bin-path)/CameraBridgeApp.app
+/tmp/CameraBridgeApp-local/CameraBridgeApp.app
 ```
+
+Override that output location with `CAMERABRIDGE_LOCAL_APP_OUTPUT_DIR=/your/path`
+if you need a different local staging directory.
 
 Launch the packaged app from Finder or with:
 
 ```bash
-open "$(swift build --show-bin-path)/CameraBridgeApp.app"
+open "/tmp/CameraBridgeApp-local/CameraBridgeApp.app"
 ```
 
 When the app starts the bundled service, `camd` loads or creates the local bearer token at:
@@ -87,12 +91,31 @@ For the supported packaged flow, external apps should rely on the localhost
 service and support-path artifacts above at runtime. They should not depend on
 hardcoded app-bundle path discovery.
 
+## Custom URL Handoff
+
+`CameraBridgeApp` registers one supported custom URL for local macOS handoff:
+
+```text
+camerabridge://permission
+```
+
+Use it when a local client needs to satisfy the API guidance
+`next_step.kind = open_camera_bridge_app`.
+
+Expected behavior:
+
+- launching the URL opens or focuses `CameraBridgeApp`
+- the existing menu bar onboarding/status UI becomes visible
+- no daemon auto-start occurs
+- no camera permission prompt is triggered automatically
+- unsupported URLs are ignored safely
+
 ## Manual Verification
 
 Use the packaged app bundle for manual verification:
 
 1. Run `apps/CameraBridgeApp/scripts/package-app.sh`.
-2. Launch `CameraBridgeApp.app` from Finder or with `open "$(swift build --show-bin-path)/CameraBridgeApp.app"`.
+2. Launch `CameraBridgeApp.app` from Finder or with `open "/tmp/CameraBridgeApp-local/CameraBridgeApp.app"`.
 3. Confirm the menu shows:
    - a clear service status row
    - a clear permission status row
@@ -105,5 +128,7 @@ Use the packaged app bundle for manual verification:
 8. Confirm `Stop CameraBridge Service` returns the menu to the stopped state.
 9. Confirm quitting the app stops the managed daemon before exit.
 10. If service launch or permission request fails, confirm the last error row appears with readable wording.
+11. Quit the app, run `open "camerabridge://permission"`, and confirm the app relaunches with the menu visible.
+12. With the app already running and the menu open, run `open "camerabridge://permission"` again and confirm the menu stays visible without starting the service or prompting for permission.
 
 Capture screenshots of the refined menu states when practical for PR notes.

--- a/apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppDeepLink.swift
+++ b/apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppDeepLink.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+@MainActor
+protocol CameraBridgeAppStatusRefreshing {
+    func refreshNow() async
+}
+
+extension CameraBridgeAppModel: CameraBridgeAppStatusRefreshing {}
+
+@MainActor
+protocol CameraBridgeAppStatusPresenting {
+    func presentStatusMenuForDeepLink()
+}
+
+@MainActor
+protocol CameraBridgeAppStatusMenuDriving {
+    var canPresentStatusMenu: Bool { get }
+
+    func activateAppForStatusMenu()
+    func openStatusMenu()
+}
+
+@MainActor
+final class CameraBridgeAppStatusMenuPresenter {
+    private let driver: any CameraBridgeAppStatusMenuDriving
+    private var isStatusMenuOpen = false
+    private var pendingPresentation = false
+
+    init(driver: any CameraBridgeAppStatusMenuDriving) {
+        self.driver = driver
+    }
+
+    func presentStatusMenu() {
+        driver.activateAppForStatusMenu()
+
+        guard driver.canPresentStatusMenu else {
+            pendingPresentation = true
+            return
+        }
+
+        pendingPresentation = false
+
+        guard !isStatusMenuOpen else {
+            return
+        }
+
+        driver.openStatusMenu()
+    }
+
+    func statusMenuWillOpen() {
+        isStatusMenuOpen = true
+    }
+
+    func statusMenuDidClose() {
+        isStatusMenuOpen = false
+    }
+
+    func statusMenuPresentationDidBecomeAvailable() {
+        guard pendingPresentation else {
+            return
+        }
+
+        presentStatusMenu()
+    }
+}
+
+enum CameraBridgeAppDeepLink: Equatable {
+    case permission
+
+    init?(url: URL) {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        components.scheme = components.scheme?.lowercased()
+        components.host = components.host?.lowercased()
+
+        guard components.scheme == "camerabridge" else {
+            return nil
+        }
+
+        guard components.host == "permission" else {
+            return nil
+        }
+
+        guard components.user == nil, components.password == nil, components.port == nil else {
+            return nil
+        }
+
+        guard components.path.isEmpty else {
+            return nil
+        }
+
+        guard components.query == nil, components.fragment == nil else {
+            return nil
+        }
+
+        self = .permission
+    }
+
+    init?(string: String) {
+        guard let url = URL(string: string) else {
+            return nil
+        }
+
+        self.init(url: url)
+    }
+}
+
+@MainActor
+final class CameraBridgeAppDeepLinkRouter {
+    typealias Logger = @Sendable (String) -> Void
+
+    private let statusRefresher: any CameraBridgeAppStatusRefreshing
+    private let statusPresenter: any CameraBridgeAppStatusPresenting
+    private let logger: Logger
+
+    init(
+        statusRefresher: any CameraBridgeAppStatusRefreshing,
+        statusPresenter: any CameraBridgeAppStatusPresenting,
+        logger: @escaping Logger = { _ in }
+    ) {
+        self.statusRefresher = statusRefresher
+        self.statusPresenter = statusPresenter
+        self.logger = logger
+    }
+
+    @discardableResult
+    func handle(_ urlString: String) async -> Bool {
+        guard let deepLink = CameraBridgeAppDeepLink(string: urlString) else {
+            logger("CameraBridgeApp ignored unsupported URL: \(urlString)")
+            return false
+        }
+
+        return await handle(deepLink)
+    }
+
+    @discardableResult
+    func handle(_ url: URL) async -> Bool {
+        guard let deepLink = CameraBridgeAppDeepLink(url: url) else {
+            logger("CameraBridgeApp ignored unsupported URL: \(url.absoluteString)")
+            return false
+        }
+
+        return await handle(deepLink)
+    }
+
+    @discardableResult
+    private func handle(_ deepLink: CameraBridgeAppDeepLink) async -> Bool {
+        switch deepLink {
+        case .permission:
+            await statusRefresher.refreshNow()
+            statusPresenter.presentStatusMenuForDeepLink()
+            return true
+        }
+    }
+}

--- a/apps/CameraBridgeApp/Sources/CameraBridgeApp/main.swift
+++ b/apps/CameraBridgeApp/Sources/CameraBridgeApp/main.swift
@@ -1,22 +1,51 @@
 import AppKit
+import Carbon
 
 let application = NSApplication.shared
 let delegate = MainActor.assumeIsolated {
-    CameraBridgeStatusBarDelegate()
+    let delegate = CameraBridgeStatusBarDelegate()
+    delegate.registerDeepLinkHandler()
+    return delegate
 }
 application.setActivationPolicy(.accessory)
 application.delegate = delegate
 application.run()
 
 @MainActor
-final class CameraBridgeStatusBarDelegate: NSObject, NSApplicationDelegate {
-    private let model = CameraBridgeAppModel()
+final class CameraBridgeStatusBarDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, CameraBridgeAppStatusPresenting, CameraBridgeAppStatusMenuDriving {
+    private let model: CameraBridgeAppModel
+    private let statusMenu: NSMenu
+    private lazy var statusMenuPresenter = CameraBridgeAppStatusMenuPresenter(driver: self)
+    private lazy var deepLinkRouter = CameraBridgeAppDeepLinkRouter(
+        statusRefresher: model,
+        statusPresenter: self,
+        logger: { message in
+            print(message)
+        }
+    )
     private var statusItem: NSStatusItem?
     private var terminationRequested = false
+
+    override init() {
+        self.model = CameraBridgeAppModel()
+        self.statusMenu = NSMenu()
+        super.init()
+        statusMenu.delegate = self
+    }
+
+    func registerDeepLinkHandler() {
+        NSAppleEventManager.shared().setEventHandler(
+            self,
+            andSelector: #selector(handleGetURLEvent(_:withReplyEvent:)),
+            forEventClass: AEEventClass(kInternetEventClass),
+            andEventID: AEEventID(kAEGetURL)
+        )
+    }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         statusItem.button?.title = "CameraBridge"
+        statusItem.menu = statusMenu
         self.statusItem = statusItem
 
         model.onChange = { [weak self] in
@@ -25,6 +54,7 @@ final class CameraBridgeStatusBarDelegate: NSObject, NSApplicationDelegate {
 
         reloadMenu()
         model.start()
+        statusMenuPresenter.statusMenuPresentationDidBecomeAvailable()
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -64,13 +94,59 @@ final class CameraBridgeStatusBarDelegate: NSObject, NSApplicationDelegate {
         NSApp.terminate(sender)
     }
 
-    private func reloadMenu() {
-        statusItem?.menu = makeMenu()
+    func menuWillOpen(_ menu: NSMenu) {
+        guard menu === statusMenu else {
+            return
+        }
+
+        statusMenuPresenter.statusMenuWillOpen()
     }
 
-    private func makeMenu() -> NSMenu {
-        let menu = NSMenu()
+    func menuDidClose(_ menu: NSMenu) {
+        guard menu === statusMenu else {
+            return
+        }
 
+        statusMenuPresenter.statusMenuDidClose()
+    }
+
+    func presentStatusMenuForDeepLink() {
+        reloadMenu()
+        statusMenuPresenter.presentStatusMenu()
+    }
+
+    var canPresentStatusMenu: Bool {
+        statusItem?.button != nil
+    }
+
+    func activateAppForStatusMenu() {
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func openStatusMenu() {
+        statusItem?.button?.performClick(nil)
+    }
+
+    @objc
+    private func handleGetURLEvent(
+        _ event: NSAppleEventDescriptor,
+        withReplyEvent replyEvent: NSAppleEventDescriptor
+    ) {
+        guard let urlString = event.paramDescriptor(forKeyword: AEKeyword(keyDirectObject))?.stringValue else {
+            return
+        }
+
+        Task { @MainActor in
+            _ = await deepLinkRouter.handle(urlString)
+        }
+    }
+
+    private func reloadMenu() {
+        statusMenu.removeAllItems()
+        populateMenu(statusMenu)
+    }
+
+    private func populateMenu(_ menu: NSMenu) {
         menu.addItem(disabledItem(title: "CameraBridge"))
         menu.addItem(disabledItem(title: model.statusSummaryTitle))
         menu.addItem(.separator())
@@ -128,8 +204,6 @@ final class CameraBridgeStatusBarDelegate: NSObject, NSApplicationDelegate {
         )
         quitItem.target = self
         menu.addItem(quitItem)
-
-        return menu
     }
 
     private func disabledItem(title: String) -> NSMenuItem {

--- a/apps/CameraBridgeApp/scripts/package-app.sh
+++ b/apps/CameraBridgeApp/scripts/package-app.sh
@@ -3,10 +3,13 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
+OUTPUT_DIR="${CAMERABRIDGE_LOCAL_APP_OUTPUT_DIR:-/tmp/CameraBridgeApp-local}"
+APP_PATH="$OUTPUT_DIR/CameraBridgeApp.app"
 
 cd "$ROOT_DIR"
-BIN_DIR="$(swift build --show-bin-path)"
 "$ROOT_DIR/scripts/release/package-app-bundle.sh" \
     --build-configuration debug \
-    --output-dir "$BIN_DIR" \
+    --output-dir "$OUTPUT_DIR" \
     --signing-mode adhoc
+
+echo "Local app: $APP_PATH"

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -128,6 +128,7 @@ Response fields:
 - `message`: optional short guidance message for local clients
 - `next_step`: optional object describing the next supported action when permission is not yet usable
 - `next_step.kind`: currently `open_camera_bridge_app`
+  Local macOS clients can satisfy this handoff by opening `camerabridge://permission`.
 
 Undecided permission response: `200 OK`
 
@@ -141,6 +142,16 @@ Undecided permission response: `200 OK`
   "status": "not_determined"
 }
 ```
+
+For the current packaged app contract, the concrete local handoff is:
+
+```bash
+open "camerabridge://permission"
+```
+
+That URL launches or focuses `CameraBridgeApp` and surfaces the existing
+onboarding/status UI. It does not auto-start the daemon and does not auto-prompt
+for permission.
 
 Error cases:
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -38,13 +38,13 @@ apps/CameraBridgeApp/scripts/package-app.sh
 Launch the packaged app:
 
 ```bash
-open "$(swift build --show-bin-path)/CameraBridgeApp.app"
+open "/tmp/CameraBridgeApp-local/CameraBridgeApp.app"
 ```
 
 You can also open the bundle directly from Finder at:
 
 ```text
-$(swift build --show-bin-path)/CameraBridgeApp.app
+/tmp/CameraBridgeApp-local/CameraBridgeApp.app
 ```
 
 ## Start The Service And Confirm Permission
@@ -116,6 +116,15 @@ returns `message: null` and `next_step: null`. When permission is still
   "status": "not_determined"
 }
 ```
+
+On macOS, a local client can turn that next step into a concrete handoff with:
+
+```bash
+open "camerabridge://permission"
+```
+
+That handoff opens the existing `CameraBridgeApp` menu bar UI only. It does not
+start the service or trigger the permission prompt automatically.
 
 The mutating endpoints use the bearer token shown in the app. In the default
 packaged flow:

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -63,7 +63,7 @@ store the newer identifier-based local requirement for `CameraBridgeApp.app`.
 2. Launch the packaged app:
 
 ```bash
-open "$(swift build --show-bin-path)/CameraBridgeApp.app"
+open "/tmp/CameraBridgeApp-local/CameraBridgeApp.app"
 ```
 
 Expected checkpoints:
@@ -72,6 +72,25 @@ Expected checkpoints:
 - the initial state reports the service as stopped
 - `Start CameraBridge Service` is available
 - developer info rows are visible even before capture
+
+2a. Verify the custom URL handoff:
+
+```bash
+open "camerabridge://permission"
+```
+
+Expected checkpoints:
+
+- if the app is already running, the status menu stays visible or becomes visible
+- the handoff does not auto-start `camd`
+- the handoff does not auto-trigger the camera permission prompt
+
+Quit the app once and repeat the same command.
+
+Expected checkpoints:
+
+- the app relaunches successfully from the custom URL
+- the status menu becomes visible after launch
 
 3. Start the service from the menu bar app.
 
@@ -191,6 +210,8 @@ release:
 - [ ] Gatekeeper accepted the notarized app
 - [ ] Installed app bundle metadata matched the release tag core version
 - [ ] Packaged `CameraBridgeApp.app` launched successfully
+- [ ] `open "camerabridge://permission"` launched or focused the app successfully
+- [ ] The custom URL handoff surfaced the menu without auto-starting the daemon
 - [ ] `camd` started from the app and reported healthy on `127.0.0.1:8731`
 - [ ] Auth token file existed at `~/Library/Application Support/CameraBridge/auth-token`
 - [ ] App surfaced base URL, token path, log path, and captures path

--- a/docs/roadmap/v1.md
+++ b/docs/roadmap/v1.md
@@ -110,7 +110,7 @@ This flow is the current bar for the shipped v1 first-capture slice.
 - permission status visibility
 - app-supervised packaged daemon lifecycle with explicit start / stop / quit behavior
 - developer-visible base URL, token path, log path, and captures path
-- custom URL scheme is deferred until after v1
+- custom URL handoff via `camerabridge://permission` for app activation and onboarding
 
 ---
 
@@ -207,7 +207,7 @@ v1 must maintain:
 - onboarding flow
 - basic docs and Python example
 - release-readiness smoke test documentation
-- custom URL scheme remains deferred
+- custom URL handoff for app activation and onboarding
 
 ---
 

--- a/tests/CameraBridgeAppTests/CameraBridgeAppDeepLinkTests.swift
+++ b/tests/CameraBridgeAppTests/CameraBridgeAppDeepLinkTests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import CameraBridgeClientSwift
+import CameraBridgeSupport
+import Testing
+@testable import CameraBridgeApp
+
+@Test
+func deepLinkParserAcceptsTheCanonicalPermissionURL() {
+    #expect(CameraBridgeAppDeepLink(string: "camerabridge://permission") == .permission)
+}
+
+@Test
+func deepLinkParserRejectsUnsupportedAndMalformedInputs() {
+    #expect(CameraBridgeAppDeepLink(string: "camera-bridge://permission") == nil)
+    #expect(CameraBridgeAppDeepLink(string: "camerabridge://open") == nil)
+    #expect(CameraBridgeAppDeepLink(string: "camerabridge://permission/status") == nil)
+    #expect(CameraBridgeAppDeepLink(string: "camerabridge://permission?prompt=true") == nil)
+    #expect(CameraBridgeAppDeepLink(string: "://permission") == nil)
+}
+
+@Test
+@MainActor
+func supportedDeepLinkRefreshesStateAndPreservesExplicitActionBoundaries() async {
+    let client = DeepLinkTestCameraBridgeAppClient()
+    await client.setServiceIsRunning(false)
+    let permissionController = DeepLinkTestPermissionController(currentStatus: .notDetermined)
+    let serviceController = DeepLinkTestServiceController(state: .stopped)
+    let model = CameraBridgeAppModel(
+        client: client,
+        runtimeConfigurationStore: DeepLinkTestRuntimeConfigurationStore(configuration: .init(host: "127.0.0.1", port: 9100)),
+        runtimeInfoStore: DeepLinkTestRuntimeInfoStore(runtimeInfo: nil),
+        permissionController: permissionController,
+        serviceController: serviceController
+    )
+    let presenter = FakeStatusPresenter()
+    let router = CameraBridgeAppDeepLinkRouter(statusRefresher: model, statusPresenter: presenter)
+
+    let handled = await router.handle("camerabridge://permission")
+
+    #expect(handled)
+    #expect(model.statusSummaryTitle == "Local service is stopped")
+    #expect(model.permissionStatusTitle == "Not Determined")
+    #expect(presenter.presentCount == 1)
+    #expect(serviceController.startCount == 0)
+    #expect(serviceController.stopCount == 0)
+    #expect(permissionController.requestCount == 0)
+}
+
+@Test
+@MainActor
+func unsupportedDeepLinkIsIgnoredWithoutPresentation() async {
+    let refresher = FakeStatusRefresher()
+    let presenter = FakeStatusPresenter()
+    let router = CameraBridgeAppDeepLinkRouter(statusRefresher: refresher, statusPresenter: presenter)
+
+    let handled = await router.handle("camerabridge://open")
+
+    #expect(!handled)
+    #expect(refresher.refreshCount == 0)
+    #expect(presenter.presentCount == 0)
+}
+
+@Test
+@MainActor
+func menuPresenterQueuesColdLaunchPresentationUntilStatusItemExists() {
+    let driver = FakeStatusMenuDriver(canPresentStatusMenu: false)
+    let presenter = CameraBridgeAppStatusMenuPresenter(driver: driver)
+
+    presenter.presentStatusMenu()
+
+    #expect(driver.activateCount == 1)
+    #expect(driver.openCount == 0)
+
+    driver.canPresentStatusMenu = true
+    presenter.statusMenuPresentationDidBecomeAvailable()
+
+    #expect(driver.activateCount == 2)
+    #expect(driver.openCount == 1)
+}
+
+@Test
+@MainActor
+func menuPresenterDoesNotToggleTheMenuClosedOnRepeatedOpens() {
+    let driver = FakeStatusMenuDriver(canPresentStatusMenu: true)
+    let presenter = CameraBridgeAppStatusMenuPresenter(driver: driver)
+
+    presenter.presentStatusMenu()
+    presenter.statusMenuWillOpen()
+    presenter.presentStatusMenu()
+
+    #expect(driver.activateCount == 2)
+    #expect(driver.openCount == 1)
+
+    presenter.statusMenuDidClose()
+    presenter.presentStatusMenu()
+
+    #expect(driver.openCount == 2)
+}
+
+@MainActor
+private final class FakeStatusPresenter: CameraBridgeAppStatusPresenting {
+    private(set) var presentCount = 0
+
+    func presentStatusMenuForDeepLink() {
+        presentCount += 1
+    }
+}
+
+@MainActor
+private final class FakeStatusRefresher: CameraBridgeAppStatusRefreshing {
+    private(set) var refreshCount = 0
+
+    func refreshNow() async {
+        refreshCount += 1
+    }
+}
+
+@MainActor
+private final class FakeStatusMenuDriver: CameraBridgeAppStatusMenuDriving {
+    var canPresentStatusMenu: Bool
+    private(set) var activateCount = 0
+    private(set) var openCount = 0
+
+    init(canPresentStatusMenu: Bool) {
+        self.canPresentStatusMenu = canPresentStatusMenu
+    }
+
+    func activateAppForStatusMenu() {
+        activateCount += 1
+    }
+
+    func openStatusMenu() {
+        openCount += 1
+    }
+}
+
+private actor DeepLinkTestCameraBridgeAppClient: CameraBridgeAppClient {
+    private var isRunning = false
+
+    func setServiceIsRunning(_ value: Bool) {
+        isRunning = value
+    }
+
+    func serviceIsRunning() async -> Bool {
+        isRunning
+    }
+}
+
+private struct DeepLinkTestRuntimeConfigurationStore: CameraBridgeRuntimeConfigurationReading {
+    var configuration: CameraBridgeRuntimeConfiguration
+
+    func loadConfiguration() throws -> CameraBridgeRuntimeConfiguration {
+        configuration
+    }
+}
+
+private struct DeepLinkTestRuntimeInfoStore: CameraBridgeRuntimeInfoReading {
+    let runtimeInfo: CameraBridgeRuntimeInfo?
+
+    func loadRuntimeInfo() throws -> CameraBridgeRuntimeInfo? {
+        runtimeInfo
+    }
+}
+
+@MainActor
+private final class DeepLinkTestPermissionController: CameraBridgeAppPermissionControlling {
+    private(set) var requestCount = 0
+    var currentStatus: CameraBridgePermissionStatus
+
+    init(currentStatus: CameraBridgePermissionStatus) {
+        self.currentStatus = currentStatus
+    }
+
+    func currentPermissionStatus() -> CameraBridgePermissionStatus {
+        currentStatus
+    }
+
+    func requestPermission() async -> CameraBridgePermissionRequestResult {
+        requestCount += 1
+        return .init(status: currentStatus, prompted: false)
+    }
+}
+
+@MainActor
+private final class DeepLinkTestServiceController: CameraBridgeServiceControlling {
+    var state: CameraBridgeManagedServiceState
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+
+    init(state: CameraBridgeManagedServiceState) {
+        self.state = state
+    }
+
+    func startIfNeeded() async throws {
+        startCount += 1
+    }
+
+    func stopIfManaged() async throws {
+        stopCount += 1
+    }
+
+    func currentManagementState() async -> CameraBridgeManagedServiceState {
+        state
+    }
+}

--- a/tests/CameraBridgeAppTests/CameraBridgeAppModelTests.swift
+++ b/tests/CameraBridgeAppTests/CameraBridgeAppModelTests.swift
@@ -267,6 +267,8 @@ private final class FakeServiceController: CameraBridgeServiceControlling {
     var state: CameraBridgeManagedServiceState
     var startError: Error?
     var stopError: Error?
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
     private var startContinuation: CheckedContinuation<Void, Never>?
     private var stopContinuation: CheckedContinuation<Void, Never>?
 
@@ -275,6 +277,8 @@ private final class FakeServiceController: CameraBridgeServiceControlling {
     }
 
     func startIfNeeded() async throws {
+        startCount += 1
+
         if let startError {
             throw startError
         }
@@ -285,6 +289,8 @@ private final class FakeServiceController: CameraBridgeServiceControlling {
     }
 
     func stopIfManaged() async throws {
+        stopCount += 1
+
         if let stopError {
             throw stopError
         }


### PR DESCRIPTION
## Summary
- register the `camerabridge://permission` URL scheme in `CameraBridgeApp`
- handle custom URL opens in the LSUIElement menu bar app and surface the existing status menu without auto-starting `camd` or auto-prompting for permission
- make contributor-local packaging repeatable by staging the local app bundle under `/tmp` instead of `.build`

## Files Changed
- app metadata and deep-link routing/presentation in `CameraBridgeApp`
- app unit coverage for parsing, routing, and menu presentation behavior
- contributor and API docs for the concrete `open_camera_bridge_app` handoff
- local packaging script and contributor-facing packaging paths

## How Tested
- `swift test --filter CameraBridgeAppTests`
- `swift build --product CameraBridgeApp`
- `apps/CameraBridgeApp/scripts/package-app.sh`
- manual: launched the packaged app from `/tmp/CameraBridgeApp-local/CameraBridgeApp.app`
- manual: ran `open "camerabridge://permission"` with the app stopped and confirmed it launched with the menu visible
- manual: ran `open "camerabridge://permission"` with the app already running and confirmed the menu stayed visible with no daemon auto-start and no automatic permission prompt

## Intentionally Deferred
- additional deep-link routes beyond `camerabridge://permission`
- any `next_step.url` API payload change
- automatic permission prompting or daemon start as a deep-link side effect

Closes #130
Closes #131
Closes #132
Closes #133
Closes #134
Closes #135