### PR TITLE
Surface selected camera device in CameraBridgeApp menu

### DIFF
--- a/apps/CameraBridgeApp/README.md
+++ b/apps/CameraBridgeApp/README.md
@@ -119,6 +119,7 @@ Use the packaged app bundle for manual verification:
 3. Confirm the menu shows:
    - a clear service status row
    - a clear permission status row
+   - a selected camera row that shows `None`, the resolved device name, or `Unavailable (<device id>)`
    - a guidance row describing the next onboarding step
    - developer-info rows for base URL, token path, log path, and captures path
 4. With permission not yet granted, confirm `Request Camera Access` is enabled even before the service is started.
@@ -126,9 +127,11 @@ Use the packaged app bundle for manual verification:
 6. Confirm that clicking `Request Camera Access` prompts from `CameraBridgeApp`.
 7. After granting permission, confirm the menu reports that CameraBridge is ready.
 8. Confirm `Stop CameraBridge Service` returns the menu to the stopped state.
-9. Confirm quitting the app stops the managed daemon before exit.
-10. If service launch or permission request fails, confirm the last error row appears with readable wording.
-11. Quit the app, run `open "camerabridge://permission"`, and confirm the app relaunches with the menu visible.
-12. With the app already running and the menu open, run `open "camerabridge://permission"` again and confirm the menu stays visible without starting the service or prompting for permission.
+9. After selecting a device through the API, confirm the menu shows the selected device name while the service remains reachable, even if the session itself is stopped.
+10. If the selected device becomes unavailable, confirm the menu shows `Unavailable (<device id>)`.
+11. Confirm quitting the app stops the managed daemon before exit.
+12. If service launch or permission request fails, confirm the last error row appears with readable wording.
+13. Quit the app, run `open "camerabridge://permission"`, and confirm the app relaunches with the menu visible.
+14. With the app already running and the menu open, run `open "camerabridge://permission"` again and confirm the menu stays visible without starting the service or prompting for permission.
 
 Capture screenshots of the refined menu states when practical for PR notes.

--- a/apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift
+++ b/apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift
@@ -78,6 +78,23 @@ final class CameraBridgeAppModel {
         }
     }
 
+    private enum SelectedDeviceDisplay: Equatable {
+        case none
+        case available(String)
+        case unavailable(String)
+
+        var title: String {
+            switch self {
+            case .none:
+                return "Selected Camera: None"
+            case .available(let name):
+                return "Selected Camera: \(name)"
+            case .unavailable(let deviceID):
+                return "Selected Camera: Unavailable (\(deviceID))"
+            }
+        }
+    }
+
     private struct DeveloperInfo: Equatable {
         var baseURL: String
         var tokenPath: String
@@ -195,11 +212,16 @@ final class CameraBridgeAppModel {
         developerInfo.capturesPath
     }
 
+    var selectedDeviceStatusTitle: String {
+        selectedDeviceDisplay.title
+    }
+
     private var serviceStatus: ServiceStatus = .stopped
     private var permissionDisplay: PermissionDisplay = .unavailable
     private var lastError: String?
     private var isRequestInFlight = false
     private var refreshTimer: Timer?
+    private var selectedDeviceDisplay: SelectedDeviceDisplay = .none
     private var developerInfo = DeveloperInfo(
         baseURL: "Unavailable",
         tokenPath: "Unavailable",
@@ -303,7 +325,8 @@ final class CameraBridgeAppModel {
 
     private func refreshState() async {
         let permissionStatus = permissionController.currentPermissionStatus()
-        switch await serviceController.currentManagementState() {
+        let managementState = await serviceController.currentManagementState()
+        switch managementState {
         case .stopped:
             serviceStatus = .stopped
         case .runningManaged:
@@ -312,9 +335,31 @@ final class CameraBridgeAppModel {
             serviceStatus = .runningExternal
         }
         permissionDisplay = .init(permissionStatus: permissionStatus)
+        selectedDeviceDisplay = await loadSelectedDeviceDisplay(for: managementState)
         developerInfo = loadDeveloperInfo()
         lastError = nil
         publishChange()
+    }
+
+    private func loadSelectedDeviceDisplay(
+        for managementState: CameraBridgeManagedServiceState
+    ) async -> SelectedDeviceDisplay {
+        guard managementState != .stopped else {
+            return .none
+        }
+
+        guard let sessionSnapshot = try? await client.sessionState(),
+              let activeDeviceID = sessionSnapshot.activeDeviceID
+        else {
+            return .none
+        }
+
+        let devices = (try? await client.devices()) ?? []
+        if let device = devices.first(where: { $0.id == activeDeviceID }) {
+            return .available(device.name)
+        }
+
+        return .unavailable(activeDeviceID)
     }
 
     private func performStartService() async {
@@ -447,6 +492,8 @@ extension DefaultCameraBridgeRuntimeInfoStore: CameraBridgeRuntimeInfoReading {}
 
 protocol CameraBridgeAppClient {
     func serviceIsRunning() async -> Bool
+    func devices() async throws -> [CameraBridgeDevice]
+    func sessionState() async throws -> CameraBridgeSessionSnapshot
 }
 
 extension CameraBridgeClient: CameraBridgeAppClient {}

--- a/apps/CameraBridgeApp/Sources/CameraBridgeApp/main.swift
+++ b/apps/CameraBridgeApp/Sources/CameraBridgeApp/main.swift
@@ -153,6 +153,7 @@ final class CameraBridgeStatusBarDelegate: NSObject, NSApplicationDelegate, NSMe
 
         menu.addItem(disabledItem(title: "Service: \(model.serviceStatusTitle)"))
         menu.addItem(disabledItem(title: "Permission: \(model.permissionStatusTitle)"))
+        menu.addItem(disabledItem(title: model.selectedDeviceStatusTitle))
         menu.addItem(disabledItem(title: model.guidanceMessage))
 
         if let lastError = model.lastErrorMessage {

--- a/apps/camd/Sources/camd/CameraBridgeDaemon.swift
+++ b/apps/camd/Sources/camd/CameraBridgeDaemon.swift
@@ -88,7 +88,7 @@ struct CameraBridgeDaemon {
                 permissionStatusProvider: permissionStatusProvider
             ),
             deviceListing: deviceListing,
-            photoProducer: AVFoundationStillPhotoProducer(),
+            stillSessionManager: AVFoundationStillSessionManager(),
             artifactStore: DefaultPhotoArtifactStore()
         )
         let authToken = try configuration.resolvedAuthToken()

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -229,6 +229,7 @@ Behavior:
 - reads that permission precondition from the same live daemon-visible permission state exposed by the permission endpoints in the shipped v1 slice
 - requires a previously selected `active_device_id`
 - does not implicitly pick or change the active device
+- prepares a live still-photo AVFoundation session for the selected device before reporting success
 - successful start sets `state` to `running` and `owner_id` to the provided caller identity
 - if another owner already holds the session, returns an ownership conflict
 
@@ -316,6 +317,7 @@ Behavior:
 - validates `device_id` against the Core device inventory
 - does not auto-start the camera session
 - does not create or transfer ownership
+- rejects device changes while the session is already `running`; callers must stop, select, and start again
 - if `owner_id` does not match the existing `owner_id`, returns an ownership conflict
 - if no session owner exists yet, device selection may succeed but the response `owner_id` remains unchanged
 
@@ -335,7 +337,7 @@ Error cases:
 - `401 unauthorized` when the bearer token is missing or invalid
 - `400 invalid_request` when the body is missing or malformed
 - `409 ownership_conflict` when another owner already controls the session
-- `409 invalid_state` when the requested device is unknown or unavailable
+- `409 invalid_state` when the session is already running or the requested device is unknown or unavailable
 
 ### `POST /v1/capture/photo`
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -7,6 +7,7 @@ This validation requires:
 
 - a real Mac
 - a real local camera device
+- at least one recorded run on a built-in Apple camera before release signoff
 - the packaged `CameraBridgeApp.app` bundle
 
 It is intentionally manual. CI should continue to avoid hardware dependencies.
@@ -163,6 +164,7 @@ Expected checkpoints:
 - device selection succeeds
 - session start succeeds
 - still capture succeeds
+- the first captured JPEG is visibly usable on a built-in Apple camera and is not severely underexposed
 - session stop succeeds
 - the reported `local_path` exists on disk under `~/Library/Application Support/CameraBridge/Captures/`
 
@@ -199,6 +201,7 @@ release:
 
 - [ ] Machine and macOS version recorded
 - [ ] Camera device model or built-in camera noted
+- [ ] Built-in Apple camera first-capture flow recorded for this release
 - [ ] `swift build` passed
 - [ ] `swift test` passed
 - [ ] Published GitHub Release zip downloaded successfully
@@ -221,6 +224,7 @@ release:
 - [ ] Stale `permission-state` file had no effect on daemon permission responses
 - [ ] `GET /v1/devices` returned the expected camera
 - [ ] Python first-capture example completed successfully
+- [ ] Built-in Apple camera capture was visibly usable and not severely underexposed
 - [ ] Capture artifact existed at the reported `local_path`
 - [ ] `GET /v1/session` returned `stopped` after cleanup
 - [ ] `Stop CameraBridge Service` returned the app to the stopped state
@@ -239,6 +243,8 @@ Fill this in during the manual run:
 - Notes:
 
 ### Latest Recorded Downloaded-Artifact Run
+
+The historical runs below predate issue `#141`. External-camera-only validation is no longer sufficient for release signoff; at least one built-in Apple camera run must also be recorded.
 
 - Date: 2026-03-22
 - Release: `v0.1.1`

--- a/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
+++ b/packages/CameraBridgeAPI/Sources/CameraBridgeAPI/CameraBridgeAPI.swift
@@ -320,6 +320,12 @@ public enum CameraBridgeRoutes {
                         code: "ownership_conflict",
                         message: "Session is owned by \(currentOwnerID)"
                     )
+                case .sessionRunning:
+                    return .error(
+                        statusCode: 409,
+                        code: "invalid_state",
+                        message: "Cannot change active device while session is running"
+                    )
                 case .unavailableDevice(let id):
                     return .error(
                         statusCode: 409,

--- a/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
+++ b/packages/CameraBridgeCore/Sources/CameraBridgeCore/CameraBridgeCore.swift
@@ -119,6 +119,7 @@ public protocol CameraPhotoCapturing: Sendable {
 
 public enum CameraDeviceSelectionError: Error, Sendable, Equatable {
     case ownershipConflict(currentOwnerID: String)
+    case sessionRunning
     case unavailableDevice(id: String)
 }
 
@@ -152,8 +153,10 @@ public enum CameraPhotoCaptureError: Error, Sendable, Equatable {
     case captureFailed(message: String)
 }
 
-public protocol CameraStillPhotoProducing: Sendable {
-    func capturePhotoData(deviceID: String) throws -> Data
+public protocol CameraStillSessionManaging: Sendable {
+    func start(deviceID: String) throws
+    func capturePhotoData() throws -> Data
+    func stop()
 }
 
 public protocol PhotoArtifactStoring: Sendable {
@@ -264,25 +267,51 @@ public struct DefaultPhotoArtifactStore: PhotoArtifactStoring {
     }
 }
 
-public struct UnimplementedStillPhotoProducer: CameraStillPhotoProducing {
+public final class UnimplementedStillSessionManager: CameraStillSessionManaging, @unchecked Sendable {
     public init() {}
 
-    public func capturePhotoData(deviceID: String) throws -> Data {
+    public func start(deviceID _: String) throws {
         throw CameraPhotoCaptureError.captureFailed(message: "Still photo capture is not configured")
     }
-}
 
-public struct AVFoundationStillPhotoProducer: CameraStillPhotoProducing {
-    public var timeout: TimeInterval
-
-    public init(timeout: TimeInterval = 10) {
-        self.timeout = timeout
+    public func capturePhotoData() throws -> Data {
+        throw CameraPhotoCaptureError.captureFailed(message: "Still photo capture is not configured")
     }
 
-    public func capturePhotoData(deviceID: String) throws -> Data {
+    public func stop() {}
+}
+
+public final class AVFoundationStillSessionManager: CameraStillSessionManaging, @unchecked Sendable {
+    public var captureTimeout: TimeInterval
+    public var exposureSettleTimeout: TimeInterval
+    public var exposurePollInterval: TimeInterval
+    public var warmupFrameCount: Int
+
+    private let lock = NSLock()
+    private let warmupDelegate = StillSessionWarmupDelegate()
+    private let warmupQueue = DispatchQueue(label: "CameraBridgeCore.StillSessionWarmup")
+    private var session: AVCaptureSession?
+    private var photoOutput: AVCapturePhotoOutput?
+    private var videoOutput: AVCaptureVideoDataOutput?
+
+    public init(
+        captureTimeout: TimeInterval = 10,
+        exposureSettleTimeout: TimeInterval = 2,
+        exposurePollInterval: TimeInterval = 0.05,
+        warmupFrameCount: Int = 10
+    ) {
+        self.captureTimeout = captureTimeout
+        self.exposureSettleTimeout = exposureSettleTimeout
+        self.exposurePollInterval = exposurePollInterval
+        self.warmupFrameCount = warmupFrameCount
+    }
+
+    public func start(deviceID: String) throws {
         guard let device = discoverDevice(id: deviceID) else {
             throw CameraPhotoCaptureError.unavailableDevice(id: deviceID)
         }
+
+        stop()
 
         let session = AVCaptureSession()
         session.beginConfiguration()
@@ -304,11 +333,50 @@ public struct AVFoundationStillPhotoProducer: CameraStillPhotoProducing {
             throw CameraPhotoCaptureError.captureFailed(message: "Unable to add photo output to capture session")
         }
 
+        let videoOutput = AVCaptureVideoDataOutput()
+        videoOutput.alwaysDiscardsLateVideoFrames = true
+        videoOutput.setSampleBufferDelegate(warmupDelegate, queue: warmupQueue)
+        guard session.canAddOutput(videoOutput) else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Unable to add video output to capture session")
+        }
+
         session.addInput(input)
         session.addOutput(output)
+        session.addOutput(videoOutput)
         session.commitConfiguration()
+
+        do {
+            try configureExposure(for: device)
+        } catch let error as CameraPhotoCaptureError {
+            throw error
+        } catch {
+            throw CameraPhotoCaptureError.captureFailed(message: error.localizedDescription)
+        }
+
+        warmupDelegate.prepareForWarmup(requiredFrames: warmupFrameCount)
         session.startRunning()
-        defer { session.stopRunning() }
+
+        do {
+            try waitForWarmupFrames(session: session)
+            try waitForExposureToSettle(device: device, session: session)
+        } catch {
+            session.stopRunning()
+            throw error
+        }
+
+        lock.lock()
+        self.session = session
+        self.photoOutput = output
+        self.videoOutput = videoOutput
+        lock.unlock()
+    }
+
+    public func capturePhotoData() throws -> Data {
+        let output: AVCapturePhotoOutput
+
+        lock.lock()
+        defer { lock.unlock() }
+        output = try requirePreparedOutputLocked()
 
         let delegate = StillPhotoCaptureDelegate()
         let settings: AVCapturePhotoSettings
@@ -319,7 +387,65 @@ public struct AVFoundationStillPhotoProducer: CameraStillPhotoProducing {
         }
 
         output.capturePhoto(with: settings, delegate: delegate)
-        return try delegate.waitForPhotoData(timeout: timeout)
+        return try delegate.waitForPhotoData(timeout: captureTimeout)
+    }
+
+    public func stop() {
+        lock.lock()
+        defer { lock.unlock() }
+        session?.stopRunning()
+        session = nil
+        photoOutput = nil
+        videoOutput = nil
+    }
+
+    private func requirePreparedOutputLocked() throws -> AVCapturePhotoOutput {
+        guard let session, session.isRunning, let photoOutput else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Still photo session is not running")
+        }
+
+        return photoOutput
+    }
+
+    private func configureExposure(for device: AVCaptureDevice) throws {
+        guard device.isExposureModeSupported(.continuousAutoExposure) else {
+            return
+        }
+
+        do {
+            try device.lockForConfiguration()
+        } catch {
+            throw CameraPhotoCaptureError.captureFailed(message: "Unable to configure camera exposure")
+        }
+
+        device.exposureMode = .continuousAutoExposure
+        device.unlockForConfiguration()
+    }
+
+    private func waitForExposureToSettle(
+        device: AVCaptureDevice,
+        session: AVCaptureSession
+    ) throws {
+        let deadline = Date().addingTimeInterval(exposureSettleTimeout)
+
+        while device.isAdjustingExposure && Date() < deadline {
+            Thread.sleep(forTimeInterval: exposurePollInterval)
+        }
+
+        guard session.isRunning else {
+            throw CameraPhotoCaptureError.captureFailed(
+                message: "Still photo session stopped during exposure warmup"
+            )
+        }
+    }
+
+    private func waitForWarmupFrames(session: AVCaptureSession) throws {
+        let receivedRequiredFrames = warmupDelegate.waitForRequiredFrames(timeout: exposureSettleTimeout)
+        guard receivedRequiredFrames || session.isRunning else {
+            throw CameraPhotoCaptureError.captureFailed(
+                message: "Still photo session stopped before warmup frames arrived"
+            )
+        }
     }
 
     private func discoverDevice(id: String) -> AVCaptureDevice? {
@@ -354,7 +480,7 @@ public final class DefaultCameraSessionController: CameraPermissionControlling, 
     private let permissionStatusProvider: any CameraPermissionStatusProviding
     private let permissionRequester: any CameraPermissionRequesting
     private let deviceListing: any CameraDeviceListing
-    private let photoProducer: any CameraStillPhotoProducing
+    private let stillSessionManager: any CameraStillSessionManaging
     private let artifactStore: any PhotoArtifactStoring
     private let now: @Sendable () -> Date
     private let stateLock = NSLock()
@@ -364,7 +490,7 @@ public final class DefaultCameraSessionController: CameraPermissionControlling, 
         permissionStatusProvider: any CameraPermissionStatusProviding = AVFoundationCameraPermissionStatusProvider(),
         permissionRequester: any CameraPermissionRequesting = AVFoundationCameraPermissionRequester(),
         deviceListing: any CameraDeviceListing,
-        photoProducer: any CameraStillPhotoProducing = UnimplementedStillPhotoProducer(),
+        stillSessionManager: any CameraStillSessionManaging = UnimplementedStillSessionManager(),
         artifactStore: any PhotoArtifactStoring = DefaultPhotoArtifactStore(),
         now: @escaping @Sendable () -> Date = { Date() },
         initialState: CameraState = CameraState()
@@ -372,7 +498,7 @@ public final class DefaultCameraSessionController: CameraPermissionControlling, 
         self.permissionStatusProvider = permissionStatusProvider
         self.permissionRequester = permissionRequester
         self.deviceListing = deviceListing
-        self.photoProducer = photoProducer
+        self.stillSessionManager = stillSessionManager
         self.artifactStore = artifactStore
         self.now = now
         self.state = initialState
@@ -380,7 +506,7 @@ public final class DefaultCameraSessionController: CameraPermissionControlling, 
 
     public convenience init(
         deviceListing: any CameraDeviceListing,
-        photoProducer: any CameraStillPhotoProducing = UnimplementedStillPhotoProducer(),
+        stillSessionManager: any CameraStillSessionManaging = UnimplementedStillSessionManager(),
         artifactStore: any PhotoArtifactStoring = DefaultPhotoArtifactStore(),
         now: @escaping @Sendable () -> Date = { Date() },
         initialState: CameraState = CameraState()
@@ -389,7 +515,7 @@ public final class DefaultCameraSessionController: CameraPermissionControlling, 
             permissionStatusProvider: AVFoundationCameraPermissionStatusProvider(),
             permissionRequester: AVFoundationCameraPermissionRequester(),
             deviceListing: deviceListing,
-            photoProducer: photoProducer,
+            stillSessionManager: stillSessionManager,
             artifactStore: artifactStore,
             now: now,
             initialState: initialState
@@ -439,6 +565,12 @@ public final class DefaultCameraSessionController: CameraPermissionControlling, 
             throw CameraDeviceSelectionError.ownershipConflict(currentOwnerID: currentOwnerID)
         }
 
+        if state.sessionState == .running {
+            let message = "Cannot change active device while session is running"
+            state.lastError = CameraStateError(message: message)
+            throw CameraDeviceSelectionError.sessionRunning
+        }
+
         guard deviceListing.availableDevices().contains(where: { $0.id == id }) else {
             let message = "Requested device is unavailable: \(id)"
             state.lastError = CameraStateError(message: message)
@@ -480,10 +612,20 @@ public final class DefaultCameraSessionController: CameraPermissionControlling, 
             throw CameraSessionLifecycleError.alreadyRunning
         }
 
-        state.sessionState = .running
-        state.currentOwnerID = ownerID
-        state.lastError = nil
-        return state
+        let activeDeviceID = state.activeDeviceID!
+
+        do {
+            try stillSessionManager.start(deviceID: activeDeviceID)
+            state.sessionState = .running
+            state.currentOwnerID = ownerID
+            state.lastError = nil
+            return state
+        } catch {
+            state.sessionState = .stopped
+            state.currentOwnerID = nil
+            state.lastError = CameraStateError(message: errorMessage(for: error))
+            throw error
+        }
     }
 
     public func stopSession(ownerID: String) throws -> CameraState {
@@ -508,6 +650,7 @@ public final class DefaultCameraSessionController: CameraPermissionControlling, 
             throw CameraSessionLifecycleError.ownershipConflict(currentOwnerID: currentOwnerID)
         }
 
+        stillSessionManager.stop()
         state.sessionState = .stopped
         state.previewState = .stopped
         state.currentOwnerID = nil
@@ -546,7 +689,7 @@ public final class DefaultCameraSessionController: CameraPermissionControlling, 
         let capturedAt = now()
 
         do {
-            let data = try photoProducer.capturePhotoData(deviceID: activeDeviceID)
+            let data = try stillSessionManager.capturePhotoData()
             let fileURL = try artifactStore.storePhotoData(
                 data,
                 deviceID: activeDeviceID,
@@ -633,6 +776,14 @@ private extension CameraPhotoCaptureError {
     }
 }
 
+private func errorMessage(for error: Error) -> String {
+    if let error = error as? CameraPhotoCaptureError {
+        return error.message
+    }
+
+    return error.localizedDescription
+}
+
 private final class StillPhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate, @unchecked Sendable {
     private let lock = NSLock()
     private let semaphore = DispatchSemaphore(value: 0)
@@ -683,5 +834,53 @@ private final class StillPhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDe
         if shouldSignal {
             semaphore.signal()
         }
+    }
+}
+
+private final class StillSessionWarmupDelegate: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, @unchecked Sendable {
+    private let lock = NSLock()
+    private var requiredFrames = 0
+    private var receivedFrames = 0
+
+    func prepareForWarmup(requiredFrames: Int) {
+        lock.lock()
+        self.requiredFrames = requiredFrames
+        receivedFrames = 0
+        lock.unlock()
+    }
+
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        _ = output
+        _ = sampleBuffer
+        _ = connection
+
+        lock.lock()
+        receivedFrames += 1
+        lock.unlock()
+    }
+
+    func waitForRequiredFrames(timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            lock.lock()
+            let isReady = receivedFrames >= requiredFrames
+            lock.unlock()
+
+            if isReady {
+                return true
+            }
+
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+
+        lock.lock()
+        let isReady = receivedFrames >= requiredFrames
+        lock.unlock()
+        return isReady
     }
 }

--- a/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
+++ b/tests/CameraBridgeAPITests/CameraBridgeAPITests.swift
@@ -725,6 +725,41 @@ func routerRejectsDeviceSelectionForOwnerMismatch() {
 }
 
 @Test
+func routerRejectsDeviceSelectionWhileSessionIsRunning() {
+    let sessionController = makeSessionController(
+        state: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        ),
+        devices: [
+            CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
+        ],
+        stillSessionManager: RecordingStillSessionManager(startedDeviceID: "camera-1")
+    )
+    let router = makeRouter(sessionController: sessionController)
+    let response = router.response(
+        for: HTTPRequest(
+            method: .post,
+            path: "/v1/session/select-device",
+            headers: ["Authorization": "Bearer test-token"],
+            body: Data(#"{"device_id":"camera-2","owner_id":"client-1"}"#.utf8)
+        )
+    )
+
+    #expect(response.statusCode == 409)
+    #expect(
+        String(decoding: response.body, as: UTF8.self) ==
+        #"{"error":{"code":"invalid_state","message":"Cannot change active device while session is running"}}"#
+    )
+    #expect(sessionController.currentCameraState().activeDeviceID == "camera-1")
+}
+
+@Test
 func routerReturnsUpdatedSessionStateForAuthorizedDeviceSelection() {
     let sessionController = makeSessionController(
         devices: [
@@ -840,6 +875,10 @@ func routerRejectsPhotoCaptureForOwnerMismatch() {
 func routerReturnsPhotoCaptureMetadataForAuthorizedOwner() throws {
     let directoryURL = makeTemporaryDirectory()
     let capturedAt = Date(timeIntervalSince1970: 1_710_000_000.123)
+    let stillSessionManager = RecordingStillSessionManager(
+        startedDeviceID: "camera-1",
+        data: Data([0x01, 0x02, 0x03])
+    )
     let sessionController = makeSessionController(
         state: CameraState(
             permissionState: .authorized,
@@ -849,7 +888,7 @@ func routerReturnsPhotoCaptureMetadataForAuthorizedOwner() throws {
             currentOwnerID: "client-1",
             lastError: nil
         ),
-        photoProducer: FixedStillPhotoProducer(data: Data([0x01, 0x02, 0x03])),
+        stillSessionManager: stillSessionManager,
         artifactStore: DefaultPhotoArtifactStore(baseDirectoryURL: directoryURL),
         now: { capturedAt }
     )
@@ -986,7 +1025,7 @@ private func makeSessionController(
     permissionRequester: any CameraPermissionRequesting = FixedPermissionRequester(
         result: .init(status: .authorized, prompted: false)
     ),
-    photoProducer: any CameraStillPhotoProducing = UnimplementedStillPhotoProducer(),
+    stillSessionManager: any CameraStillSessionManaging = RecordingStillSessionManager(),
     artifactStore: any PhotoArtifactStoring = DefaultPhotoArtifactStore(
         baseDirectoryURL: URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("CameraBridgeAPITests", isDirectory: true)
@@ -997,7 +1036,7 @@ private func makeSessionController(
         permissionStatusProvider: permissionStatusProvider,
         permissionRequester: permissionRequester,
         deviceListing: FixedDeviceListing(devices: devices),
-        photoProducer: photoProducer,
+        stillSessionManager: stillSessionManager,
         artifactStore: artifactStore,
         now: now,
         initialState: state
@@ -1028,11 +1067,33 @@ private struct FixedDeviceListing: CameraDeviceListing {
     }
 }
 
-private struct FixedStillPhotoProducer: CameraStillPhotoProducing {
-    let data: Data
+private final class RecordingStillSessionManager: CameraStillSessionManaging, @unchecked Sendable {
+    private var activeDeviceID: String?
+    private let data: Data?
 
-    func capturePhotoData(deviceID: String) throws -> Data {
-        data
+    init(startedDeviceID: String? = nil, data: Data? = nil) {
+        self.activeDeviceID = startedDeviceID
+        self.data = data
+    }
+
+    func start(deviceID: String) throws {
+        activeDeviceID = deviceID
+    }
+
+    func capturePhotoData() throws -> Data {
+        guard activeDeviceID != nil else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Still photo session is not running")
+        }
+
+        guard let data else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Missing test photo data")
+        }
+
+        return data
+    }
+
+    func stop() {
+        activeDeviceID = nil
     }
 }
 

--- a/tests/CameraBridgeAppTests/CameraBridgeAppDeepLinkTests.swift
+++ b/tests/CameraBridgeAppTests/CameraBridgeAppDeepLinkTests.swift
@@ -144,6 +144,14 @@ private actor DeepLinkTestCameraBridgeAppClient: CameraBridgeAppClient {
     func serviceIsRunning() async -> Bool {
         isRunning
     }
+
+    func devices() async throws -> [CameraBridgeDevice] {
+        []
+    }
+
+    func sessionState() async throws -> CameraBridgeSessionSnapshot {
+        .init(state: .stopped, activeDeviceID: nil, ownerID: nil, lastError: nil)
+    }
 }
 
 private struct DeepLinkTestRuntimeConfigurationStore: CameraBridgeRuntimeConfigurationReading {

--- a/tests/CameraBridgeAppTests/CameraBridgeAppModelTests.swift
+++ b/tests/CameraBridgeAppTests/CameraBridgeAppModelTests.swift
@@ -35,6 +35,7 @@ func stoppedServiceStateShowsLocalPermissionGuidanceAndDeveloperInfo() async {
     #expect(!model.canStopService)
     #expect(model.canRequestCameraAccess)
     #expect(model.developerBaseURL == "http://127.0.0.1:9100")
+    #expect(model.selectedDeviceStatusTitle == "Selected Camera: None")
 }
 
 @Test
@@ -42,6 +43,15 @@ func stoppedServiceStateShowsLocalPermissionGuidanceAndDeveloperInfo() async {
 func runningManagedServiceShowsReadyStateAndAllowsStop() async {
     let client = FakeCameraBridgeAppClient()
     await client.setServiceIsRunning(true)
+    await client.setSessionSnapshot(
+        .init(
+            state: .running,
+            activeDeviceID: "camera-1",
+            ownerID: "client-1",
+            lastError: nil
+        )
+    )
+    await client.setDevices([CameraBridgeDevice(id: "camera-1", name: "Built-in Camera", position: .front)])
     let permissionController = FakeCameraBridgeAppPermissionController(currentStatus: .authorized)
     let runtimeInfoStore = FakeRuntimeInfoStore(
         runtimeInfo: .init(
@@ -72,6 +82,7 @@ func runningManagedServiceShowsReadyStateAndAllowsStop() async {
     #expect(model.canStopService)
     #expect(model.developerBaseURL == "http://127.0.0.1:9101")
     #expect(model.developerTokenPath == "/tmp/auth-token")
+    #expect(model.selectedDeviceStatusTitle == "Selected Camera: Built-in Camera")
 }
 
 @Test
@@ -99,6 +110,94 @@ func runningExternalServiceShowsExternalStateAndDisablesStop() async {
         model.guidanceMessage ==
         "A local CameraBridge service is already running outside this app and camera access is available."
     )
+    #expect(model.selectedDeviceStatusTitle == "Selected Camera: None")
+}
+
+@Test
+@MainActor
+func stoppedSessionStillShowsResolvedSelectedDevice() async {
+    let client = FakeCameraBridgeAppClient()
+    await client.setServiceIsRunning(true)
+    await client.setSessionSnapshot(
+        .init(
+            state: .stopped,
+            activeDeviceID: "camera-2",
+            ownerID: nil,
+            lastError: nil
+        )
+    )
+    await client.setDevices([CameraBridgeDevice(id: "camera-2", name: "Desk Camera", position: .external)])
+    let model = CameraBridgeAppModel(
+        client: client,
+        runtimeConfigurationStore: FakeRuntimeConfigurationStore(configuration: .init()),
+        runtimeInfoStore: FakeRuntimeInfoStore(runtimeInfo: nil),
+        permissionController: FakeCameraBridgeAppPermissionController(currentStatus: .authorized),
+        serviceController: FakeServiceController(state: .runningExternal)
+    )
+
+    await model.refreshNow()
+
+    #expect(model.selectedDeviceStatusTitle == "Selected Camera: Desk Camera")
+}
+
+@Test
+@MainActor
+func missingSelectedDeviceShowsUnavailableStateWithPreservedID() async {
+    let client = FakeCameraBridgeAppClient()
+    await client.setServiceIsRunning(true)
+    await client.setSessionSnapshot(
+        .init(
+            state: .running,
+            activeDeviceID: "camera-missing",
+            ownerID: "client-1",
+            lastError: nil
+        )
+    )
+    await client.setDevices([CameraBridgeDevice(id: "camera-1", name: "Built-in Camera", position: .front)])
+    let model = CameraBridgeAppModel(
+        client: client,
+        runtimeConfigurationStore: FakeRuntimeConfigurationStore(configuration: .init()),
+        runtimeInfoStore: FakeRuntimeInfoStore(runtimeInfo: nil),
+        permissionController: FakeCameraBridgeAppPermissionController(currentStatus: .authorized),
+        serviceController: FakeServiceController(state: .runningManaged)
+    )
+
+    await model.refreshNow()
+
+    #expect(model.selectedDeviceStatusTitle == "Selected Camera: Unavailable (camera-missing)")
+}
+
+@Test
+@MainActor
+func refreshClearsSelectedDeviceWhenServiceBecomesStopped() async {
+    let client = FakeCameraBridgeAppClient()
+    await client.setServiceIsRunning(true)
+    await client.setSessionSnapshot(
+        .init(
+            state: .running,
+            activeDeviceID: "camera-1",
+            ownerID: "client-1",
+            lastError: nil
+        )
+    )
+    await client.setDevices([CameraBridgeDevice(id: "camera-1", name: "Built-in Camera", position: .front)])
+    let serviceController = FakeServiceController(state: .runningManaged)
+    let model = CameraBridgeAppModel(
+        client: client,
+        runtimeConfigurationStore: FakeRuntimeConfigurationStore(configuration: .init()),
+        runtimeInfoStore: FakeRuntimeInfoStore(runtimeInfo: nil),
+        permissionController: FakeCameraBridgeAppPermissionController(currentStatus: .authorized),
+        serviceController: serviceController
+    )
+
+    await model.refreshNow()
+    #expect(model.selectedDeviceStatusTitle == "Selected Camera: Built-in Camera")
+
+    await client.setServiceIsRunning(false)
+    serviceController.state = .stopped
+    await model.refreshNow()
+
+    #expect(model.selectedDeviceStatusTitle == "Selected Camera: None")
 }
 
 @Test
@@ -203,13 +302,36 @@ func permissionRequestDisablesActionWhilePromptIsInFlightAndSyncsAuthorizedState
 
 private actor FakeCameraBridgeAppClient: CameraBridgeAppClient {
     private var isRunning = false
+    private var devicesList: [CameraBridgeDevice] = []
+    private var sessionSnapshot = CameraBridgeSessionSnapshot(
+        state: .stopped,
+        activeDeviceID: nil,
+        ownerID: nil,
+        lastError: nil
+    )
 
     func setServiceIsRunning(_ value: Bool) {
         isRunning = value
     }
 
+    func setDevices(_ value: [CameraBridgeDevice]) {
+        devicesList = value
+    }
+
+    func setSessionSnapshot(_ value: CameraBridgeSessionSnapshot) {
+        sessionSnapshot = value
+    }
+
     func serviceIsRunning() async -> Bool {
         isRunning
+    }
+
+    func devices() async throws -> [CameraBridgeDevice] {
+        devicesList
+    }
+
+    func sessionState() async throws -> CameraBridgeSessionSnapshot {
+        sessionSnapshot
     }
 }
 

--- a/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
+++ b/tests/CameraBridgeCoreTests/CameraBridgeCoreTests.swift
@@ -221,12 +221,14 @@ func defaultCameraSessionControllerRejectsMismatchedOwner() {
 
 @Test
 func defaultCameraSessionControllerStartsSessionWithSelectedDeviceAndOwner() throws {
+    let stillSessionManager = RecordingStillSessionManager()
     let controller = DefaultCameraSessionController(
         deviceListing: FixedDeviceListing(
             devices: [
                 CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
             ]
         ),
+        stillSessionManager: stillSessionManager,
         initialState: CameraState(
             permissionState: .notDetermined,
             sessionState: .stopped,
@@ -244,6 +246,40 @@ func defaultCameraSessionControllerStartsSessionWithSelectedDeviceAndOwner() thr
     #expect(state.activeDeviceID == "camera-1")
     #expect(state.currentOwnerID == "client-1")
     #expect(state.lastError == nil)
+    #expect(stillSessionManager.startedDeviceIDs == ["camera-1"])
+}
+
+@Test
+func defaultCameraSessionControllerRejectsDeviceSelectionWhileSessionIsRunning() {
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+                CameraDevice(id: "camera-2", name: "Desk Camera", position: .external),
+            ]
+        ),
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .running,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: "client-1",
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.selectDevice(id: "camera-2", ownerID: "client-1")
+        Issue.record("Expected running session device selection to fail")
+    } catch let error as CameraDeviceSelectionError {
+        #expect(error == .sessionRunning)
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    let state = controller.currentCameraState()
+    #expect(state.activeDeviceID == "camera-1")
+    #expect(state.lastError == CameraStateError(message: "Cannot change active device while session is running"))
 }
 
 @Test
@@ -380,13 +416,53 @@ func defaultCameraSessionControllerRejectsStartForOwnerConflict() {
 }
 
 @Test
-func defaultCameraSessionControllerStopsRunningSessionAndReleasesOwner() throws {
+func defaultCameraSessionControllerRetainsStartFailureAsLastError() {
+    let stillSessionManager = RecordingStillSessionManager(
+        startError: CameraPhotoCaptureError.captureFailed(message: "Exposure warmup failed")
+    )
     let controller = DefaultCameraSessionController(
         deviceListing: FixedDeviceListing(
             devices: [
                 CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
             ]
         ),
+        stillSessionManager: stillSessionManager,
+        initialState: CameraState(
+            permissionState: .authorized,
+            sessionState: .stopped,
+            previewState: .stopped,
+            activeDeviceID: "camera-1",
+            currentOwnerID: nil,
+            lastError: nil
+        )
+    )
+
+    do {
+        _ = try controller.startSession(ownerID: "client-1", permissionState: .authorized)
+        Issue.record("Expected session start to surface session manager failure")
+    } catch let error as CameraPhotoCaptureError {
+        #expect(error == .captureFailed(message: "Exposure warmup failed"))
+    } catch {
+        Issue.record("Unexpected error: \(error)")
+    }
+
+    let state = controller.currentCameraState()
+    #expect(state.sessionState == .stopped)
+    #expect(state.activeDeviceID == "camera-1")
+    #expect(state.currentOwnerID == nil)
+    #expect(state.lastError == CameraStateError(message: "Exposure warmup failed"))
+}
+
+@Test
+func defaultCameraSessionControllerStopsRunningSessionAndReleasesOwner() throws {
+    let stillSessionManager = RecordingStillSessionManager(startedDeviceID: "camera-1")
+    let controller = DefaultCameraSessionController(
+        deviceListing: FixedDeviceListing(
+            devices: [
+                CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front),
+            ]
+        ),
+        stillSessionManager: stillSessionManager,
         initialState: CameraState(
             permissionState: .authorized,
             sessionState: .running,
@@ -404,6 +480,7 @@ func defaultCameraSessionControllerStopsRunningSessionAndReleasesOwner() throws 
     #expect(state.activeDeviceID == "camera-1")
     #expect(state.currentOwnerID == nil)
     #expect(state.lastError == nil)
+    #expect(stillSessionManager.stopCount == 1)
 }
 
 @Test
@@ -469,11 +546,15 @@ func defaultCameraSessionControllerCapturesPhotoForRunningOwnedSession() throws 
     let directoryURL = makeTemporaryDirectory()
     let capturedAt = Date(timeIntervalSince1970: 1_710_000_000.123)
     let expectedData = Data([0x01, 0x02, 0x03, 0x04])
+    let stillSessionManager = RecordingStillSessionManager(
+        startedDeviceID: "camera-1",
+        data: expectedData
+    )
     let controller = DefaultCameraSessionController(
         deviceListing: FixedDeviceListing(
             devices: [CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front)]
         ),
-        photoProducer: FixedStillPhotoProducer(data: expectedData),
+        stillSessionManager: stillSessionManager,
         artifactStore: DefaultPhotoArtifactStore(baseDirectoryURL: directoryURL),
         now: { capturedAt },
         initialState: CameraState(
@@ -493,6 +574,7 @@ func defaultCameraSessionControllerCapturesPhotoForRunningOwnedSession() throws 
     #expect(artifact.localPath.hasPrefix(directoryURL.path))
     #expect(try Data(contentsOf: URL(fileURLWithPath: artifact.localPath)) == expectedData)
     #expect(controller.currentCameraState().lastError == nil)
+    #expect(stillSessionManager.captureCount == 1)
 }
 
 @Test
@@ -553,13 +635,15 @@ func defaultCameraSessionControllerRejectsCaptureForOwnerMismatch() {
 
 @Test
 func defaultCameraSessionControllerRetainsCaptureFailureAsLastError() {
+    let stillSessionManager = RecordingStillSessionManager(
+        startedDeviceID: "camera-1",
+        captureError: .captureFailed(message: "AVFoundation timed out")
+    )
     let controller = DefaultCameraSessionController(
         deviceListing: FixedDeviceListing(
             devices: [CameraDevice(id: "camera-1", name: "Built-in Camera", position: .front)]
         ),
-        photoProducer: FailingStillPhotoProducer(
-            error: .captureFailed(message: "AVFoundation timed out")
-        ),
+        stillSessionManager: stillSessionManager,
         initialState: CameraState(
             permissionState: .authorized,
             sessionState: .running,
@@ -610,19 +694,59 @@ private final class PermissionRequestResultBox: @unchecked Sendable {
     var result: PermissionRequestResult?
 }
 
-private struct FixedStillPhotoProducer: CameraStillPhotoProducing {
-    let data: Data
+private final class RecordingStillSessionManager: CameraStillSessionManaging, @unchecked Sendable {
+    private(set) var startedDeviceIDs: [String]
+    private(set) var captureCount = 0
+    private(set) var stopCount = 0
 
-    func capturePhotoData(deviceID: String) throws -> Data {
-        data
+    private var activeDeviceID: String?
+    private let data: Data?
+    private let startError: CameraPhotoCaptureError?
+    private let captureError: CameraPhotoCaptureError?
+
+    init(
+        startedDeviceID: String? = nil,
+        data: Data? = nil,
+        startError: CameraPhotoCaptureError? = nil,
+        captureError: CameraPhotoCaptureError? = nil
+    ) {
+        self.startedDeviceIDs = startedDeviceID.map { [$0] } ?? []
+        self.activeDeviceID = startedDeviceID
+        self.data = data
+        self.startError = startError
+        self.captureError = captureError
     }
-}
 
-private struct FailingStillPhotoProducer: CameraStillPhotoProducing {
-    let error: CameraPhotoCaptureError
+    func start(deviceID: String) throws {
+        if let startError {
+            throw startError
+        }
 
-    func capturePhotoData(deviceID: String) throws -> Data {
-        throw error
+        startedDeviceIDs.append(deviceID)
+        activeDeviceID = deviceID
+    }
+
+    func capturePhotoData() throws -> Data {
+        captureCount += 1
+
+        if let captureError {
+            throw captureError
+        }
+
+        guard activeDeviceID != nil else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Still photo session is not running")
+        }
+
+        guard let data else {
+            throw CameraPhotoCaptureError.captureFailed(message: "Missing test photo data")
+        }
+
+        return data
+    }
+
+    func stop() {
+        stopCount += 1
+        activeDeviceID = nil
     }
 }
 


### PR DESCRIPTION
## Summary
- add a read-only selected camera status row to the CameraBridgeApp menu
- resolve the selected camera from `/v1/session` and `/v1/devices`, including an unavailable fallback
- extend app-model tests and manual verification notes for the new menu state

## Files Changed
- `apps/CameraBridgeApp/Sources/CameraBridgeApp/CameraBridgeAppModel.swift`
- `apps/CameraBridgeApp/Sources/CameraBridgeApp/main.swift`
- `tests/CameraBridgeAppTests/CameraBridgeAppModelTests.swift`
- `tests/CameraBridgeAppTests/CameraBridgeAppDeepLinkTests.swift`
- `apps/CameraBridgeApp/README.md`

## How It Was Tested
- `swift test`
- packaged `CameraBridgeApp` locally and verified the menu shows the resolved selected camera name after device selection
- confirmed the selected camera row remains visible after the session stops while the service stays reachable

## Deferred
- no device switching or editing controls were added to the app menu

Closes #143