### PR TITLE
[Chore]: Fix release checksum output and record v0.1.1 validation

### DIFF
--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -241,6 +241,21 @@ Fill this in during the manual run:
 ### Latest Recorded Downloaded-Artifact Run
 
 - Date: 2026-03-22
+- Release: `v0.1.1`
+- Machine: Mac17,3
+- macOS version: 26.3.1 (25D2128)
+- Camera device: Not exercised in this downloaded-artifact validation run
+- Result: Partial
+- Notes:
+  - Local maintainer release run completed Developer ID signing, notarization with `Accepted`, stapling, and `stapler validate`
+  - The staged-path `spctl --type open` check returned `source=Insufficient Context`, which remained advisory and did not contradict the downloaded-artifact validation
+  - The published `CameraBridgeApp-v0.1.1-macos.zip` artifact was downloaded from GitHub Releases and its SHA-256 digest matched `99574e2d81c05140eceb7bba979d6f01b86c3d78307ccb39bfb86b1d9960678b`
+  - The downloaded app passed `codesign --verify` and `xcrun stapler validate`
+  - The downloaded app bundle was installed to `/Applications`, reported `CFBundleShortVersionString=0.1.1`, launched successfully, and responded to `open 'camerabridge://permission'`
+  - The published `.sha256` file still contained the build-path filename rather than the release-asset filename, and that script behavior was corrected after publication for future releases
+  - A full real-camera packaged-flow smoke test from the downloaded `v0.1.1` artifact still needs to be recorded separately
+
+- Date: 2026-03-22
 - Release: `v0.1.0`
 - Machine: Mac17,3
 - macOS version: 26.3.1 (25D2128)

--- a/scripts/release/create-release-artifacts.sh
+++ b/scripts/release/create-release-artifacts.sh
@@ -75,6 +75,7 @@ APP_PATH="$STAGE_DIR/CameraBridgeApp.app"
 NOTARIZATION_ZIP="$OUTPUT_DIR/${ARTIFACT_PREFIX}-notarization.zip"
 RELEASE_ZIP="$OUTPUT_DIR/${ARTIFACT_PREFIX}.zip"
 CHECKSUM_FILE="$OUTPUT_DIR/${ARTIFACT_PREFIX}.zip.sha256"
+RELEASE_ZIP_NAME="$(basename "$RELEASE_ZIP")"
 
 mkdir -p "$STAGE_DIR"
 rm -f "$NOTARIZATION_ZIP" "$RELEASE_ZIP" "$CHECKSUM_FILE"
@@ -114,7 +115,10 @@ if [[ "$SIGNING_MODE" == "developer-id" && "$SKIP_NOTARIZATION" != "1" ]]; then
 fi
 
 ditto -c -k --keepParent "$APP_PATH" "$RELEASE_ZIP"
-shasum -a 256 "$RELEASE_ZIP" > "$CHECKSUM_FILE"
+(
+    cd "$OUTPUT_DIR"
+    shasum -a 256 "$RELEASE_ZIP_NAME"
+) > "$CHECKSUM_FILE"
 
 codesign --verify --strict --verbose=2 "$APP_PATH"
 


### PR DESCRIPTION
## Summary
- write release `.sha256` files with the published asset filename instead of the build-path filename
- record the `v0.1.1` downloaded-artifact validation in the release-readiness doc

## How Tested
- `scripts/release/create-release-artifacts.sh --version v0.1.2-rc.1 --signing-mode adhoc --skip-notarization` with `CAMERABRIDGE_RELEASE_OUTPUT_DIR=/tmp/CameraBridge-checksum-smoke`
- confirmed the generated checksum file contains `CameraBridgeApp-v0.1.2-rc.1-macos.zip` as the filename
- completed the `v0.1.1` downloaded-artifact validation flow and recorded the results in `docs/release-readiness.md`

## Notes
- The recorded `v0.1.1` downloaded-artifact run is intentionally marked partial because the full real-camera packaged-flow smoke test was not rerun from the published artifact.
- The temporary `/tmp/CameraBridgeApp-pre-v0.1.1.app.backup` app backup created during release validation was removed.