### PR TITLE
[Docs]: Refresh packaged-flow install, compatibility, and homepage copy

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -39,6 +39,8 @@ management.
 - if permission is still undecided, downstream apps should expect the guided
   `POST /v1/permissions/request` response and direct the user to
   `CameraBridgeApp`
+- local macOS clients may satisfy that user-facing handoff with
+  `camerabridge://permission` as a convenience path to the installed app
 
 ## Packaged Flow Assumptions
 
@@ -56,4 +58,6 @@ guidance, support, and manual verification.
 That path is not the downstream runtime compatibility guarantee. Downstream
 code should not hardcode the bundle path as a discovery mechanism. If an
 integrating app wants to help the user find or launch CameraBridge, it should
-do so as a UX convenience rather than as part of the runtime contract.
+do so as a UX convenience rather than as part of the runtime contract. The
+supported convenience handoff for local macOS integrations is
+`camerabridge://permission`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,7 +29,12 @@ shasum -a 256 CameraBridgeApp-v0.x.y-macos.zip
 cat CameraBridgeApp-v0.x.y-macos.zip.sha256
 ```
 
-The output lines should match exactly.
+Compare the SHA-256 digest values. The hexadecimal digest should match before
+you install the app.
+
+For the published `v0.1.1` release specifically, the `.sha256` file still
+contains the original build-path filename rather than the downloaded asset
+filename. Treat the digest as authoritative for that release.
 
 3. Unzip the archive.
 4. Move `CameraBridgeApp.app` into `/Applications/`.
@@ -51,6 +56,13 @@ In the supported packaged flow:
 
 External apps should treat CameraBridge as an external local service that may
 require the user to launch the app first.
+
+If a local macOS client receives `next_step.kind = open_camera_bridge_app`, it
+can hand off the user to the installed app with:
+
+```bash
+open "camerabridge://permission"
+```
 
 ## Upgrade
 

--- a/site/index.html
+++ b/site/index.html
@@ -6,7 +6,7 @@
     <title>CameraBridge | Local macOS camera service over localhost</title>
     <meta
       name="description"
-      content="CameraBridge is a local macOS camera service with a small, versioned localhost API for apps, scripts, and local software."
+      content="CameraBridge is a signed macOS menu bar app and local camera service with a small, versioned localhost API for apps, scripts, and local software."
     />
     <meta
       property="og:title"
@@ -14,7 +14,7 @@
     />
     <meta
       property="og:description"
-      content="A narrow local macOS camera service with explicit permissions, device discovery, session control, and still capture."
+      content="A narrow local macOS camera service with a signed app, explicit permissions, device discovery, session control, and still capture."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://rschroed.github.io/CameraBridge/" />
@@ -25,7 +25,7 @@
     />
     <meta
       name="twitter:description"
-      content="A local macOS camera service for apps and scripts without embedding AVFoundation."
+      content="A signed local macOS camera service for apps and scripts without embedding AVFoundation."
     />
     <link rel="stylesheet" href="styles.css" />
   </head>
@@ -45,9 +45,10 @@
           <p class="eyebrow">Local-only macOS camera service</p>
           <h1>Local camera access on macOS, through one narrow localhost boundary.</h1>
           <p class="hero-copy">
-            CameraBridge exposes AVFoundation through a small, versioned local API
-            so apps, scripts, and local software can use the camera through one
-            deliberate macOS service instead of embedding native glue repeatedly.
+            CameraBridge ships as a signed menu bar app plus a small, versioned
+            localhost API so apps, scripts, and local software can rely on one
+            deliberate macOS camera service instead of embedding native glue
+            repeatedly.
           </p>
           <div class="hero-actions">
             <a class="button button-primary" href="https://github.com/rschroed/CameraBridge/releases"
@@ -61,7 +62,8 @@
             >
           </div>
           <ul class="hero-meta" aria-label="Highlights">
-            <li>Explicit camera permission state</li>
+            <li>Signed packaged app for install, status, and service control</li>
+            <li>Explicit camera permission state and recovery path</li>
             <li>Localhost API for device and session control</li>
             <li>Still photo capture with local artifact metadata</li>
           </ul>
@@ -121,9 +123,10 @@
             </p>
           </div>
           <p class="section-copy">
-            Clients speak HTTP. CameraBridge owns native camera interaction. macOS
-            still owns permissions. The result is a predictable local boundary
-            instead of app-specific camera code.
+            Clients speak HTTP. CameraBridge owns native camera interaction and
+            the menu bar app owns onboarding and status visibility. macOS still
+            owns permissions. The result is a predictable local boundary instead
+            of app-specific camera code.
           </p>
         </section>
 
@@ -146,8 +149,9 @@
             <article class="scope-block">
               <p class="item-label">Local product shape</p>
               <ul>
-                <li><code>camd</code> daemon and CLI entrypoint</li>
-                <li>Menu bar app for onboarding and status</li>
+                <li>Signed <code>CameraBridgeApp</code> bundle for install and lifecycle</li>
+                <li>Bundled <code>camd</code> daemon managed by the app</li>
+                <li>Menu bar onboarding, status, and permission recovery</li>
                 <li>Single active camera session model</li>
                 <li>Implicit ownership via session start in v1</li>
                 <li>Structured logs and local artifact metadata</li>
@@ -219,9 +223,11 @@ curl -s -X POST http://127.0.0.1:8731/v1/capture/photo \
           <p class="annotation">Readable by humans. Legible to agents.</p>
           <p class="section-copy">
             The shipped path is intentionally small but real: discover a device,
-            use the local bearer token surfaced by the app, start the session,
-            and capture a still image. For a minimal end-to-end helper, the repo
-            also ships a Python first-capture example.
+            use the local bearer token surfaced by the installed app, start the
+            session, and capture a still image. If permission needs user
+            attention, local macOS clients can hand off to the app through the
+            documented `camerabridge://permission` flow. For a minimal end-to-end
+            helper, the repo also ships a Python first-capture example.
           </p>
         </section>
 
@@ -231,9 +237,9 @@ curl -s -X POST http://127.0.0.1:8731/v1/capture/photo \
             <h2 id="cta-title">Start with the packaged flow.</h2>
           </div>
           <p class="section-copy">
-            External adopters should install the signed app bundle first, then
-            use the install guide for setup and the API contract when wiring a
-            local client against the current v1 surface.
+            External adopters should install the signed app bundle first, use
+            the menu bar app for service start and permission recovery, and then
+            wire local clients against the current v1 localhost API surface.
           </p>
           <div class="cta-actions">
             <a class="button button-primary" href="https://github.com/rschroed/CameraBridge/releases"


### PR DESCRIPTION
Closes #138

## Summary
- update the install guide checksum wording for the published `v0.1.1` assets
- make the compatibility guide name the concrete `camerabridge://permission` handoff
- refresh homepage copy so it reflects the signed packaged app, menu bar onboarding/status flow, and localhost API

## Files Changed
- `docs/install.md`
- `docs/compatibility.md`
- `site/index.html`

## How Tested
- `git diff --check`
- read-through verification of the changed install, compatibility, and homepage sections
- confirmed the homepage release/install/API links remain pointed at the intended GitHub destinations

## Intentionally Deferred
- no API changes
- no release reissue for the published `v0.1.1` checksum filename caveat
- no broader docs rewrite beyond these three files